### PR TITLE
feat(api): add health check endpoint

### DIFF
--- a/battle_hexes_api/README.md
+++ b/battle_hexes_api/README.md
@@ -2,6 +2,9 @@
 
 Server-side functions for Battle Hexes.
 
+The API exposes a simple health check at `GET /health` for use with load
+balancers and uptime monitoring.
+
 ## Local Set-up
 
 Create a virtual environment.

--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -21,6 +21,14 @@ from battle_hexes_core.game.sparseboard import SparseBoard  # noqa: E402
 from battle_hexes_api.samplegame import SampleGameCreator  # noqa: E402
 
 app = FastAPI()
+
+
+@app.get("/health")
+def health():
+    """Health check endpoint used by load balancers."""
+    return {"status": "ok"}
+
+
 game_repo = GameRepository()
 
 app.add_middleware(

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -12,6 +12,11 @@ class TestFastAPI(unittest.TestCase):
     def setUp(self):
         self.client = TestClient(app)
 
+    def test_health_check(self):
+        response = self.client.get('/health')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
     def test_create_game(self):
         post_response = self.client.post('/games')
         new_game_id = post_response.json().get('id')


### PR DESCRIPTION
## Summary
- add `/health` endpoint for AWS load balancer checks
- cover health check with a unit test
- mention the endpoint in API documentation

## Testing
- `./server-side-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6897cac6fa8c83279c85d8aa4ef9d7c5