### PR TITLE
Fix test dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,8 @@ This repository contains two main projects:
 
 - **`battle-hexes-web`**: the JavaScript frontend using p5.js.
 - **`battle-hexes-api`**: the Python backend built with FastAPI.
+
+## Helper scripts
+
+- `api-checks.sh`: Runs unit tests and the `flake8` linter for the Python API.
+  Execute this from the repository root with `./api-checks.sh`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,10 @@ This repository contains two main projects:
 
 - `api-checks.sh`: Runs unit tests and the `flake8` linter for the Python API.
   Execute this from the repository root with `./api-checks.sh`.
+
+### Working with the API
+
+- Install dependencies using both requirement files:
+  `pip install -r requirements.txt -r requirements-test.txt`.
+- Keep code Flake8-compliant and run `./api-checks.sh` before sending a PR to
+  ensure tests and linting pass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ This repository contains two main projects:
 ## Helper scripts
 
 - `api-checks.sh`: Runs unit tests and the `flake8` linter for the Python API.
-  Execute this from the repository root with `./api-checks.sh`.
+  Execute this from the repository root with `./api-checks.sh`. The script runs
+  in a subshell so it won't change your current working directory.
 
 ### Working with the API
 

--- a/api-checks.sh
+++ b/api-checks.sh
@@ -15,3 +15,7 @@ API_DIR="$REPO_ROOT/battle-hexes-api"
   pytest
   flake8 src/ tests/
 )
+
+# Capture and forward the exit code of the subshell
+exit_code=$?
+exit $exit_code

--- a/api-checks.sh
+++ b/api-checks.sh
@@ -9,7 +9,9 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 API_DIR="$REPO_ROOT/battle-hexes-api"
 
-cd "$API_DIR"
-
-pytest
-flake8 src/ tests/
+# Run checks in a subshell so the caller's directory is not affected
+(
+  cd "$API_DIR"
+  pytest
+  flake8 src/ tests/
+)

--- a/api-checks.sh
+++ b/api-checks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Convenience script to run unit tests and flake8 for the Battle Hexes API.
+# Assumes dependencies are installed.
+
+set -euo pipefail
+
+# Determine repository root directory
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+API_DIR="$REPO_ROOT/battle-hexes-api"
+
+cd "$API_DIR"
+
+pytest
+flake8 src/ tests/

--- a/battle-hexes-api/README.md
+++ b/battle-hexes-api/README.md
@@ -18,7 +18,7 @@ Upgrade `pip`.
 
 Install dependencies.
 
-    pip install -r requirements.txt 
+    pip install -r requirements.txt -r requirements-test.txt
 
 ## Running Locally
 

--- a/battle-hexes-api/README.md
+++ b/battle-hexes-api/README.md
@@ -38,3 +38,8 @@ To run the `flake8` linter:
 
     flake8 src/ tests/
 
+## Convenience script
+
+From the repository root you can run `./api-checks.sh` to execute both the tests
+and `flake8` together. This is useful before committing code.
+

--- a/battle-hexes-api/requirements-test.txt
+++ b/battle-hexes-api/requirements-test.txt
@@ -1,2 +1,3 @@
 flake8
 pytest
+httpx==0.27.*


### PR DESCRIPTION
## Summary
- add `httpx` to API test requirements
- clarify install command in API README

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `pytest`
- `flake8 src/ tests/`
- `./api-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6859f22867148327b143981dda4f5ab7