### PR TITLE
Add minimal deploy workflow for web frontend

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy Web Project
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        working-directory: battle-hexes-web
+        run: npm install
+
+      - name: Build
+        working-directory: battle-hexes-web
+        run: npm run build
+
+      - name: Deploy placeholder
+        run: echo "Deploy step not implemented"


### PR DESCRIPTION
## Summary
- add a manual `Deploy Web Project` workflow with placeholder deploy step
- run `npm run build` before deploying

## Testing
- `./server-side-checks.sh`
- `cd battle-hexes-web && npm install`
- `cd battle-hexes-web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f76691d8c8327bf987be2de30e497