### PR TITLE
Add end game callback to Player

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/game/gameplayer.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/gameplayer.py
@@ -26,3 +26,6 @@ class GamePlayer:
                 break
 
             self.game.next_player()
+
+        for player in self.game.get_players():
+            player.end_game_cb()

--- a/battle_hexes_core/src/battle_hexes_core/game/player.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/player.py
@@ -38,3 +38,7 @@ class Player(BaseModel):
     def combat_results(self, combat_results: CombatResults) -> None:
         """Informs the player of the combat results."""
         raise NotImplementedError("Subclasses must implement combat_results")
+
+    def end_game_cb(self) -> None:
+        """Called when the game has concluded."""
+        pass

--- a/battle_hexes_core/tests/game/test_gameplayer.py
+++ b/battle_hexes_core/tests/game/test_gameplayer.py
@@ -1,6 +1,7 @@
 import unittest
 import uuid
 from unittest.mock import patch, MagicMock
+from pydantic import PrivateAttr
 
 from battle_hexes_core.game.board import Board
 from battle_hexes_core.game.game import Game
@@ -11,6 +12,8 @@ from battle_hexes_core.unit.unit import Unit
 
 
 class DummyCPUPlayer(Player):
+    _ended: bool = PrivateAttr(False)
+
     def __init__(self, name, factions):
         super().__init__(name=name, type=PlayerType.CPU, factions=factions)
 
@@ -22,6 +25,9 @@ class DummyCPUPlayer(Player):
 
     def combat_results(self, combat_results):
         pass
+
+    def end_game_cb(self):
+        self._ended = True
 
 
 class TestGamePlayer(unittest.TestCase):
@@ -76,3 +82,5 @@ class TestGamePlayer(unittest.TestCase):
         self.assertEqual(len(units), 1)
         self.assertIs(units[0], red_unit)
         self.assertEqual(StubCombat.instances, 1)
+        self.assertTrue(red_player._ended)
+        self.assertTrue(blue_player._ended)


### PR DESCRIPTION
## Summary
- add `end_game_cb` method to base Player class
- call `end_game_cb` for all players at the end of the game loop
- extend GamePlayer tests to verify callbacks

## Testing
- `./server-side-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886aa1d685883278ec9e0024f46b85c