### PR TITLE
Enable CPU vs CPU play

### DIFF
--- a/battle-hexes-api/src/game/game.py
+++ b/battle-hexes-api/src/game/game.py
@@ -79,14 +79,20 @@ class Game:
         red_faction = Faction(
              id=UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479", version=4),
              name="Red Faction", color="#C81010")
-        player1 = Player(name="Player 1",
-                         type=PlayerType.HUMAN,
-                         factions=[red_faction])
 
         blue_faction = Faction(
              id=UUID("38400000-8cf0-11bd-b23e-10b96e4ef00d", version=4),
              name="Blue Faction", color="#4682B4")
+
         board = Board(10, 10)
+
+        player1 = RandomPlayer(
+            name="Player 1",
+            type=PlayerType.CPU,
+            factions=[red_faction],
+            board=board
+        )
+
         player2 = RandomPlayer(
             name="Player 2",
             type=PlayerType.CPU,

--- a/battle-hexes-web/src/battle-draw.js
+++ b/battle-hexes-web/src/battle-draw.js
@@ -25,6 +25,10 @@ new p5((p) => {
   const game = new GameCreator().createGame(gameData);
   const menu = new Menu(game);
 
+  if (!game.getCurrentPlayer().isHuman()) {
+    game.getCurrentPlayer().play(game);
+  }
+
   const hexDrawWithCoords = new HexDrawer(p, hexRadius);
   hexDrawWithCoords.setShowHexCoords(true);
   const hexDraw = new HexDrawer(p, hexRadius);


### PR DESCRIPTION
## Summary
- update sample game to have both players controlled by the CPU
- automatically trigger CPU play when the first player is a CPU

## Testing
- `./api-checks.sh`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68731d7e14e88327b5db9574e85e27c7