### PR TITLE
feat(web): hash static assets and set cache headers

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -52,7 +52,13 @@ jobs:
       - name: Sync build artifacts
         env:
           BUCKET_NAME: ${{ secrets.WEB_BUCKET_NAME }}
-        run: aws s3 sync battle-hexes-web/dist s3://$BUCKET_NAME
+        run: |
+          aws s3 sync battle-hexes-web/dist s3://$BUCKET_NAME \
+            --exclude "index.html" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --delete
+          aws s3 cp battle-hexes-web/dist/index.html s3://$BUCKET_NAME/index.html \
+            --cache-control "no-cache, max-age=0, must-revalidate"
 
       - name: Show stack outputs
         run: |

--- a/battle-hexes-web/cloudformation-template.yml
+++ b/battle-hexes-web/cloudformation-template.yml
@@ -69,6 +69,23 @@ Resources:
             QueryString: false
             Cookies:
               Forward: none
+          DefaultTTL: 0
+          MinTTL: 0
+          MaxTTL: 31536000
+        CacheBehaviors:
+          - PathPattern: 'index.html'
+            TargetOriginId: WebsiteOrigin
+            ViewerProtocolPolicy: redirect-to-https
+            AllowedMethods: [GET, HEAD]
+            CachedMethods: [GET, HEAD]
+            Compress: true
+            ForwardedValues:
+              QueryString: false
+              Cookies:
+                Forward: none
+            DefaultTTL: 0
+            MinTTL: 0
+            MaxTTL: 0
         PriceClass: PriceClass_100  # Cheapest CDN tier
         ViewerCertificate:
           AcmCertificateArn: !Ref AcmCertificateArn

--- a/battle-hexes-web/webpack.config.js
+++ b/battle-hexes-web/webpack.config.js
@@ -6,8 +6,9 @@ module.exports = (env = {}) => ({
   mode: 'development',
   entry: './src/battle-draw.js',
   output: {
-    filename: 'main.js',
+    filename: 'main.[contenthash:8].js',
     path: path.resolve(__dirname, 'dist'),
+    clean: true,
   },
   module: {
     rules: [


### PR DESCRIPTION
## Summary
- add content-hashed output and clean dist directory in webpack
- deploy scripts upload assets with long-lived cache-control and no-cache index.html
- configure CloudFront to disable caching for index.html while allowing long TTL for other assets

## Testing
- `npm test`
- `./server-side-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a46c409c1c8327b310bfe5e8503d28