### PR TITLE
Remove unused runtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,19 @@ Turn-based strategy game engine.
 
 See [HOW_TO_PLAY.md](HOW_TO_PLAY.md) for an overview of the game mechanics.
 
+## Setting up the API
+
+Create a virtual environment and install dependencies from both requirement files:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r battle-hexes-api/requirements.txt -r battle-hexes-api/requirements-test.txt
+```
+
+You can run unit tests and linting together with:
+
+```bash
+./api-checks.sh
+```
+


### PR DESCRIPTION
## Summary
- drop unnecessary httpx requirement from API runtime dependencies
- document installation of API requirements in root README

## Testing
- `pip install -r battle-hexes-api/requirements.txt -r battle-hexes-api/requirements-test.txt`
- `./api-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6875a4b20d6c83279e9b26b77106402a