### PR TITLE
Run RL agent training in API workflow

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Run checks
         run: ./server-side-checks.sh
+
+      - name: Train Q-learning agent
+        run: ./battle_agent_rl/train_qlearning.sh 10


### PR DESCRIPTION
## Summary
- Train Q-learning agent during API tests as an additional end-to-end check

## Testing
- `./server-side-checks.sh`
- `(cd /tmp && /workspace/battle-hexes/battle_agent_rl/train_qlearning.sh 10)`

------
https://chatgpt.com/codex/tasks/task_e_688d7a8ac274832797fdf13633b62699