### PR TITLE
Add end-turn endpoint and client update

### DIFF
--- a/battle-hexes-api/src/game/game.py
+++ b/battle-hexes-api/src/game/game.py
@@ -36,6 +36,14 @@ class Game:
     def get_current_player(self) -> Player:
         return self.current_player
 
+    def next_player(self) -> Player:
+        """Advance to the next player and return it."""
+        if not self.players:
+            return None
+        idx = self.players.index(self.current_player)
+        self.current_player = self.players[(idx + 1) % len(self.players)]
+        return self.current_player
+
     def to_game_model(self) -> GameModel:
         return GameModel(
             id=self.id,

--- a/battle-hexes-api/src/main.py
+++ b/battle-hexes-api/src/main.py
@@ -55,3 +55,13 @@ def generate_movement(game_id: str):
     current_player = game.get_current_player()
     plans = current_player.movement()
     return {"plans": [p.to_dict() for p in plans]}
+
+
+@app.post('/games/{game_id}/end-turn')
+def end_turn(game_id: str, sparse_board: SparseBoard = Body(...)):
+    """Update game state at the end of a player's turn."""
+    game = game_repo.get_game(game_id)
+    game.update(sparse_board)
+    game.next_player()
+    game_repo.update_game(game)
+    return game.to_game_model()

--- a/battle-hexes-api/tests/test_main.py
+++ b/battle-hexes-api/tests/test_main.py
@@ -53,3 +53,17 @@ class TestFastAPI(unittest.TestCase):
         self.assertEqual(response.json(), {"plans": [{"plan": 1}]})
         mock_player.movement.assert_called_once_with()
         mock_plan.to_dict.assert_called_once_with()
+
+    @patch('main.game_repo')
+    def test_end_turn(self, mock_game_repo):
+        mock_game = MagicMock()
+        mock_game_repo.get_game.return_value = mock_game
+        sparse_board_data = {"units": []}
+
+        game_id = "game-789"
+        self.client.post(f"/games/{game_id}/end-turn", json=sparse_board_data)
+
+        mock_game.update.assert_called_once_with(
+            SparseBoard(**sparse_board_data))
+        mock_game.next_player.assert_called_once_with()
+        mock_game_repo.update_game.assert_called_once_with(mock_game)

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -1,3 +1,6 @@
+import axios from 'axios';
+import { API_URL } from './model/battle-api.js';
+
 export class Menu {
   #game;
   #selHexContentsDiv;
@@ -89,8 +92,12 @@ export class Menu {
     const switchedPlayers = this.#game.endPhase();
     this.updateMenu();
     this.#disableOrEnableActionButton();
-    
+
     if (switchedPlayers) {
+      axios.post(
+        `${API_URL}/games/${this.#game.getId()}/end-turn`,
+        this.#game.getBoard().sparseBoard()
+      ).catch(err => console.error('Failed to update game state', err));
       this.#game.getCurrentPlayer().play(this.#game);
     }
   }


### PR DESCRIPTION
## Summary
- add `next_player` helper on Game model
- add `/games/{game_id}/end-turn` REST endpoint
- test new endpoint
- trigger API call from frontend when ending a turn

## Testing
- `./api-checks.sh`
- `npm run test-and-build`

------
https://chatgpt.com/codex/tasks/task_e_686328d8b2a08327aad8d1214e9ee2ab