### PR TITLE
Handle off-board retreats as eliminations

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/combat/combat.py
+++ b/battle_hexes_core/src/battle_hexes_core/combat/combat.py
@@ -50,6 +50,9 @@ class Combat:
                         battle_participants[0].row,
                         battle_participants[0].column):
                     self.board.remove_units(battle_participants[0])
+                    combat_result.combat_result = (
+                        CombatResult.ATTACKER_ELIMINATED
+                    )
             case CombatResult.DEFENDER_ELIMINATED:
                 self.board.remove_units(battle_participants[1])
             case CombatResult.DEFENDER_RETREAT_2:
@@ -61,6 +64,9 @@ class Combat:
                         battle_participants[1].row,
                         battle_participants[1].column):
                     self.board.remove_units(battle_participants[1])
+                    combat_result.combat_result = (
+                        CombatResult.DEFENDER_ELIMINATED
+                    )
             case CombatResult.EXCHANGE:
                 self.board.remove_units(battle_participants)
             case _:

--- a/battle_hexes_core/tests/combat/test_combat.py
+++ b/battle_hexes_core/tests/combat/test_combat.py
@@ -152,8 +152,25 @@ class TestCombat(unittest.TestCase):
         self.board.add_unit(self.red_unit, 0, 1)
         self.board.add_unit(self.blue_unit, 0, 0)
         self.combat.set_static_die_roll(3)
-
-        self.combat.resolve_combat()
+        combat_result = self.combat.resolve_combat()
 
         self.assertEqual(1, len(self.board.get_units()))
         self.assertEqual(self.red_unit, self.board.get_units()[0])
+        self.assertEqual(
+            CombatResult.DEFENDER_ELIMINATED,
+            combat_result.get_battles()[0].get_combat_result(),
+        )
+
+    def test_attacker_retreat_off_map_eliminates_unit(self):
+        self.board.add_unit(self.red_unit, 0, 0)
+        self.board.add_unit(self.blue_unit, 0, 1)
+        self.combat.set_static_die_roll(4)
+
+        combat_result = self.combat.resolve_combat()
+
+        self.assertEqual(1, len(self.board.get_units()))
+        self.assertEqual(self.blue_unit, self.board.get_units()[0])
+        self.assertEqual(
+            CombatResult.ATTACKER_ELIMINATED,
+            combat_result.get_battles()[0].get_combat_result(),
+        )


### PR DESCRIPTION
## Summary
- mark a retreat off the board as an elimination for either side
- test attacker elimination when retreating off the board
- verify defender retreat off map returns elimination result

## Testing
- `./server-side-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6886c875fb5c8327af67b9c7e63cb8c3