### PR TITLE
Refactor play loop

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/game/game.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/game.py
@@ -75,9 +75,11 @@ class Game:
                 return player
         raise ValueError(f"No player found for faction {faction.name}")
 
-    def play(self) -> None:
-        """
-        Start the game loop and play until the game is over. All players must
-        be of type CPU.
-        """
-        pass
+    def is_game_over(self) -> bool:
+        """Return True if zero or one players still have units on the board."""
+        active_players = {
+            unit.player.name
+            for unit in self.get_board().get_units()
+            if unit.get_coords() is not None
+        }
+        return len(active_players) <= 1

--- a/battle_hexes_core/src/battle_hexes_core/game/gameplayer.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/gameplayer.py
@@ -1,0 +1,27 @@
+from battle_hexes_core.game.game import Game
+from battle_hexes_core.game.player import PlayerType
+from battle_hexes_core.combat.combat import Combat
+
+
+class GamePlayer:
+    def __init__(self, game: Game) -> None:
+        self.game = game
+
+    def play(self) -> None:
+        """Run CPU turns until only one player has units remaining."""
+        for player in self.game.get_players():
+            if player.type is not PlayerType.CPU:
+                raise ValueError("All players must be of type CPU")
+
+        while not self.game.is_game_over():
+            current_player = self.game.get_current_player()
+
+            plans = current_player.movement()
+            self.game.apply_movement_plans(plans)
+
+            Combat(self.game).resolve_combat()
+
+            if self.game.is_game_over():
+                break
+
+            self.game.next_player()

--- a/battle_hexes_core/tests/game/test_gameplayer.py
+++ b/battle_hexes_core/tests/game/test_gameplayer.py
@@ -1,0 +1,78 @@
+import unittest
+import uuid
+from unittest.mock import patch, MagicMock
+
+from battle_hexes_core.game.board import Board
+from battle_hexes_core.game.game import Game
+from battle_hexes_core.game.gameplayer import GamePlayer
+from battle_hexes_core.game.player import Player, PlayerType
+from battle_hexes_core.unit.faction import Faction
+from battle_hexes_core.unit.unit import Unit
+
+
+class DummyCPUPlayer(Player):
+    def __init__(self, name, factions):
+        super().__init__(name=name, type=PlayerType.CPU, factions=factions)
+
+    def movement(self):
+        return []
+
+    def movement_cb(self):
+        pass
+
+    def combat_results(self, combat_results):
+        pass
+
+
+class TestGamePlayer(unittest.TestCase):
+    def test_play_requires_cpu_players(self):
+        board = Board(2, 2)
+        fac = Faction(id=uuid.uuid4(), name="F", color="red")
+        player = Player(name="P", type=PlayerType.HUMAN, factions=[fac])
+        game = Game([player], board)
+        gp = GamePlayer(game)
+        with self.assertRaises(ValueError):
+            gp.play()
+
+    def test_play_until_one_player_left(self):
+        board = Board(2, 2)
+        red_faction = Faction(id=uuid.uuid4(), name="Red", color="red")
+        blue_faction = Faction(id=uuid.uuid4(), name="Blue", color="blue")
+
+        red_player = DummyCPUPlayer("Red", [red_faction])
+        blue_player = DummyCPUPlayer("Blue", [blue_faction])
+
+        red_unit = Unit(
+            uuid.uuid4(), "R", red_faction, red_player, "I", 1, 1, 1
+        )
+        blue_unit = Unit(
+            uuid.uuid4(), "B", blue_faction, blue_player, "I", 1, 1, 1
+        )
+        board.add_unit(red_unit, 0, 0)
+        board.add_unit(blue_unit, 0, 1)
+
+        game = Game([red_player, blue_player], board)
+        gp = GamePlayer(game)
+
+        class StubCombat:
+            instances = 0
+
+            def __init__(self, game_obj):
+                self.game = game_obj
+
+            def resolve_combat(self):
+                StubCombat.instances += 1
+                units_to_remove = [
+                    u for u in self.game.get_board().get_units()
+                    if u.player == blue_player
+                ]
+                self.game.get_board().remove_units(units_to_remove)
+                return MagicMock()
+
+        with patch("battle_hexes_core.game.gameplayer.Combat", StubCombat):
+            gp.play()
+
+        units = game.get_board().get_units()
+        self.assertEqual(len(units), 1)
+        self.assertIs(units[0], red_unit)
+        self.assertEqual(StubCombat.instances, 1)


### PR DESCRIPTION
## Summary
- move play and game-over logic to new `GamePlayer` class
- drop `Combat` import from `Game`
- update tests to use `GamePlayer`
- move `is_game_over` back to `Game`
- remove unused TYPE_CHECKING logic in `Combat`

## Testing
- `./server-side-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68868b72b0f88327b1b1790139dca95d