### PR TITLE
Add e2e step to web CI

### DIFF
--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -34,3 +34,11 @@ jobs:
       - name: Build project
         working-directory: battle-hexes-web
         run: npm run build
+
+      - name: Install Playwright browsers
+        working-directory: battle-hexes-web
+        run: npx playwright install --with-deps
+
+      - name: Run e2e tests
+        working-directory: battle-hexes-web
+        run: npm run test:e2e


### PR DESCRIPTION
## Summary
- add playwright browser install step
- run e2e tests in CI
- move the browser download step until after the build

## Testing
- `./api-checks.sh`
- `flake8 battle-hexes-api/src/ battle-hexes-api/tests/`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68634948cc18832791b32704bf532ec0