### PR TITLE
Implement CPU turn auto-progression

### DIFF
--- a/battle-hexes-web/src/player/cpu-player.js
+++ b/battle-hexes-web/src/player/cpu-player.js
@@ -24,6 +24,17 @@ export class CpuPlayer extends Player {
 
         game.endPhase();
         eventBus.emit('menuUpdate');
+
+        if (game.getCurrentPhase() === 'End Turn') {
+          await new Promise(resolve => setTimeout(resolve, 1000));
+          await axios.post(
+            `${API_URL}/games/${game.getId()}/end-turn`,
+            game.getBoard().sparseBoard()
+          ).catch(err => console.error('Failed to update game state', err));
+          game.endPhase();
+          eventBus.emit('menuUpdate');
+          game.getCurrentPlayer().play(game);
+        }
       } catch (err) {
         console.error('Failed to fetch CPU movement plans', err);
       }

--- a/battle-hexes-web/tests/player/cpu-player.test.js
+++ b/battle-hexes-web/tests/player/cpu-player.test.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { CpuPlayer } from '../../src/player/cpu-player.js';
 import { Game } from '../../src/model/game.js';
 import { Board } from '../../src/model/board.js';
-import { Players } from '../../src/player/player.js';
+import { Player, Players } from '../../src/player/player.js';
 import { API_URL } from '../../src/model/battle-api.js';
 import { BoardUpdater } from '../../src/model/board-updater.js';
 
@@ -24,7 +24,7 @@ describe('CpuPlayer', () => {
     mockUpdateBoard.mockClear();
     cpuPlayer = new CpuPlayer('CPU');
     const board = new Board(1, 1);
-    const players = new Players([cpuPlayer]);
+    const players = new Players([cpuPlayer, new Player('Dummy')]);
     game = new Game('game-1', ['Movement', 'Combat', 'End Turn'], players, board);
   });
 
@@ -36,10 +36,27 @@ describe('CpuPlayer', () => {
     expect(game.getCurrentPhase()).toBe('Combat');
   });
 
-  test('skips combat when there is none', async () => {
+  test('skips combat when there is none and automatically ends turn', async () => {
+    jest.useFakeTimers();
     jest.spyOn(game.getBoard(), 'hasCombat').mockReturnValue(false);
-    await cpuPlayer.play(game);
+
+    const playPromise = cpuPlayer.play(game);
+    await Promise.resolve();
+
     expect(game.getCurrentPhase()).toBe('End Turn');
+    expect(axios.post).toHaveBeenCalledWith(
+      `${API_URL}/games/${game.getId()}/movement`
+    );
+    expect(axios.post).toHaveBeenCalledTimes(1);
+
+    await jest.runAllTimersAsync();
+    await playPromise;
+
+    expect(axios.post).toHaveBeenCalledWith(
+      `${API_URL}/games/${game.getId()}/end-turn`,
+      game.getBoard().sparseBoard()
+    );
+    expect(game.getCurrentPhase()).toBe('Movement');
   });
 
   test('does not call endpoint in other phases', async () => {


### PR DESCRIPTION
## Summary
- automatically end the CPU player's turn after a short delay
- test that the CPU player advances from `End Turn` back to `Movement`

## Testing
- `npm test --prefix battle-hexes-web`
- `./api-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6871996c68448327b479df69e844524e