### PR TITLE
Detect game over when one player remains

### DIFF
--- a/HOW_TO_PLAY.md
+++ b/HOW_TO_PLAY.md
@@ -14,4 +14,9 @@ This rule means that movement plans cannot pass through hexes that border enemy
 units. If a path would cause a unit to become adjacent to an opponent, the unit
 must end its movement on that hex.
 
+## Ending the Game
+
+Play continues until only one player still has units on the board. When all of
+your opponents' forces have been eliminated, the game ends immediately.
+
 

--- a/battle-hexes-web/src/index.html
+++ b/battle-hexes-web/src/index.html
@@ -52,6 +52,8 @@
     </div>
     <br/>
     <button id="endPhaseBtn"></button>
+    <h3 id="gameOverLabel" style="display: none;">Game Over</h3>
+    <button id="newGameBtn" style="display: none;">New Game</button>
   </div>
   <div id="canvas-container"></div>
   <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;700&display=swap" rel="stylesheet">

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -6,12 +6,18 @@ export class Menu {
   #selHexContentsDiv;
   #selHexCoordDiv;
   #unitMovesLeftDiv;
+  #newGameBtn;
+  #gameOverLabel;
 
   constructor(game) {
     this.#game = game;
     this.#selHexContentsDiv = document.getElementById('selHexContents');
     this.#selHexCoordDiv = document.getElementById('selHexCoord');
     this.#unitMovesLeftDiv = document.getElementById('unitMovesLeftDiv');
+    this.#newGameBtn = document.getElementById('newGameBtn');
+    this.#gameOverLabel = document.getElementById('gameOverLabel');
+
+    this.#newGameBtn.addEventListener('click', () => location.reload());
 
     this.#initPhasesInMenu();
     this.#initPhaseEndButton();
@@ -70,6 +76,12 @@ export class Menu {
     this.#setCurrentTurn();
     this.#updatePhasesStyling();
     this.#disableOrEnableActionButton();
+
+    if (this.#game.isGameOver()) {
+      this.#showGameOver();
+    } else {
+      this.#hideGameOver();
+    }
   }
 
   #updateCombatIndicator() {
@@ -116,7 +128,7 @@ export class Menu {
 
   #disableOrEnableActionButton() {
     const endPhaseBtn = document.getElementById('endPhaseBtn');
-    endPhaseBtn.disabled = !this.#game.getCurrentPlayer().isHuman();
+    endPhaseBtn.disabled = !this.#game.getCurrentPlayer().isHuman() || this.#game.isGameOver();
   }
 
   #postCombat() {
@@ -140,5 +152,15 @@ export class Menu {
         phaseElem.classList.remove('current-phase');
       }
     }
+  }
+
+  #showGameOver() {
+    this.#gameOverLabel.style.display = 'block';
+    this.#newGameBtn.style.display = 'block';
+  }
+
+  #hideGameOver() {
+    this.#gameOverLabel.style.display = 'none';
+    this.#newGameBtn.style.display = 'none';
   }
 }

--- a/battle-hexes-web/src/model/game.js
+++ b/battle-hexes-web/src/model/game.js
@@ -63,6 +63,14 @@ export class Game {
     return this.#board;
   }
 
+  isGameOver() {
+    const owners = new Set();
+    for (const unit of this.#board.getUnits()) {
+      owners.add(unit.getOwningPlayer());
+    }
+    return owners.size <= 1;
+  }
+
   resolveCombat(finishedCb) {
     return this.#combatResolver.resolveCombat().then(() => {
       if (finishedCb) {

--- a/battle-hexes-web/tests/model/game.test.js
+++ b/battle-hexes-web/tests/model/game.test.js
@@ -1,5 +1,7 @@
 import { Board } from "../../src/model/board";
 import { Game } from "../../src/model/game";
+import { Faction } from "../../src/model/faction";
+import { Unit } from "../../src/model/unit";
 import { Player, Players } from "../../src/player/player";
 
 let game;
@@ -34,5 +36,30 @@ describe('endPhase', () => {
     expect(switched).toBe(true);
     expect(game.getCurrentPhase()).toBe(phases[0]);
     expect(game.getCurrentPlayer()).toEqual(player2);
+  });
+});
+
+describe('isGameOver', () => {
+  test('returns false when multiple players have units', () => {
+    const f1 = new Faction('f1', 'f1', '#f00');
+    const f2 = new Faction('f2', 'f2', '#0f0');
+    f1.setOwningPlayer(player1);
+    f2.setOwningPlayer(player2);
+
+    const u1 = new Unit('u1', 'Unit1', f1, null, 1, 1, 1);
+    const u2 = new Unit('u2', 'Unit2', f2, null, 1, 1, 1);
+    game.getBoard().addUnit(u1, 0, 0);
+    game.getBoard().addUnit(u2, 0, 1);
+
+    expect(game.isGameOver()).toBe(false);
+  });
+
+  test('returns true when only one player has units', () => {
+    const f1 = new Faction('f1', 'f1', '#f00');
+    f1.setOwningPlayer(player1);
+    const u1 = new Unit('u1', 'Unit1', f1, null, 1, 1, 1);
+    game.getBoard().addUnit(u1, 0, 0);
+
+    expect(game.isGameOver()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add `Game.isGameOver` and check for it in the menu
- show **Game Over** message and disable phase button
- provide a new game button that reloads the page
- document the new end condition
- test the `isGameOver` logic

## Testing
- `npm test --silent`
- `./api-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_687312be8cf88327a9418e8ae9022049