### PR TITLE
Add no-op RL player

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository now contains several packages:
 
 - **battle_hexes_core** – domain models like `Game`, `Board` and `Unit`.
 - **battle_agent_random** – a simple `RandomPlayer` implementation.
-- **battle_agent_rl** – a placeholder for reinforcement learning agents.
+- **battle_agent_rl** – early reinforcement learning agents. Currently includes an `RLPlayer` that performs no movement.
 - **battle_hexes_api** – a FastAPI service for game lifecycle endpoints.
 - **battle-hexes-web** – a p5.js web-based UI.
 Source code for each project lives inside its own `src` directory (for example `battle_hexes_core/src` or `battle-hexes-web/src`) so the project name is not repeated.

--- a/battle_agent_rl/README.md
+++ b/battle_agent_rl/README.md
@@ -1,3 +1,4 @@
 # Battle Agent RL
 
-Placeholder for future reinforcement learning based agents.
+This package will host reinforcement learning based agents. It currently
+contains a simple `RLPlayer` class that returns no movement plans.

--- a/battle_agent_rl/checks.sh
+++ b/battle_agent_rl/checks.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PYTHONPATH="$REPO_ROOT/battle_hexes_core/src:$REPO_ROOT/battle_agent_rl/src"
+cd "$REPO_ROOT/battle_agent_rl"
+pytest -v --import-mode=importlib
+flake8 .

--- a/battle_agent_rl/pytest.ini
+++ b/battle_agent_rl/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = src
+addopts = --import-mode=importlib

--- a/battle_agent_rl/src/battle_agent_rl/__init__.py
+++ b/battle_agent_rl/src/battle_agent_rl/__init__.py
@@ -1,0 +1,3 @@
+from .rlplayer import RLPlayer
+
+__all__ = ["RLPlayer"]

--- a/battle_agent_rl/src/battle_agent_rl/rlplayer.py
+++ b/battle_agent_rl/src/battle_agent_rl/rlplayer.py
@@ -1,0 +1,19 @@
+from typing import List
+from pydantic import PrivateAttr
+from battle_hexes_core.game.board import Board
+from battle_hexes_core.game.player import Player
+from battle_hexes_core.game.unitmovementplan import UnitMovementPlan
+
+
+class RLPlayer(Player):
+    """Simple reinforcement learning player that performs no actions."""
+
+    _board: Board = PrivateAttr()
+
+    def __init__(self, name: str, type, factions, board: Board):
+        super().__init__(name=name, type=type, factions=factions)
+        self._board = board
+
+    def movement(self) -> List[UnitMovementPlan]:
+        """Return an empty list of movement plans."""
+        return []

--- a/battle_agent_rl/tests/__init__.py
+++ b/battle_agent_rl/tests/__init__.py
@@ -1,0 +1,1 @@
+# __init__.py for tests

--- a/battle_agent_rl/tests/test_rlplayer.py
+++ b/battle_agent_rl/tests/test_rlplayer.py
@@ -1,0 +1,44 @@
+import unittest
+import uuid
+
+from battle_agent_rl.rlplayer import RLPlayer
+from battle_hexes_core.game.board import Board
+from battle_hexes_core.game.game import Game
+from battle_hexes_core.game.player import Player, PlayerType
+from battle_hexes_core.unit.faction import Faction
+from battle_hexes_core.unit.unit import Unit
+
+
+class TestRLPlayer(unittest.TestCase):
+    def setUp(self):
+        self.board = Board(8, 8)
+        self.faction = Faction(id=uuid.uuid4(), name="Red", color="red")
+        player = Player(
+            name="Red Player",
+            type=PlayerType.CPU,
+            factions=[self.faction],
+        )
+        self.rl_player = RLPlayer(
+            name="RL Player",
+            type=PlayerType.CPU,
+            factions=[self.faction],
+            board=self.board,
+        )
+        self.game = Game(players=[player], board=self.board)
+        self.unit = Unit(
+            uuid.uuid4(),
+            "Red Unit",
+            self.faction,
+            player,
+            "Infantry",
+            2,
+            2,
+            3,
+        )
+
+    def test_no_moves_on_empty_board(self):
+        self.assertEqual(self.rl_player.movement(), [])
+
+    def test_no_moves_even_with_units(self):
+        self.board.add_unit(self.unit, 4, 4)
+        self.assertEqual(self.rl_player.movement(), [])

--- a/server-side-checks.sh
+++ b/server-side-checks.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
-export PYTHONPATH="$REPO_ROOT/battle_hexes_core/src:$REPO_ROOT/battle_agent_random/src:$REPO_ROOT/battle_hexes_api/src:${PYTHONPATH:-}"
+export PYTHONPATH="$REPO_ROOT/battle_hexes_core/src:$REPO_ROOT/battle_agent_random/src:$REPO_ROOT/battle_agent_rl/src:$REPO_ROOT/battle_hexes_api/src:${PYTHONPATH:-}"
 
 cd "$REPO_ROOT/battle_hexes_core"
 pytest
 cd "$REPO_ROOT/battle_agent_random"
+pytest
+cd "$REPO_ROOT/battle_agent_rl"
 pytest
 cd "$REPO_ROOT/battle_hexes_api"
 pytest
@@ -14,4 +16,5 @@ cd "$REPO_ROOT"
 flake8 \
   battle_hexes_core/src battle_hexes_core/tests \
   battle_agent_random/src battle_agent_random/tests \
+  battle_agent_rl/src battle_agent_rl/tests \
   battle_hexes_api/src battle_hexes_api/tests


### PR DESCRIPTION
## Summary
- implement `RLPlayer` as a placeholder reinforcement learning agent
- add unit tests for RL player behavior
- integrate RL package into repo lint/test scripts
- document the RL package in the README files

## Testing
- `./server-side-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_687acce8def48327b2c6d080fe9da23b