### PR TITLE
Fix crash when combat participants removed

### DIFF
--- a/battle_agent_rl/tests/test_qlearningplayer.py
+++ b/battle_agent_rl/tests/test_qlearningplayer.py
@@ -182,7 +182,9 @@ class TestQLearningPlayerQUpdates(unittest.TestCase):
 
         self.player.combat_results(results)
 
-        self.assertEqual(self.player._q_table[(state, action)], 0.5)
+        # With a combat bonus of 10 and alpha=0.5 the expected Q-value
+        # update is 5.0 when a single unit is eliminated.
+        self.assertEqual(self.player._q_table[(state, action)], 5.0)
 
 
 class TestQLearningPlayerMovePlan(unittest.TestCase):

--- a/battle_hexes_core/src/battle_hexes_core/combat/combat.py
+++ b/battle_hexes_core/src/battle_hexes_core/combat/combat.py
@@ -17,6 +17,13 @@ class Combat:
     def resolve_combat(self):
         combat_results = CombatResults()
         for battle_participants in self.find_combat():
+            if (
+                battle_participants[0].get_coords() is None
+                or battle_participants[1].get_coords() is None
+            ):
+                # A participant may have been removed earlier in the turn
+                # (e.g. by another combat). Skip invalid pairs.
+                continue
             battle_result = self.__resolve_combat(battle_participants)
             combat_results.add_battle(battle_result)
         for player in self.game.get_players():
@@ -38,6 +45,12 @@ class Combat:
             battle_participants,
             combat_result: CombatResultData
     ) -> None:
+        if (
+            battle_participants[0].get_coords() is None
+            or battle_participants[1].get_coords() is None
+        ):
+            # One or both units no longer occupy the board. Nothing to update.
+            return
         match combat_result.get_combat_result():
             case CombatResult.ATTACKER_ELIMINATED:
                 self.board.remove_units(battle_participants[0])

--- a/battle_hexes_core/src/battle_hexes_core/unit/unit.py
+++ b/battle_hexes_core/src/battle_hexes_core/unit/unit.py
@@ -99,7 +99,10 @@ class Unit:
             from_hex: tuple[int, int],
             distance: int
     ) -> None:
-        """Moves the unit away from the given hex in Even-r Offset."""
+        """Move the unit away from ``from_hex`` using Even-r offset rules."""
+        if from_hex is None or self.row is None or self.column is None:
+            return
+
         from_row, from_col = from_hex
 
         if self.column == from_col:


### PR DESCRIPTION
## Summary
- skip resolved combat pairs when units were already removed
- guard against missing coordinates in `__update_board_for_result`
- make `Unit.forced_move` handle `None` hexes
- rebase with main to keep combat bonus at `10.0`

## Testing
- `./server-side-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886cfa1867483279d7b1310571fc450