### PR TITLE
feat(web): add custom domain support

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -34,15 +34,26 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Deploy infrastructure
+        env:
+          BUCKET_NAME: ${{ secrets.WEB_BUCKET_NAME }}
+          ACM_CERT_ARN: ${{ secrets.ACM_CERT_ARN }}
+          HOSTED_ZONE_ID: ${{ secrets.HOSTED_ZONE_ID }}
+          WEB_DOMAIN_NAME: ${{ secrets.WEB_DOMAIN_NAME }}
         run: |
           aws cloudformation deploy \
             --stack-name battle-hexes-web \
             --template-file battle-hexes-web/cloudformation-template.yml \
-            --parameter-overrides BucketName=${{ secrets.WEB_BUCKET_NAME }} \
+            --parameter-overrides \
+              BucketName=$BUCKET_NAME \
+              AcmCertificateArn=$ACM_CERT_ARN \
+              HostedZoneId=$HOSTED_ZONE_ID \
+              WebDomainName=$WEB_DOMAIN_NAME \
             --no-fail-on-empty-changeset
 
       - name: Sync build artifacts
-        run: aws s3 sync battle-hexes-web/dist s3://${{ secrets.WEB_BUCKET_NAME }}
+        env:
+          BUCKET_NAME: ${{ secrets.WEB_BUCKET_NAME }}
+        run: aws s3 sync battle-hexes-web/dist s3://$BUCKET_NAME
 
       - name: Show stack outputs
         run: |

--- a/battle-hexes-web/README.md
+++ b/battle-hexes-web/README.md
@@ -29,3 +29,28 @@ The web frontend now includes simple browser-based tests using Playwright.
 
     npm run test-and-build
 
+## Deployment
+
+The `cloudformation-template.yml` provisions an S3 bucket, CloudFront
+distribution, and Route 53 record for a custom domain. You will need:
+
+- `BucketName` – S3 bucket for static assets
+- `AcmCertificateArn` – ACM certificate ARN in `us-east-1`
+- `HostedZoneId` – Route 53 hosted zone ID for `battlehexes.com`
+- `WebDomainName` – (optional) fully qualified domain name, defaults to
+  `dev.battlehexes.com`
+
+Deploy using AWS CLI:
+
+```
+aws cloudformation deploy \
+  --template-file cloudformation-template.yml \
+  --stack-name battle-hexes-web \
+  --parameter-overrides BucketName=YOUR_BUCKET \
+    AcmCertificateArn=YOUR_CERT_ARN HostedZoneId=YOUR_ZONE_ID \
+    WebDomainName=dev.battlehexes.com
+```
+
+After the stack completes, the site will be served from your specified
+domain using HTTPS.
+

--- a/battle-hexes-web/cloudformation-template.yml
+++ b/battle-hexes-web/cloudformation-template.yml
@@ -4,6 +4,16 @@ Parameters:
   BucketName:
     Type: String
     Description: Name of the S3 bucket to host the website
+  AcmCertificateArn:
+    Type: String
+    Description: ACM certificate ARN in us-east-1 for the web domain
+  HostedZoneId:
+    Type: String
+    Description: Public hosted zone ID for battlehexes.com
+  WebDomainName:
+    Type: String
+    Default: dev.battlehexes.com
+    Description: Public DNS name for this environment
 Resources:
   WebsiteBucket:
     Type: AWS::S3::Bucket
@@ -36,6 +46,8 @@ Resources:
       DistributionConfig:
         Enabled: true
         DefaultRootObject: index.html
+        Aliases:
+          - !Ref WebDomainName
         Origins:
           - Id: WebsiteOrigin
             DomainName: !Sub "${WebsiteBucket}.s3-website-${AWS::Region}.amazonaws.com"
@@ -54,6 +66,21 @@ Resources:
             Cookies:
               Forward: none
         PriceClass: PriceClass_100  # Cheapest CDN tier
+        ViewerCertificate:
+          AcmCertificateArn: !Ref AcmCertificateArn
+          SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2021
+
+  WebsiteAliasRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Ref WebDomainName
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt WebsiteDistribution.DomainName
+        HostedZoneId: !GetAtt WebsiteDistribution.HostedZoneId
+        EvaluateTargetHealth: false
 Outputs:
   BucketName:
     Description: Name of the website bucket
@@ -64,3 +91,6 @@ Outputs:
   CloudFrontURL:
     Description: "CloudFront distribution URL"
     Value: !Sub "https://${WebsiteDistribution.DomainName}"
+  WebUrl:
+    Description: Public URL for the website
+    Value: !Sub "https://${WebDomainName}"


### PR DESCRIPTION
## Summary
- allow CloudFront to serve dev.battlehexes.com via ACM certificate
- document deployment parameters for the web stack
- derive CloudFront hosted zone dynamically and pass domain parameters in CI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a26f3c56f0832791e0e2ce3fee10d5