### PR TITLE
Fix retreating units leaving the board

### DIFF
--- a/battle-hexes-api/src/combat/combat.py
+++ b/battle-hexes-api/src/combat/combat.py
@@ -40,6 +40,10 @@ class Combat:
                     battle_participants[1].get_coords(),
                     2
                 )
+                if not self.board.is_in_bounds(
+                        battle_participants[0].row,
+                        battle_participants[0].column):
+                    self.board.remove_units(battle_participants[0])
             case CombatResult.DEFENDER_ELIMINATED:
                 self.board.remove_units(battle_participants[1])
             case CombatResult.DEFENDER_RETREAT_2:
@@ -47,6 +51,10 @@ class Combat:
                     battle_participants[0].get_coords(),
                     2
                 )
+                if not self.board.is_in_bounds(
+                        battle_participants[1].row,
+                        battle_participants[1].column):
+                    self.board.remove_units(battle_participants[1])
             case CombatResult.EXCHANGE:
                 self.board.remove_units(battle_participants)
             case _:

--- a/battle-hexes-api/src/game/board.py
+++ b/battle-hexes-api/src/game/board.py
@@ -56,6 +56,10 @@ class Board:
             return self.hexes[index]
         return None
 
+    def is_in_bounds(self, row: int, column: int) -> bool:
+        """Return True if the coordinates are on the board."""
+        return 0 <= row < self.rows and 0 <= column < self.columns
+
     def add_unit(self, unit: Unit, row: int, column: int) -> None:
         if not (0 <= row < self.rows) or not (0 <= column < self.columns):
             raise ValueError("Unit is out of bounds")

--- a/battle-hexes-api/tests/combat/test_combat.py
+++ b/battle-hexes-api/tests/combat/test_combat.py
@@ -141,3 +141,13 @@ class TestCombat(unittest.TestCase):
 
         self.assertEqual(2, len(self.board.get_units()))
         self.assertEqual((5, 5), self.blue_unit.get_coords())
+
+    def test_defender_retreat_off_map_eliminates_unit(self):
+        self.board.add_unit(self.red_unit, 0, 1)
+        self.board.add_unit(self.blue_unit, 0, 0)
+        self.combat.set_static_die_roll(3)
+
+        self.combat.resolve_combat()
+
+        self.assertEqual(1, len(self.board.get_units()))
+        self.assertEqual(self.red_unit, self.board.get_units()[0])


### PR DESCRIPTION
## Summary
- add `is_in_bounds` helper to `Board`
- remove units that retreat off the board
- test defender elimination when forced off-map

## Testing
- `./api-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873243f4f8c8327ba15fcf41fdc064b