### PR TITLE
Implement movement endpoint

### DIFF
--- a/battle-hexes-api/src/game/player.py
+++ b/battle-hexes-api/src/game/player.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 from enum import Enum
 from typing import List
 from src.unit.faction import Faction
+from src.game.unitmovementplan import UnitMovementPlan
 
 
 class PlayerType(Enum):
@@ -22,3 +23,7 @@ class Player(BaseModel):
 
     def own_units(self, units) -> List:
         return [unit for unit in units if self.owns(unit)]
+
+    def movement(self) -> List[UnitMovementPlan]:
+        """Return a list of movement plans for the player's units."""
+        raise NotImplementedError("Subclasses must implement movement")

--- a/battle-hexes-api/src/game/unitmovementplan.py
+++ b/battle-hexes-api/src/game/unitmovementplan.py
@@ -9,3 +9,13 @@ class UnitMovementPlan:
 
     def __repr__(self):
         return f"UnitMovementPlan(unit={self.unit}, path={self.path})"
+
+    def to_dict(self) -> dict:
+        """Serialize this plan into a simple dictionary."""
+        return {
+            "unit_id": str(self.unit.get_id()),
+            "path": [
+                {"row": h.row, "column": h.column}
+                for h in self.path
+            ],
+        }

--- a/battle-hexes-api/src/main.py
+++ b/battle-hexes-api/src/main.py
@@ -46,3 +46,12 @@ def resolve_combat(
     sparse_board = game.get_board().to_sparse_board()
     sparse_board.last_combat_results = results.battles_as_result_schema()
     return sparse_board
+
+
+@app.post('/games/{game_id}/movement')
+def generate_movement(game_id: str):
+    """Generate movement plans for the current player."""
+    game = game_repo.get_game(game_id)
+    current_player = game.get_current_player()
+    plans = current_player.movement()
+    return {"plans": [p.to_dict() for p in plans]}

--- a/battle-hexes-api/tests/game/test_player.py
+++ b/battle-hexes-api/tests/game/test_player.py
@@ -1,0 +1,9 @@
+import unittest
+from src.game.player import Player, PlayerType
+
+
+class TestPlayer(unittest.TestCase):
+    def test_movement_not_implemented(self):
+        player = Player(name='P1', type=PlayerType.HUMAN, factions=[])
+        with self.assertRaises(NotImplementedError):
+            player.movement()

--- a/battle-hexes-api/tests/game/test_unitmovementplan.py
+++ b/battle-hexes-api/tests/game/test_unitmovementplan.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import MagicMock
+from src.game.unitmovementplan import UnitMovementPlan
+from src.game.hex import Hex
+
+
+class TestUnitMovementPlan(unittest.TestCase):
+    def test_to_dict(self):
+        unit = MagicMock()
+        unit.get_id.return_value = 'uid-1'
+        plan = UnitMovementPlan(unit, [Hex(1, 2), Hex(2, 3)])
+        expected = {
+            'unit_id': 'uid-1',
+            'path': [
+                {'row': 1, 'column': 2},
+                {'row': 2, 'column': 3},
+            ],
+        }
+        self.assertEqual(plan.to_dict(), expected)
+        unit.get_id.assert_called_once_with()

--- a/battle-hexes-api/tests/test_main.py
+++ b/battle-hexes-api/tests/test_main.py
@@ -36,3 +36,20 @@ class TestFastAPI(unittest.TestCase):
             SparseBoard(**sparse_board_data))
         mock_game_repo.update_game.assert_called_once_with(mock_game)
         mock_board.to_sparse_board.assert_called_once()
+
+    @patch('main.game_repo')
+    def test_generate_movement(self, mock_game_repo):
+        mock_plan = MagicMock()
+        mock_player = MagicMock()
+        mock_player.movement.return_value = [mock_plan]
+        mock_game = MagicMock()
+        mock_game.get_current_player.return_value = mock_player
+        mock_game_repo.get_game.return_value = mock_game
+        mock_plan.to_dict.return_value = {"plan": 1}
+
+        game_id = "game-456"
+        response = self.client.post(f"/games/{game_id}/movement")
+
+        self.assertEqual(response.json(), {"plans": [{"plan": 1}]})
+        mock_player.movement.assert_called_once_with()
+        mock_plan.to_dict.assert_called_once_with()


### PR DESCRIPTION
## Summary
- add `movement` method to `Player`
- expose `/games/{game_id}/movement` endpoint
- serialize movement plans with `UnitMovementPlan.to_dict`
- test movement endpoint and `Player` behavior
- unit test `UnitMovementPlan.to_dict`

## Testing
- `./api-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_685a05d5cd3c8327917566ac58a2be02