### PR TITLE
Add Docker support for API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Docker build context for the API image
+# Ignore git and local environments
+.git
+.github
+.env
+*.venv
+__pycache__
+*.pyc
+
+# Exclude tests and development scripts
+**/tests
+**/checks.sh
+
+# Frontend not needed for API image
+battle-hexes-web

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ You can run unit tests and linting for all Python packages with:
 ./server-side-checks.sh
 ```
 
+### Running the API with Docker
+
+The API project includes a Dockerfile at `battle_hexes_api/Dockerfile`. From the
+repository root build and run the image:
+
+```bash
+docker build -f battle_hexes_api/Dockerfile -t battle-hexes-api .
+docker run -p 8000:8000 battle-hexes-api
+```
+
+The API will be available at <http://localhost:8000>.
+
 ## Setting up the Web UI
 
 Install Node dependencies and run the frontend tests inside `battle-hexes-web`:

--- a/battle_hexes_api/Dockerfile
+++ b/battle_hexes_api/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.11-slim
+
+# Dockerfile for the battle_hexes_api service
+
+# Set up work directory
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY battle_hexes_core ./battle_hexes_core
+COPY battle_agent_rl ./battle_agent_rl
+COPY battle_hexes_api ./battle_hexes_api
+
+# Make source packages importable
+ENV PYTHONPATH=/app/battle_hexes_core/src:/app/battle_agent_rl/src:/app/battle_hexes_api/src
+
+# Expose API port
+WORKDIR /app/battle_hexes_api
+EXPOSE 8000
+
+# Start the API using Uvicorn
+CMD ["uvicorn", "battle_hexes_api.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- Dockerize API with a Dockerfile and .dockerignore
- Document Docker build and run instructions
- Move Dockerfile into API project for clarity

## Testing
- `./server-side-checks.sh`
- `docker build -f battle_hexes_api/Dockerfile -t battle-hexes-api .` *(fails: Cannot connect to the Docker daemon)*
- `docker run -p 8000:8000 battle-hexes-api` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6893fc7ddd6883278f9eb8ed1e2b8140