### PR TITLE
Fix unit positions and movement reset after CPU turn

### DIFF
--- a/battle-hexes-api/src/main.py
+++ b/battle-hexes-api/src/main.py
@@ -64,14 +64,19 @@ def generate_movement(game_id: str):
 
 
 @app.post('/games/{game_id}/end-turn')
-def end_turn(game_id: str):
+def end_turn(game_id: str, sparse_board: SparseBoard = Body(...)):
     """Update game state at the end of a player's turn."""
     game = game_repo.get_game(game_id)
+
+    # sync the server-side board state with the client provided one
+    game.update(sparse_board)
+
     old_player = game.get_current_player()
     new_player = game.next_player()
     print(
         f"The turn has ended for player: {old_player.name}. "
         f"Now it's {new_player.name}'s turn."
     )
+
     game_repo.update_game(game)
     return game.to_game_model()

--- a/battle-hexes-api/tests/test_main.py
+++ b/battle-hexes-api/tests/test_main.py
@@ -79,10 +79,16 @@ class TestFastAPI(unittest.TestCase):
         mock_game_repo.get_game.return_value = mock_game
 
         game_id = "game-789"
+        sparse_board_data = {"units": []}
+
         response = self.client.post(
-            f"/games/{game_id}/end-turn"
+            f"/games/{game_id}/end-turn",
+            json=sparse_board_data
         )
 
+        mock_game.update.assert_called_once_with(
+            SparseBoard(**sparse_board_data)
+        )
         mock_game.get_current_player.assert_called_once_with()
         mock_game.next_player.assert_called_once_with()
         mock_game_repo.update_game.assert_called_once_with(mock_game)

--- a/battle-hexes-web/src/model/game.js
+++ b/battle-hexes-web/src/model/game.js
@@ -27,6 +27,7 @@ export class Game {
     if (newPhaseIdx >= this.#phases.length) {
       this.#currentPhase = this.#phases[0];
       this.#players.nextPlayer();
+      this.#board.resetMovesRemaining();
       return true;
     } else {
       this.#currentPhase = this.#phases[newPhaseIdx];


### PR DESCRIPTION
## Summary
- sync board state on `end-turn` API endpoint
- reset unit movement when advancing turn in the frontend
- update unit test for new API behaviour

## Testing
- `npm test --prefix battle-hexes-web`
- `./api-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6871a0cd79848327b5b864f30a1f28f8