### PR TITLE
Enable ARM64 and Fargate Spot support for API deployment

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -25,15 +25,20 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build, tag, and push Docker image to ECR
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push multi-arch Docker image to ECR
         env:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
           IMAGE_TAG: latest
         run: |
-          docker build -f battle_hexes_api/Dockerfile -t $ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -f battle_hexes_api/Dockerfile \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            --push .
 
   deploy-cloudformation:
     name: Deploy CloudFormation Stack

--- a/battle_hexes_api/ecs-backend.yml
+++ b/battle_hexes_api/ecs-backend.yml
@@ -26,6 +26,9 @@ Resources:
     Type: AWS::ECS::Cluster
     Properties:
       ClusterName: battle-hexes-dev-cluster
+      CapacityProviders:
+        - FARGATE
+        - FARGATE_SPOT
 
   TaskExecutionRole:
     Type: AWS::IAM::Role
@@ -126,6 +129,9 @@ Resources:
       Memory: 512
       NetworkMode: awsvpc
       ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      RuntimePlatform:
+        CpuArchitecture: ARM64
+        OperatingSystemFamily: LINUX
       ContainerDefinitions:
         - Name: battle-hexes-api
           Image: !Ref EcrImage
@@ -138,7 +144,11 @@ Resources:
     Properties:
       Cluster: !Ref BattleHexesCluster
       DesiredCount: 1
-      LaunchType: FARGATE
+      CapacityProviderStrategy:
+        - CapacityProvider: FARGATE_SPOT
+          Weight: 2
+        - CapacityProvider: FARGATE
+          Weight: 1
       HealthCheckGracePeriodSeconds: 60
       LoadBalancers:
         - ContainerName: battle-hexes-api
@@ -151,6 +161,16 @@ Resources:
           SecurityGroups:
             - !Ref BattleHexesSecurityGroup
       TaskDefinition: !Ref BattleHexesTaskDefinition
+
+  BattleHexesServiceAutoScalingTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    DependsOn: BattleHexesService
+    Properties:
+      MinCapacity: 0
+      MaxCapacity: 2
+      ResourceId: !Sub "service/${BattleHexesCluster}/${BattleHexesService}"
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
 
   ApiAliasRecord:
     Type: AWS::Route53::RecordSet


### PR DESCRIPTION
## Summary
- allow ECS cluster to use FARGATE and FARGATE_SPOT with a strategy preferring spot capacity
- run task definition on ARM64 Linux and add auto scaling target for 0-2 tasks
- build and push multi-arch Docker images via Buildx in api-deploy workflow

## Testing
- `./server-side-checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8ea7441488327abbc58c8152d5f4e