### PR TITLE
Skip empty combat phase

### DIFF
--- a/battle-hexes-web/src/model/game.js
+++ b/battle-hexes-web/src/model/game.js
@@ -30,6 +30,10 @@ export class Game {
       return true;
     } else {
       this.#currentPhase = this.#phases[newPhaseIdx];
+      if (this.#currentPhase.toLowerCase() === 'combat'
+          && !this.#board.hasCombat()) {
+        return this.endPhase();
+      }
       return false;
     }
   }

--- a/battle-hexes-web/src/player/cpu-player.js
+++ b/battle-hexes-web/src/player/cpu-player.js
@@ -23,9 +23,6 @@ export class CpuPlayer extends Player {
         );
 
         game.endPhase();
-        if (!game.getBoard().hasCombat()) {
-          game.endPhase();
-        }
         eventBus.emit('menuUpdate');
       } catch (err) {
         console.error('Failed to fetch CPU movement plans', err);

--- a/battle-hexes-web/tests/model/game.test.js
+++ b/battle-hexes-web/tests/model/game.test.js
@@ -20,15 +20,18 @@ describe('constructor', () => {
 });
 
 describe('endPhase', () => {
-  test('endPhase moves to next phase when turn is not over', () => {
-    game.endPhase();
+  test('moves to combat when there is combat', () => {
+    jest.spyOn(game.getBoard(), 'hasCombat').mockReturnValue(true);
+    const switched = game.endPhase();
+    expect(switched).toBe(false);
     expect(game.getCurrentPhase()).toBe(phases[1]);
     expect(game.getCurrentPlayer()).toEqual(player1);
   });
 
-  test('endPhase moves to next player when turn is over', () => {
-    game.endPhase();
-    game.endPhase();
+  test('skips combat and moves to next player when none', () => {
+    jest.spyOn(game.getBoard(), 'hasCombat').mockReturnValue(false);
+    const switched = game.endPhase();
+    expect(switched).toBe(true);
     expect(game.getCurrentPhase()).toBe(phases[0]);
     expect(game.getCurrentPlayer()).toEqual(player2);
   });


### PR DESCRIPTION
## Summary
- skip the Combat phase if the board has no combat
- update CPU player to rely on the new behavior
- adjust Game unit tests for combat skipping

## Testing
- `npm test`
- `./api-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68719604b33c8327888d97402245209a