### PR TITLE
Allow GameFactory to create repeatable games

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/samplegame.py
+++ b/battle_hexes_api/src/battle_hexes_api/samplegame.py
@@ -68,8 +68,8 @@ class SampleGameCreator:
         )
         blue_unit.set_coords(8, 19)
 
-        return GameFactory().create_game(
+        return GameFactory(
             board_size,
             [player1, player2],
             [red_unit, blue_unit],
-        )
+        ).create_game()

--- a/battle_hexes_core/src/battle_hexes_core/game/gamefactory.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/gamefactory.py
@@ -5,35 +5,37 @@ from battle_hexes_core.unit.unit import Unit
 
 
 class GameFactory:
-    def create_game(
-            self,
-            board_size: tuple[int, int],
-            players: list[Player],
-            units: list[Unit]
-            ) -> Game:
-        """Create a ``Game`` with the given board size, players and units."""
-        rows, cols = board_size
+    """Factory for generating ``Game`` instances from preset components."""
 
-        board = None
-        for player in players:
+    def __init__(
+        self,
+        board_size: tuple[int, int],
+        players: list[Player],
+        units: list[Unit],
+    ) -> None:
+        self.board_size = board_size
+        self.players = players
+        self.units = units
+
+        # Record the starting coordinates of each unit so they can be reset on
+        # each ``create_game`` call.
+        self._unit_start_positions = {
+            unit: unit.get_coords() for unit in units
+        }
+
+    def create_game(self) -> Game:
+        """Create a ``Game`` using the stored board size, players and units."""
+        rows, cols = self.board_size
+        # Always create a fresh board for a new game and assign it to players
+        board = Board(rows, cols)
+        for player in self.players:
             if hasattr(player, "_board"):
-                board = getattr(player, "_board")
-                break
+                player._board = board
 
-        if (
-            board is None
-            or board.get_rows() != rows
-            or board.get_columns() != cols
-        ):
-            board = Board(rows, cols)
-            for player in players:
-                if hasattr(player, "_board"):
-                    player._board = board
+        game = Game(self.players, board)
 
-        game = Game(players, board)
-
-        for unit in units:
-            coords = unit.get_coords()
+        for unit in self.units:
+            coords = self._unit_start_positions.get(unit)
             if coords is None:
                 continue
             board.add_unit(unit, coords[0], coords[1])


### PR DESCRIPTION
## Summary
- make `GameFactory` store board size, players and units
- create a new board on every call and reset unit coordinates
- update `SampleGameCreator` for new `GameFactory` API

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `./server-side-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886780656808327a550f8243efbf407