### PR TITLE
Add animated unit movement

### DIFF
--- a/battle-hexes-web/src/animation/movement-animator.js
+++ b/battle-hexes-web/src/animation/movement-animator.js
@@ -1,0 +1,32 @@
+import { eventBus } from '../event-bus.js';
+
+export class MovementAnimator {
+  #board;
+  #delay;
+
+  constructor(board, delay = 300) {
+    this.#board = board;
+    this.#delay = delay;
+  }
+
+  async animate(unit, path, adjustMoves = false) {
+    if (!unit || !path || path.length < 2) {
+      return;
+    }
+
+    let prevHex = path[0];
+    for (let i = 1; i < path.length; i++) {
+      const nextHex = path[i];
+      this.#board.updateUnitPosition(unit, prevHex, nextHex);
+      eventBus.emit('redraw');
+      await new Promise(resolve => setTimeout(resolve, this.#delay));
+      prevHex = nextHex;
+    }
+
+    if (adjustMoves) {
+      unit.move(prevHex, this.#board.getAdjacentHexes(prevHex));
+    }
+    this.#board.refreshCombat();
+    eventBus.emit('menuUpdate');
+  }
+}

--- a/battle-hexes-web/src/model/board.js
+++ b/battle-hexes-web/src/model/board.js
@@ -1,4 +1,5 @@
 import { Hex } from './hex.js';
+import { MovementAnimator } from '../animation/movement-animator.js';
 
 export class Board {
   #hexMap;
@@ -6,10 +7,12 @@ export class Board {
   #hoverHex;
   #units;
   #players;
+  #animator;
 
   constructor(rows, columns) {
     this.#hexMap = new Map();
     this.#units = new Set();
+    this.#animator = new MovementAnimator(this);
 
     for (let row = 0; row < rows; row++) {
       for (let column = 0; column < columns; column++) {
@@ -33,6 +36,10 @@ export class Board {
 
   getUnits() {
     return this.#units;
+  }
+
+  getAnimator() {
+    return this.#animator;
   }
 
   getHex(row, column) {
@@ -60,9 +67,8 @@ export class Board {
         && oldSelection.getUnits()[0].isMovable() && !this.isOppositionHex(hexToSelect)) {
       const units = oldSelection.getUnits();
       console.log(`Moving unit ${units[0]}.`);
-      this.moveUnit(units[0], oldSelection, hexToSelect);
-      // units[0].addToMovePath(oldSelection);
-      // units[0].addToMovePath(hexToSelect);
+      const path = [oldSelection, hexToSelect];
+      this.#animator.animate(units[0], path, true);
       oldSelection.setSelected(false);
       hexToSelect.setSelected(true);
       this.setHoverHex(undefined);

--- a/battle-hexes-web/src/player/cpu-player.js
+++ b/battle-hexes-web/src/player/cpu-player.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { API_URL } from '../model/battle-api.js';
 import { BoardUpdater } from '../model/board-updater.js';
 import { eventBus } from '../event-bus.js';
+import { MovementAnimator } from '../animation/movement-animator.js';
 
 export class CpuPlayer extends Player {
   constructor(name, factions) {
@@ -19,6 +20,20 @@ export class CpuPlayer extends Player {
           `${API_URL}/games/${game.getId()}/movement`
         );
         console.log('CPU movement plans:', response.data);
+
+        const animator = new MovementAnimator(game.getBoard());
+        for (const plan of response.data.plans) {
+          const unit = [...game.getBoard().getUnits()].find(
+            u => u.getId() === plan.unit_id
+          );
+          if (unit) {
+            const path = plan.path.map(h =>
+              game.getBoard().getHex(h.row, h.column)
+            );
+            await animator.animate(unit, path);
+          }
+        }
+
         const boardUpdater = new BoardUpdater();
         boardUpdater.updateBoard(
           game.getBoard(),

--- a/battle-hexes-web/tests/animation/movement-animator.test.js
+++ b/battle-hexes-web/tests/animation/movement-animator.test.js
@@ -1,0 +1,50 @@
+import { MovementAnimator } from '../../src/animation/movement-animator.js';
+import { eventBus } from '../../src/event-bus.js';
+
+jest.mock('../../src/event-bus.js', () => ({
+  eventBus: {
+    emit: jest.fn(),
+  },
+}));
+
+describe('MovementAnimator', () => {
+  let board;
+  let animator;
+  let unit;
+  let hexA, hexB, hexC;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    eventBus.emit.mockClear();
+    board = {
+      updateUnitPosition: jest.fn(),
+      refreshCombat: jest.fn(),
+      getAdjacentHexes: jest.fn(() => new Set()),
+    };
+    unit = { move: jest.fn() };
+    hexA = { id: 'a' };
+    hexB = { id: 'b' };
+    hexC = { id: 'c' };
+    animator = new MovementAnimator(board, 50);
+  });
+
+  test('animates movement path and updates board', async () => {
+    const promise = animator.animate(unit, [hexA, hexB, hexC], true);
+
+    expect(board.updateUnitPosition).toHaveBeenCalledWith(unit, hexA, hexB);
+    expect(eventBus.emit).toHaveBeenCalledWith('redraw');
+
+    await jest.runOnlyPendingTimersAsync();
+    await Promise.resolve();
+
+    expect(board.updateUnitPosition).toHaveBeenCalledWith(unit, hexB, hexC);
+    expect(eventBus.emit).toHaveBeenLastCalledWith('redraw');
+
+    await jest.runOnlyPendingTimersAsync();
+    await promise;
+
+    expect(unit.move).toHaveBeenCalledWith(hexC, new Set());
+    expect(board.refreshCombat).toHaveBeenCalled();
+    expect(eventBus.emit).toHaveBeenCalledWith('menuUpdate');
+  });
+});

--- a/battle-hexes-web/tests/model/board.test.js
+++ b/battle-hexes-web/tests/model/board.test.js
@@ -1,3 +1,10 @@
+import { MovementAnimator } from '../../src/animation/movement-animator.js';
+jest.mock('../../src/animation/movement-animator.js', () => ({
+  MovementAnimator: jest.fn().mockImplementation(() => ({
+    animate: jest.fn(),
+  })),
+}));
+
 import { Board } from '../../src/model/board.js';
 import { Faction } from '../../src/model/faction.js';
 import { Unit } from '../../src/model/unit.js';
@@ -81,5 +88,31 @@ describe('sparseBoard', () => {
 
     expect(unitMap['unit-002'].row).toBe(2);
     expect(unitMap['unit-002'].column).toBe(4)
+  });
+});
+
+describe('animator integration', () => {
+  test('getAnimator returns animator instance from constructor', () => {
+    const board = new Board(1, 1);
+    expect(typeof board.getAnimator().animate).toBe('function');
+  });
+
+  test('selectHex uses animator to animate movement', () => {
+    const player = { isHuman: () => true };
+    const factions = [new Faction('f1', 'f1', '#f00')];
+    factions[0].setOwningPlayer(player);
+    const board = new Board(1, 2);
+    board.setPlayers({ getCurrentPlayer: () => player });
+    const unit = new Unit('u1', 'Unit', factions[0], null, 1, 1, 1);
+    board.addUnit(unit, 0, 0);
+
+    const start = board.getHex(0, 0);
+    const end = board.getHex(0, 1);
+
+    const animatorInstance = board.getAnimator();
+    board.selectHex(start);
+    board.selectHex(end);
+
+    expect(animatorInstance.animate).toHaveBeenCalledWith(unit, [start, end], true);
   });
 });


### PR DESCRIPTION
## Summary
- add `MovementAnimator` to animate board moves without blocking the UI
- integrate animator into board logic for human moves
- animate CPU moves based on server-provided movement paths

## Testing
- `npm --prefix battle-hexes-web install`
- `npm --prefix battle-hexes-web test`
- `pip install -r battle-hexes-api/requirements.txt -r battle-hexes-api/requirements-test.txt`
- `./api-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_687305a58a848327a35b604ed2b84b7e