### PR TITLE
Apply CPU movement update from server

### DIFF
--- a/battle-hexes-web/src/player/cpu-player.js
+++ b/battle-hexes-web/src/player/cpu-player.js
@@ -1,6 +1,7 @@
 import { playerTypes, Player } from './player.js';
 import axios from 'axios';
 import { API_URL } from '../model/battle-api.js';
+import { BoardUpdater } from '../model/board-updater.js';
 
 export class CpuPlayer extends Player {
   constructor(name, factions) {
@@ -14,6 +15,11 @@ export class CpuPlayer extends Player {
           `${API_URL}/games/${game.getId()}/movement`
         );
         console.log('CPU movement plans:', response.data);
+        const boardUpdater = new BoardUpdater();
+        boardUpdater.updateBoard(
+          game.getBoard(),
+          response.data.game.board.units
+        );
       } catch (err) {
         console.error('Failed to fetch CPU movement plans', err);
       }

--- a/battle-hexes-web/tests/player/cpu-player.test.js
+++ b/battle-hexes-web/tests/player/cpu-player.test.js
@@ -4,8 +4,15 @@ import { Game } from '../../src/model/game.js';
 import { Board } from '../../src/model/board.js';
 import { Players } from '../../src/player/player.js';
 import { API_URL } from '../../src/model/battle-api.js';
+import { BoardUpdater } from '../../src/model/board-updater.js';
 
 jest.mock('axios');
+const mockUpdateBoard = jest.fn();
+jest.mock('../../src/model/board-updater.js', () => ({
+  BoardUpdater: jest.fn().mockImplementation(() => ({
+    updateBoard: mockUpdateBoard,
+  })),
+}));
 
 describe('CpuPlayer', () => {
   let cpuPlayer;
@@ -13,7 +20,8 @@ describe('CpuPlayer', () => {
 
   beforeEach(() => {
     axios.post.mockClear();
-    axios.post.mockResolvedValue({ data: { plans: [] } });
+    axios.post.mockResolvedValue({ data: { game: { board: { units: [] } }, plans: [] } });
+    mockUpdateBoard.mockClear();
     cpuPlayer = new CpuPlayer('CPU');
     const board = new Board(1, 1);
     const players = new Players([cpuPlayer]);
@@ -23,11 +31,13 @@ describe('CpuPlayer', () => {
   test('calls movement endpoint during movement phase', async () => {
     await cpuPlayer.play(game);
     expect(axios.post).toHaveBeenCalledWith(`${API_URL}/games/${game.getId()}/movement`);
+    expect(mockUpdateBoard).toHaveBeenCalledWith(game.getBoard(), []);
   });
 
   test('does not call endpoint in other phases', async () => {
     game.endPhase(); // move to Combat phase
     await cpuPlayer.play(game);
     expect(axios.post).not.toHaveBeenCalled();
+    expect(mockUpdateBoard).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- update CpuPlayer to modify board with movement results
- mock BoardUpdater in cpu-player tests
- verify CpuPlayer applies movement to the board

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68718bf19fcc832783e33582e997c372