### PR TITLE
Add random unit placement option

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/game/gamefactory.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/gamefactory.py
@@ -1,3 +1,5 @@
+from random import choice
+
 from battle_hexes_core.game.board import Board
 from battle_hexes_core.game.game import Game
 from battle_hexes_core.game.player import Player
@@ -12,10 +14,12 @@ class GameFactory:
         board_size: tuple[int, int],
         players: list[Player],
         units: list[Unit],
+        randomize_positions: bool = False,
     ) -> None:
         self.board_size = board_size
         self.players = players
         self.units = units
+        self.randomize_positions = randomize_positions
 
         # Record the starting coordinates of each unit so they can be reset on
         # each ``create_game`` call.
@@ -34,10 +38,27 @@ class GameFactory:
 
         game = Game(self.players, board)
 
+        used_coords = set()
         for unit in self.units:
             coords = self._unit_start_positions.get(unit)
             if coords is None:
                 continue
+
+            if self.randomize_positions:
+                coords = self._random_coords(rows, cols, used_coords)
             board.add_unit(unit, coords[0], coords[1])
+            used_coords.add(coords)
 
         return game
+
+    def _random_coords(
+        self, rows: int, cols: int, used: set[tuple[int, int]]
+    ) -> tuple[int, int]:
+        """Return random board coordinates not already used."""
+        available = [
+            (r, c)
+            for r in range(rows)
+            for c in range(cols)
+            if (r, c) not in used
+        ]
+        return choice(available)

--- a/battle_hexes_core/tests/game/test_gamefactory.py
+++ b/battle_hexes_core/tests/game/test_gamefactory.py
@@ -1,0 +1,69 @@
+import unittest
+import uuid
+from unittest.mock import patch
+
+from battle_hexes_core.game.gamefactory import GameFactory
+from battle_hexes_core.game.player import Player, PlayerType
+from battle_hexes_core.unit.faction import Faction
+from battle_hexes_core.unit.unit import Unit
+
+
+class TestGameFactory(unittest.TestCase):
+    def setUp(self):
+        self.board_size = (3, 3)
+        self.faction = Faction(id=uuid.uuid4(), name="F", color="red")
+        self.player = Player(
+            name="P",
+            type=PlayerType.CPU,
+            factions=[self.faction],
+        )
+        self.unit1 = Unit(
+            uuid.uuid4(),
+            "U1",
+            self.faction,
+            self.player,
+            "I",
+            1,
+            1,
+            1,
+            row=0,
+            column=0,
+        )
+        self.unit2 = Unit(
+            uuid.uuid4(),
+            "U2",
+            self.faction,
+            self.player,
+            "I",
+            1,
+            1,
+            1,
+            row=1,
+            column=1,
+        )
+
+    def test_create_game_uses_initial_positions(self):
+        factory = GameFactory(
+            self.board_size,
+            [self.player],
+            [self.unit1, self.unit2],
+        )
+        game = factory.create_game()
+        coords = [u.get_coords() for u in game.get_board().get_units()]
+        self.assertIn((0, 0), coords)
+        self.assertIn((1, 1), coords)
+
+    def test_create_game_randomizes_positions(self):
+        with patch(
+            "battle_hexes_core.game.gamefactory.choice",
+            side_effect=[(0, 2), (1, 0)],
+        ):
+            factory = GameFactory(
+                self.board_size,
+                [self.player],
+                [self.unit1, self.unit2],
+                randomize_positions=True,
+            )
+            game = factory.create_game()
+        coords = [u.get_coords() for u in game.get_board().get_units()]
+        self.assertCountEqual(coords, [(0, 2), (1, 0)])


### PR DESCRIPTION
## Summary
- add an optional `randomize_positions` flag to `GameFactory`
- implement coordinate randomization when creating a game
- test `GameFactory` with and without randomized start positions

## Testing
- `./server-side-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886aaedcba0832784ee7aed48ea6d14