### PR TITLE
Advance CPU player phase automatically

### DIFF
--- a/battle-hexes-web/src/battle-draw.js
+++ b/battle-hexes-web/src/battle-draw.js
@@ -49,6 +49,9 @@ new p5((p) => {
       console.log('Redrawing board.');
       p.draw();
     });
+    eventBus.on('menuUpdate', () => {
+      menu.updateMenu();
+    });
   };
 
   p.draw = function() {

--- a/battle-hexes-web/src/model/board-updater.js
+++ b/battle-hexes-web/src/model/board-updater.js
@@ -19,6 +19,7 @@ export class BoardUpdater {
     }
 
     eventBus.emit('redraw');
+    eventBus.emit('menuUpdate');
   }
 
   #findUnit(id, units) {

--- a/battle-hexes-web/src/player/cpu-player.js
+++ b/battle-hexes-web/src/player/cpu-player.js
@@ -2,6 +2,7 @@ import { playerTypes, Player } from './player.js';
 import axios from 'axios';
 import { API_URL } from '../model/battle-api.js';
 import { BoardUpdater } from '../model/board-updater.js';
+import { eventBus } from '../event-bus.js';
 
 export class CpuPlayer extends Player {
   constructor(name, factions) {
@@ -20,6 +21,12 @@ export class CpuPlayer extends Player {
           game.getBoard(),
           response.data.game.board.units
         );
+
+        game.endPhase();
+        if (!game.getBoard().hasCombat()) {
+          game.endPhase();
+        }
+        eventBus.emit('menuUpdate');
       } catch (err) {
         console.error('Failed to fetch CPU movement plans', err);
       }

--- a/battle-hexes-web/tests/model/board-updater.test.js
+++ b/battle-hexes-web/tests/model/board-updater.test.js
@@ -24,24 +24,27 @@ describe('updateBoard', () => {
 
   test('update empty board with no units', () => {
     boardUpdater.updateBoard(board, []);
-    expect(eventBus.emit).toHaveBeenCalledTimes(1);
+    expect(eventBus.emit).toHaveBeenCalledTimes(2);
     expect(eventBus.emit).toHaveBeenCalledWith('redraw');
+    expect(eventBus.emit).toHaveBeenCalledWith('menuUpdate');
   });
 
   test('one unit no update', () => {
     board.addUnit(redUnit, 4, 5);
     boardUpdater.updateBoard(board, [{id: 'unit-001', row: 4, column: 5}]);
     expect(redUnit.getContainingHex().coordsHumanString()).toBe('4, 5');
-    expect(eventBus.emit).toHaveBeenCalledTimes(1);
+    expect(eventBus.emit).toHaveBeenCalledTimes(2);
     expect(eventBus.emit).toHaveBeenCalledWith('redraw');
+    expect(eventBus.emit).toHaveBeenCalledWith('menuUpdate');
   });
 
   test('one unit moves', () => {
     board.addUnit(redUnit, 4, 5);
     boardUpdater.updateBoard(board, [{id: 'unit-001', row: 6, column: 7}]);
     expect(redUnit.getContainingHex().coordsHumanString()).toBe('6, 7');
-    expect(eventBus.emit).toHaveBeenCalledTimes(1);
+    expect(eventBus.emit).toHaveBeenCalledTimes(2);
     expect(eventBus.emit).toHaveBeenCalledWith('redraw');
+    expect(eventBus.emit).toHaveBeenCalledWith('menuUpdate');
   });
 
   test('one unit eliminated', () => {
@@ -49,7 +52,8 @@ describe('updateBoard', () => {
     boardUpdater.updateBoard(board, []);
     expect(redUnit.getContainingHex()).toBeNull();
     expect(board.getHex(4, 5).getUnits().length).toBe(0);
-    expect(eventBus.emit).toHaveBeenCalledTimes(1);
+    expect(eventBus.emit).toHaveBeenCalledTimes(2);
     expect(eventBus.emit).toHaveBeenCalledWith('redraw');
+    expect(eventBus.emit).toHaveBeenCalledWith('menuUpdate');
   });
 });

--- a/battle-hexes-web/tests/player/cpu-player.test.js
+++ b/battle-hexes-web/tests/player/cpu-player.test.js
@@ -25,13 +25,21 @@ describe('CpuPlayer', () => {
     cpuPlayer = new CpuPlayer('CPU');
     const board = new Board(1, 1);
     const players = new Players([cpuPlayer]);
-    game = new Game('game-1', ['Movement', 'Combat'], players, board);
+    game = new Game('game-1', ['Movement', 'Combat', 'End Turn'], players, board);
   });
 
-  test('calls movement endpoint during movement phase', async () => {
+  test('calls movement endpoint during movement phase and advances phase based on combat', async () => {
+    jest.spyOn(game.getBoard(), 'hasCombat').mockReturnValue(true);
     await cpuPlayer.play(game);
     expect(axios.post).toHaveBeenCalledWith(`${API_URL}/games/${game.getId()}/movement`);
     expect(mockUpdateBoard).toHaveBeenCalledWith(game.getBoard(), []);
+    expect(game.getCurrentPhase()).toBe('Combat');
+  });
+
+  test('skips combat when there is none', async () => {
+    jest.spyOn(game.getBoard(), 'hasCombat').mockReturnValue(false);
+    await cpuPlayer.play(game);
+    expect(game.getCurrentPhase()).toBe('End Turn');
   });
 
   test('does not call endpoint in other phases', async () => {


### PR DESCRIPTION
## Summary
- update menu after CPU moves by adding a new `menuUpdate` event
- have the CPU advance the game phase after its movement
- listen for the new event in the drawing loop
- update tests for BoardUpdater and CpuPlayer

## Testing
- `npm test`
- `./api-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68718f43975c8327a90aa2dceb4ab97b