### PR TITLE
Enable episode count CLI option for Q-learning trainer

### DIFF
--- a/battle_agent_rl/README.md
+++ b/battle_agent_rl/README.md
@@ -23,3 +23,9 @@ The number of training episodes can be passed as an argument:
 ./train_qlearning.sh 10
 ```
 
+You can also invoke the trainer module directly:
+
+```bash
+python -m battle_agent_rl.qlearningtrainer 10
+```
+

--- a/battle_agent_rl/src/battle_agent_rl/qlearningtrainer.py
+++ b/battle_agent_rl/src/battle_agent_rl/qlearningtrainer.py
@@ -1,5 +1,6 @@
 """Utility to train a simple Q-learning agent against a random opponent."""
 
+import argparse
 import uuid
 from typing import List
 
@@ -81,4 +82,15 @@ def main(episodes: int = 5) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(
+        description="Train the Q-learning player against a random opponent"
+    )
+    parser.add_argument(
+        "episodes",
+        nargs="?",
+        type=int,
+        default=5,
+        help="number of training episodes to run",
+    )
+    args = parser.parse_args()
+    main(args.episodes)


### PR DESCRIPTION
## Summary
- add argparse CLI to `qlearningtrainer.py`
- document running `qlearningtrainer` directly

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `./server-side-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886ae2b6a708327aaa9a317c47040f8