### PR TITLE
Enable continuation of multi-unit Q-learning training

### DIFF
--- a/battle_agent_rl/src/battle_agent_rl/qmultiunittrainer.py
+++ b/battle_agent_rl/src/battle_agent_rl/qmultiunittrainer.py
@@ -1,9 +1,10 @@
 """Train a multi-unit Q-learning agent against a random opponent."""
 
 import argparse
+import logging
 import random
 import uuid
-import logging
+from pathlib import Path
 from typing import List
 
 from battle_agent_rl.multiunitqlearn import MulitUnitQLearnPlayer
@@ -96,6 +97,15 @@ def main(episodes: int = 5, max_turns: int = 5) -> None:
     """Train the MultiUnit Q-learning player."""
     random_player, rl_player, units = build_players()
 
+    q_table_path = Path("q_multiunit_table.pkl")
+    if q_table_path.exists():
+        rl_player.load_q_table(str(q_table_path))
+        logger.info("Loaded existing Q-table from %s", q_table_path)
+    else:
+        logger.info(
+            "No existing Q-table found at %s, starting fresh", q_table_path
+        )
+
     game_factory = GameFactory(
         board_size=(16, 16),
         players=[random_player, rl_player],
@@ -106,7 +116,7 @@ def main(episodes: int = 5, max_turns: int = 5) -> None:
     agent_trainer = AgentTrainer(game_factory, episodes, max_turns=max_turns)
     agent_trainer.train()
     # rl_player.print_q_table()
-    rl_player.save_q_table("q_multiunit_table.pkl")
+    rl_player.save_q_table(str(q_table_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Load existing `q_multiunit_table.pkl` before training and log whether it's reused or newly created

## Testing
- `pip install --break-system-packages -r requirements.txt -r requirements-test.txt`
- `./server-side-checks.sh`
- `flake8 battle_agent_rl/src/battle_agent_rl/qmultiunittrainer.py`


------
https://chatgpt.com/codex/tasks/task_e_68b62a1f9e9c8327a911e90a5cda0b82