### PR TITLE
Add combat rewards to QLearningPlayer

### DIFF
--- a/battle_agent_rl/src/battle_agent_rl/qlearningplayer.py
+++ b/battle_agent_rl/src/battle_agent_rl/qlearningplayer.py
@@ -10,7 +10,6 @@ from battle_hexes_core.combat.combatresults import CombatResults
 from battle_hexes_core.game.board import Board
 from battle_hexes_core.game.unitmovementplan import UnitMovementPlan
 from battle_hexes_core.unit.faction import Faction
-from battle_hexes_core.unit.unit import Unit
 
 from .rlplayer import RLPlayer
 
@@ -22,6 +21,7 @@ class QLearningPlayer(RLPlayer):
     _gamma: float = PrivateAttr()
     _epsilon: float = PrivateAttr()
     _q: Dict[Tuple[Hashable, Hashable], float] = PrivateAttr()
+    _last_actions: Dict[str, Tuple[Hashable, Hashable]] = PrivateAttr()
 
     def __init__(
         self,
@@ -38,6 +38,7 @@ class QLearningPlayer(RLPlayer):
         self._gamma = gamma
         self._epsilon = epsilon
         self._q = defaultdict(float)
+        self._last_actions = {}
 
     # ------------------------------------------------------------------
     # Q-Learning helpers
@@ -85,36 +86,22 @@ class QLearningPlayer(RLPlayer):
     # ------------------------------------------------------------------
     # Reward helpers
     # ------------------------------------------------------------------
-    # TODO this should be handled by combat_results()
-    def elimination_reward(
-        self,
-        before_units: List[Unit],
-        after_units: List[Unit],
-    ) -> int:
-        """Return reward for units eliminated between two board states."""
-        friend_ids_before = {
-            u.get_id()
-            for u in before_units
-            if u.get_faction() in self.factions
-        }
-        friend_ids_after = {
-            u.get_id()
-            for u in after_units
-            if u.get_faction() in self.factions
-        }
-        enemy_ids_before = {
-            u.get_id()
-            for u in before_units
-            if u.get_faction() not in self.factions
-        }
-        enemy_ids_after = {
-            u.get_id()
-            for u in after_units
-            if u.get_faction() not in self.factions
-        }
-        friends_lost = len(friend_ids_before - friend_ids_after)
-        enemies_eliminated = len(enemy_ids_before - enemy_ids_after)
-        return enemies_eliminated - friends_lost
+    def calculate_reward(self, combat_results: CombatResults) -> int:
+        """Return reward based on combat outcomes."""
+        from battle_hexes_core.combat.combatresult import CombatResult
+
+        attacker = bool(self._last_actions)
+        reward = 0
+        for battle in combat_results.get_battles():
+            result = battle.get_combat_result()
+            if result == CombatResult.DEFENDER_ELIMINATED:
+                reward += 1 if attacker else -1
+            elif result == CombatResult.ATTACKER_ELIMINATED:
+                reward += -1 if attacker else 1
+            elif result == CombatResult.EXCHANGE:
+                # Both sides lose one unit
+                reward += 0
+        return reward
 
     # ------------------------------------------------------------------
     # Movement (\u03b5-greedy using Q-table). State is board snapshot.
@@ -131,6 +118,7 @@ class QLearningPlayer(RLPlayer):
     def movement(self) -> List[UnitMovementPlan]:
         plans: List[UnitMovementPlan] = []
         state = self.board_state()
+        self._last_actions = {}
         for unit in self.own_units(self._board.get_units()):
             start_hex = self._board.get_hex(unit.row, unit.column)
             reachable = list(self._board.get_reachable_hexes(unit, start_hex))
@@ -141,6 +129,7 @@ class QLearningPlayer(RLPlayer):
             chosen = self.choose_action(state, actions)
             if chosen is None:
                 continue
+            self._last_actions[str(unit.get_id())] = (state, chosen)
             _, row, col = chosen
             target_hex = self._board.get_hex(row, col)
             path = self._board.shortest_path(unit, start_hex, target_hex)
@@ -150,6 +139,8 @@ class QLearningPlayer(RLPlayer):
 
     def combat_results(self, combat_results: CombatResults) -> None:
         """Informs the player of the combat results."""
-        # TODO !
-        # This method can be used to update Q-values based on combat outcomes.
-        pass
+        reward = self.calculate_reward(combat_results)
+        next_state = self.board_state()
+        for state, action in self._last_actions.values():
+            self.update_q(state, action, reward, next_state)
+        self._last_actions = {}

--- a/battle_agent_rl/src/battle_agent_rl/qlearningplayer.py
+++ b/battle_agent_rl/src/battle_agent_rl/qlearningplayer.py
@@ -144,3 +144,4 @@ class QLearningPlayer(RLPlayer):
         for state, action in self._last_actions.values():
             self.update_q(state, action, reward, next_state)
         self._last_actions = {}
+        print("Q-table after combat:", dict(self._q))

--- a/battle_agent_rl/src/battle_agent_rl/qlearningplayer.py
+++ b/battle_agent_rl/src/battle_agent_rl/qlearningplayer.py
@@ -144,4 +144,30 @@ class QLearningPlayer(RLPlayer):
         for state, action in self._last_actions.values():
             self.update_q(state, action, reward, next_state)
         self._last_actions = {}
-        print("Q-table after combat:", dict(self._q))
+        print("Q-table after combat:")
+        print(self._format_q_table(next_state))
+
+    # ------------------------------------------------------------------
+    # Debug helpers
+    # ------------------------------------------------------------------
+    def _format_q_table(self, state: Hashable) -> str:
+        """Return a human-readable Q-table for the given board state."""
+        rows = []
+        for r in range(self._board.get_rows()):
+            indent = " " if r % 2 == 1 else ""
+            cells = []
+            for c in range(self._board.get_columns()):
+                q_vals = [
+                    self._q[(s, a)]
+                    for (s, a) in self._q
+                    if (
+                        s == state
+                        and isinstance(a, tuple)
+                        and a[1] == r
+                        and a[2] == c
+                    )
+                ]
+                cell = f"{max(q_vals):4.1f}" if q_vals else "   ."
+                cells.append(cell)
+            rows.append(indent + " ".join(cells))
+        return "\n".join(rows)

--- a/battle_agent_rl/tests/test_qlearningplayer.py
+++ b/battle_agent_rl/tests/test_qlearningplayer.py
@@ -5,6 +5,11 @@ from battle_hexes_core.game.board import Board
 from battle_hexes_core.game.player import Player, PlayerType
 from battle_hexes_core.unit.faction import Faction
 from battle_hexes_core.unit.unit import Unit
+from battle_hexes_core.combat.combatresult import (
+    CombatResult,
+    CombatResultData,
+)
+from battle_hexes_core.combat.combatresults import CombatResults
 
 
 def test_qlearning_update_rule():
@@ -26,24 +31,82 @@ def test_qlearning_update_rule():
     assert player.q_table[(state, "a")] == expected
 
 
-def test_elimination_reward():
+def test_calculate_reward():
+    board = Board(1, 1)
+    faction = Faction(id=uuid.uuid4(), name="F", color="red")
+    agent = QLearningPlayer(
+        name="QL",
+        type=PlayerType.CPU,
+        factions=[faction],
+        board=board,
+    )
+
+    # Attacker case
+    agent._last_actions = {"x": ("s", "a")}
+    results = CombatResults()
+    results.add_battle(
+        CombatResultData((1, 1), 1, CombatResult.DEFENDER_ELIMINATED)
+    )
+    assert agent.calculate_reward(results) == 1
+
+    results = CombatResults()
+    results.add_battle(
+        CombatResultData((1, 1), 1, CombatResult.ATTACKER_ELIMINATED)
+    )
+    assert agent.calculate_reward(results) == -1
+
+    # Defender case
+    agent._last_actions = {}
+    results = CombatResults()
+    results.add_battle(
+        CombatResultData((1, 1), 1, CombatResult.ATTACKER_ELIMINATED)
+    )
+    assert agent.calculate_reward(results) == 1
+    results = CombatResults()
+    results.add_battle(
+        CombatResultData((1, 1), 1, CombatResult.DEFENDER_ELIMINATED)
+    )
+    assert agent.calculate_reward(results) == -1
+
+
+def test_combat_results_updates_q_table():
     board = Board(2, 2)
     faction_a = Faction(id=uuid.uuid4(), name="A", color="blue")
     faction_b = Faction(id=uuid.uuid4(), name="B", color="green")
-    player = Player(name="P", type=PlayerType.CPU, factions=[faction_a])
+    other_player = Player(name="O", type=PlayerType.CPU, factions=[faction_b])
     agent = QLearningPlayer(
         name="QL",
         type=PlayerType.CPU,
         factions=[faction_a],
         board=board,
+        alpha=1.0,
+        gamma=0.0,
+        epsilon=0.0,
     )
-    ally = Unit(uuid.uuid4(), "Ally", faction_a, player, "Inf", 1, 1, 1)
-    enemy = Unit(uuid.uuid4(), "Enemy", faction_b, player, "Inf", 1, 1, 1)
-    # Before state has both units
-    before = [ally, enemy]
-    # After state loses the enemy
-    after = [ally]
-    assert agent.elimination_reward(before, after) == 1
-    # After losing the ally
-    after = [enemy]
-    assert agent.elimination_reward(before, after) == -1
+    ally = Unit(uuid.uuid4(), "Ally", faction_a, agent, "Inf", 1, 1, 1)
+    enemy = Unit(
+        uuid.uuid4(),
+        "Enemy",
+        faction_b,
+        other_player,
+        "Inf",
+        1,
+        1,
+        1,
+    )
+    board.add_unit(ally, 0, 0)
+    board.add_unit(enemy, 0, 1)
+
+    state = agent.board_state()
+    action = (ally.get_id(), ally.row, ally.column)
+    agent._last_actions = {str(ally.get_id()): (state, action)}
+
+    results = CombatResults()
+    results.add_battle(
+        CombatResultData((1, 1), 1, CombatResult.DEFENDER_ELIMINATED)
+    )
+    board.remove_units(enemy)
+
+    agent.combat_results(results)
+
+    assert agent.q_table[(state, action)] == 1


### PR DESCRIPTION
## Summary
- track chosen actions and board state in `QLearningPlayer`
- implement reward update logic in `combat_results`
- extend unit tests for Q-learning player
- install missing test dependencies

## Testing
- `./server-side-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_687c38783c7883279db314ac867dea57