### PR TITLE
Add player ownership to units and enemy detection

### DIFF
--- a/battle-hexes-api/src/unit/unit.py
+++ b/battle-hexes-api/src/unit/unit.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 import uuid
 from src.unit.faction import Faction
 from src.unit.sparseunit import SparseUnit
+from src.game.player import Player
 
 
 class UnitModel(BaseModel):
@@ -17,9 +18,19 @@ class UnitModel(BaseModel):
 
 
 class Unit:
-    def __init__(self, id: uuid.UUID, name: str, faction: Faction, type: str,
-                 attack: int, defense: int, move: int,
-                 row: int = None, column: int = None):
+    def __init__(
+            self,
+            id: uuid.UUID,
+            name: str,
+            faction: Faction,
+            type: str,
+            attack: int,
+            defense: int,
+            move: int,
+            player: Player | None = None,
+            row: int | None = None,
+            column: int | None = None,
+    ):
         self.id = id
         self.name = name
         self.faction = faction
@@ -27,6 +38,7 @@ class Unit:
         self.attack = attack
         self.defense = defense
         self.move = move
+        self.player = player
         self.row = row
         self.column = column
 
@@ -50,6 +62,21 @@ class Unit:
 
     def get_move(self):
         return self.move
+
+    def get_move_points(self):
+        """Compatibility alias for move value."""
+        return self.move
+
+    def get_player(self) -> Player | None:
+        return self.player
+
+    def is_friendly(self, other: "Unit") -> bool:
+        if self.player is not None and other.player is not None:
+            return self.player == other.player
+        return self.faction == other.faction
+
+    def is_enemy(self, other: "Unit") -> bool:
+        return not self.is_friendly(other)
 
     def set_coords(self, row: int, column: int):
         self.row = row

--- a/battle-hexes-api/tests/game/test_board.py
+++ b/battle-hexes-api/tests/game/test_board.py
@@ -4,6 +4,7 @@ from game.board import Board
 from game.sparseboard import SparseBoard
 from unit.faction import Faction
 from unit.unit import Unit
+from game.player import Player, PlayerType
 
 
 class TestBoard(unittest.TestCase):
@@ -199,6 +200,37 @@ class TestBoard(unittest.TestCase):
             actual_coords, expected_coords,
             "Reachable hexes should only include the starting hex"
         )
+
+    def test_enemy_adjacent_detection(self):
+        red_player = Player(name="Red", type=PlayerType.HUMAN,
+                            factions=[self.red_faction])
+        blue_player = Player(name="Blue", type=PlayerType.CPU,
+                             factions=[self.blue_faction])
+        self.red_unit.player = red_player
+        self.blue_unit.player = blue_player
+        self.board.add_unit(self.red_unit, 2, 2)
+        self.board.add_unit(self.blue_unit, 2, 3)
+
+        target_hex = self.board.get_hex(2, 2)
+        self.assertTrue(self.board.enemy_adjacent(self.red_unit, target_hex))
+
+    def test_get_reachable_hexes_avoids_enemy_adjacent(self):
+        red_player = Player(name="Red", type=PlayerType.HUMAN,
+                            factions=[self.red_faction])
+        blue_player = Player(name="Blue", type=PlayerType.CPU,
+                             factions=[self.blue_faction])
+        self.red_unit.player = red_player
+        self.blue_unit.player = blue_player
+        self.board.add_unit(self.red_unit, 2, 2)
+        self.board.add_unit(self.blue_unit, 2, 3)
+
+        start_hex = self.board.get_hex(2, 2)
+        reachable_hexes = self.board.get_reachable_hexes(
+            self.red_unit, start_hex, move_points=1
+        )
+
+        coords = {(h.row, h.column) for h in reachable_hexes}
+        self.assertNotIn((2, 3), coords)
 
     # def test_get_reachable_hexes_with_obstacles(self):
     #     self.board.add_unit(self.red_unit, 2, 2)


### PR DESCRIPTION
## Summary
- allow units to hold an optional `Player` reference
- expose helpers on `Unit` for determining friend or foe
- add board utilities for locating units and checking if a hex is enemy-adjacent
- update reachable hex logic to avoid hexes next to enemies
- test enemy adjacency and updated pathfinding

## Testing
- `pytest tests/game/test_board.py::TestBoard::test_enemy_adjacent_detection -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683fa2e7379c832781ff0a31454ab540