### PR TITLE
Add CloudFormation deployment for web project

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -36,6 +36,13 @@ jobs:
       # TODO debugging step to verify AWS credentials
       - name: Check AWS identity
         run: aws sts get-caller-identity
+      - name: Deploy infrastructure
+        run: |
+          aws cloudformation deploy \
+            --stack-name battle-hexes-web \
+            --template-file battle-hexes-web/cloudformation-template.yml \
+            --parameter-overrides BucketName=${{ secrets.WEB_BUCKET_NAME }} \
+            --no-fail-on-empty-changeset
 
-      - name: Deploy placeholder
-        run: echo "Deploy step not implemented"
+      - name: Sync build artifacts
+        run: aws s3 sync battle-hexes-web/dist s3://${{ secrets.WEB_BUCKET_NAME }}

--- a/battle-hexes-web/cloudformation-template.yml
+++ b/battle-hexes-web/cloudformation-template.yml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Static website hosting for Battle Hexes web project
+Parameters:
+  BucketName:
+    Type: String
+    Description: Name of the S3 bucket to host the website
+Resources:
+  WebsiteBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketName
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: index.html
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
+    DeletionPolicy: Retain
+  WebsiteBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref WebsiteBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: PublicReadGetObject
+            Effect: Allow
+            Principal: '*'
+            Action: s3:GetObject
+            Resource: !Sub '${WebsiteBucket.Arn}/*'
+Outputs:
+  BucketName:
+    Description: Name of the website bucket
+    Value: !Ref WebsiteBucket
+  WebsiteURL:
+    Description: URL for website hosted on S3
+    Value: !GetAtt WebsiteBucket.WebsiteURL


### PR DESCRIPTION
## Summary
- add CloudFormation template provisioning an S3 bucket for the web frontend
- wire web deploy workflow to run the CloudFormation stack and upload build artifacts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68915d8f69608327b7347399b765f2bd