### PR TITLE
Fix path planning stopping near enemies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ This repository contains two main projects:
 - **`battle-hexes-web`**: the JavaScript frontend using p5.js.
 - **`battle-hexes-api`**: the Python backend built with FastAPI.
 
+See [HOW_TO_PLAY.md](HOW_TO_PLAY.md) for a primer on the core game rules.
+
 ## Helper scripts
 
 - `api-checks.sh`: Runs unit tests and the `flake8` linter for the Python API.

--- a/HOW_TO_PLAY.md
+++ b/HOW_TO_PLAY.md
@@ -1,0 +1,17 @@
+# How to Play Battle Hexes
+
+Battle Hexes is a turn-based strategy game played on a hexagonal grid.
+Players take turns moving their units across the board and engaging in combat.
+
+## Movement and Combat
+
+Units have a limited number of movement points each turn. They may move to any
+adjacent hex, spending one movement point per hex. Movement stops immediately
+when a unit enters a hex that is adjacent to an enemy unit. A unit may not move
+again until combat around that hex is resolved.
+
+This rule means that movement plans cannot pass through hexes that border enemy
+units. If a path would cause a unit to become adjacent to an opponent, the unit
+must end its movement on that hex.
+
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # battle-hexes
+
 Turn-based strategy game engine.
+
+See [HOW_TO_PLAY.md](HOW_TO_PLAY.md) for an overview of the game mechanics.
+

--- a/battle-hexes-api/src/game/board.py
+++ b/battle-hexes-api/src/game/board.py
@@ -142,13 +142,18 @@ class Board:
             if cost >= move_points:
                 continue
 
+            if self.enemy_adjacent(unit, current_hex):
+                # Movement must stop when entering a hex adjacent to an enemy
+                # unit, so do not expand further from this hex.
+                continue
+
             for neighbor in self.get_neighboring_hexes(current_hex):
-                if neighbor not in visited:
-                    visited.add(neighbor)
+                coord = (neighbor.row, neighbor.column)
+                if coord not in visited:
+                    visited.add(coord)
                     reachable_hexes.add(neighbor)
-                    if not self.enemy_adjacent(unit, neighbor):
-                        # TODO static cost of 1
-                        queue.append((neighbor, cost + 1))
+                    # TODO static cost of 1
+                    queue.append((neighbor, cost + 1))
 
         return reachable_hexes
 
@@ -172,6 +177,10 @@ class Board:
 
             if current_hex == end:
                 return new_path
+
+            if self.enemy_adjacent(unit, current_hex):
+                # Cannot continue moving once adjacent to an enemy unit
+                continue
 
             for neighbor in self.get_neighboring_hexes(current_hex):
                 if (

--- a/battle-hexes-api/tests/game/test_board.py
+++ b/battle-hexes-api/tests/game/test_board.py
@@ -278,3 +278,27 @@ class TestBoard(unittest.TestCase):
             len(reachable_hexes), 16,
             "Unit with 2 move points should reach 16 hexes excl obstacles"
         )
+
+    def test_shortest_path_avoids_enemy_adjacent(self):
+        self.board.add_unit(self.red_unit, 2, 2)
+        self.board.add_unit(self.blue_unit, 0, 3)
+
+        start_hex = self.board.get_hex(2, 2)
+        end_hex = self.board.get_hex(0, 2)
+
+        path = self.board.shortest_path(self.red_unit, start_hex, end_hex)
+        coords = [(h.row, h.column) for h in path]
+
+        self.assertTrue(len(coords) > 1)
+        self.assertNotIn((1, 2), coords)
+        self.assertEqual(coords[-1], (0, 2))
+
+    def test_shortest_path_blocked_when_start_adjacent(self):
+        self.board.add_unit(self.red_unit, 2, 2)
+        self.board.add_unit(self.blue_unit, 1, 2)
+
+        start_hex = self.board.get_hex(2, 2)
+        end_hex = self.board.get_hex(2, 3)
+
+        path = self.board.shortest_path(self.red_unit, start_hex, end_hex)
+        self.assertEqual(path, [])


### PR DESCRIPTION
## Summary
- stop movement expansion from hexes adjacent to enemies
- ensure shortest path ends when an enemy is adjacent
- document the game rule in HOW_TO_PLAY.md and reference it
- cover enemy adjacency rules with new unit tests

## Testing
- `./api-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68730dd713b883279e148bd941ee0b63