### PR TITLE
Implement RL pathfinding utilities

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/game/board.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/board.py
@@ -265,6 +265,60 @@ class Board:
 
         return nearest_enemy
 
+    def path_towards(
+        self, unit: Unit, target_hex: Hex, max_steps: int
+    ) -> List[Hex]:
+        """Return a truncated shortest path from the unit to ``target_hex``."""
+        if unit.get_coords() is None:
+            return []
+
+        start_hex = self.get_hex(*unit.get_coords())
+        if start_hex is None:
+            return []
+
+        reachable = self.get_reachable_hexes(
+            unit, start_hex, move_points=max_steps
+        )
+        if not reachable:
+            return [start_hex]
+
+        best = min(
+            reachable, key=lambda h: Board.hex_distance(h, target_hex)
+        )
+
+        full_path = self.shortest_path(unit, start_hex, best)
+        if not full_path:
+            return [start_hex]
+
+        return full_path[: max_steps + 1]
+
+    def path_away_from(
+        self, unit: Unit, threat_hex: Hex, max_steps: int
+    ) -> List[Hex]:
+        """Return a path that increases distance from ``threat_hex``."""
+        if unit.get_coords() is None:
+            return []
+
+        start_hex = self.get_hex(*unit.get_coords())
+        if start_hex is None:
+            return []
+
+        reachable = self.get_reachable_hexes(
+            unit, start_hex, move_points=max_steps
+        )
+        if not reachable:
+            return [start_hex]
+
+        farthest = max(
+            reachable, key=lambda h: Board.hex_distance(h, threat_hex)
+        )
+
+        path = self.shortest_path(unit, start_hex, farthest)
+        if not path:
+            return [start_hex]
+
+        return path[: max_steps + 1]
+
     def get_units_for_hexes(self, hexes: List[Hex]) -> List[Unit]:
         units = []
         for unit in self.units.values():

--- a/battle_hexes_core/tests/game/test_board.py
+++ b/battle_hexes_core/tests/game/test_board.py
@@ -311,3 +311,25 @@ class TestBoard(unittest.TestCase):
         self.assertEqual(Board.hex_distance(a, a), 0)
         self.assertEqual(Board.hex_distance(a, b), 1)
         self.assertEqual(Board.hex_distance(a, c), 2)
+
+    def test_path_towards_limited_steps(self):
+        self.board.add_unit(self.red_unit, 2, 1)
+        self.board.add_unit(self.blue_unit, 4, 1)
+
+        enemy_hex = self.board.get_hex(4, 1)
+        path = self.board.path_towards(self.red_unit, enemy_hex, 1)
+        coords = [(h.row, h.column) for h in path]
+        self.assertEqual(coords, [(2, 1), (3, 1)])
+
+    def test_path_away_from_increases_distance(self):
+        self.board.add_unit(self.red_unit, 2, 1)
+        self.board.add_unit(self.blue_unit, 0, 1)
+
+        threat_hex = self.board.get_hex(0, 1)
+        start_hex = self.board.get_hex(2, 1)
+        start_dist = Board.hex_distance(start_hex, threat_hex)
+        path = self.board.path_away_from(self.red_unit, threat_hex, 1)
+        end_hex = path[-1]
+        end_dist = Board.hex_distance(end_hex, threat_hex)
+        self.assertEqual(len(path), 2)
+        self.assertGreater(end_dist, start_dist)


### PR DESCRIPTION
## Summary
- add `path_towards` and `path_away_from` helpers on `Board`
- implement movement planning in `QLearningPlayer`
- use `move_plan` to build movement orders
- expand unit tests for new behaviours

## Testing
- `./server-side-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_688658ffadb883278946818dd82a8a21