### PR TITLE
Add environment-specific API builds for web frontend

### DIFF
--- a/battle-hexes-web/README.md
+++ b/battle-hexes-web/README.md
@@ -23,7 +23,13 @@ The web frontend now includes simple browser-based tests using Playwright.
 
 ### Building the App
 
+Build for a locally running API:
+
     npm run build
+
+Build for the dev API deployment:
+
+    npm run build:dev
 
 ### Lint, Test, and Build
 

--- a/battle-hexes-web/eslint.config.mjs
+++ b/battle-hexes-web/eslint.config.mjs
@@ -4,6 +4,13 @@ import pluginJs from "@eslint/js";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  {languageOptions: { globals: globals.browser }},
+  {
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        process: "readonly",
+      },
+    },
+  },
   pluginJs.configs.recommended,
 ];

--- a/battle-hexes-web/package.json
+++ b/battle-hexes-web/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "lint": "eslint src/",
     "test": "jest",
-    "build": "webpack",
+    "build": "webpack --env API_URL=http://localhost:8000",
+    "build:dev": "webpack --env API_URL=https://dev-api.battlehexes.com",
     "test-and-build": "npm run lint && npm test && npm run build",
     "test:e2e": "npm run build && playwright test"
   },

--- a/battle-hexes-web/src/model/battle-api.js
+++ b/battle-hexes-web/src/model/battle-api.js
@@ -1,1 +1,1 @@
-export const API_URL = 'http://localhost:8000';
+export const API_URL = process.env.API_URL || 'http://localhost:8000';

--- a/battle-hexes-web/webpack.config.js
+++ b/battle-hexes-web/webpack.config.js
@@ -1,7 +1,8 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 
-module.exports = {
+module.exports = (env = {}) => ({
   mode: 'development',
   entry: './src/battle-draw.js',
   output: {
@@ -15,11 +16,14 @@ module.exports = {
         use: ['style-loader', 'css-loader'],
       },
     ],
-  },  
+  },
   plugins: [
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, 'src/index.html'), // Path to your HTML file
       filename: 'index.html', // The name of the output file in the dist folder
     }),
+    new webpack.DefinePlugin({
+      'process.env.API_URL': JSON.stringify(env.API_URL || 'http://localhost:8000'),
+    }),
   ],
-};
+});


### PR DESCRIPTION
## Summary
- Configure frontend API base URL via `API_URL` env
- Provide `build` and `build:dev` scripts for localhost and dev API
- Document usage of new build scripts

## Testing
- `npm test`
- `npm run build`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_68a28e25f52c832790ed81a6c8784a6b