### PR TITLE
Use SampleGame scenario for multi-unit training

### DIFF
--- a/battle_agent_rl/src/battle_agent_rl/qmultiunittrainer.py
+++ b/battle_agent_rl/src/battle_agent_rl/qmultiunittrainer.py
@@ -1,9 +1,9 @@
-"""Train a multi-unit Q-learning agent against a random opponent."""
+"""Train a multi-unit Q-learning agent on the SampleGame scenario."""
 
 import argparse
 import logging
-import random
 import uuid
+from uuid import UUID
 from pathlib import Path
 from typing import List
 
@@ -20,77 +20,73 @@ from battle_hexes_core.unit.unit import Unit
 logger = logging.getLogger(__name__)
 
 
-# (attack, defense, movement) with weights for selection
-_UNIT_STATS = [
-    ((1, 1, 6), 10),
-    ((2, 2, 4), 10),
-    ((2, 2, 6), 30),  # second most common
-    ((4, 4, 4), 50),  # most common
-    ((5, 4, 4), 2),   # rare
-]
-
-
-def _random_stats() -> tuple[int, int, int]:
-    """Return a random (attack, defense, move) tuple."""
-    stats, weights = zip(*_UNIT_STATS)
-    attack, defense, move = random.choices(stats, weights=weights, k=1)[0]
-    return attack, defense, move
-
-
-def _generate_units(
-    player: RandomPlayer | MulitUnitQLearnPlayer, count: int, name_prefix: str
-) -> List[Unit]:
-    """Create ``count`` units for ``player`` with random stats."""
-    units: List[Unit] = []
-    for i in range(count):
-        attack, defense, move = _random_stats()
-        unit = Unit(
-            id=uuid.uuid4(),
-            name=f"{name_prefix} Unit {i + 1}",
-            faction=player.factions[0],
-            player=player,
-            type="Infantry",
-            attack=attack,
-            defense=defense,
-            move=move,
-            row=0,
-            column=0,
-        )
-        units.append(unit)
-    return units
-
-
 def build_players() -> tuple[RandomPlayer, MulitUnitQLearnPlayer, List[Unit]]:
-    """Create players and a random distribution of starting units."""
-    random_player_factions = [
-        Faction(id=uuid.uuid4(), name="Random Faction", color="red")
-    ]
-    rl_player_factions = [
-        Faction(id=uuid.uuid4(), name="RL Faction", color="blue")
-    ]
+    """Create players and units matching ``SampleGameCreator``."""
+    red_faction = Faction(
+        id=UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479", version=4),
+        name="Red Faction",
+        color="#C81010",
+    )
+
+    blue_faction = Faction(
+        id=UUID("38400000-8cf0-11bd-b23e-10b96e4ef00d", version=4),
+        name="Blue Faction",
+        color="#4682B4",
+    )
 
     random_player = RandomPlayer(
-        name="Random Player",
+        name="Player 1",
         type=PlayerType.CPU,
-        factions=random_player_factions,
-        board=None,  # Board will be set later
+        factions=[red_faction],
+        board=None,
     )
 
     rl_player = MulitUnitQLearnPlayer(
-        name="MultiUnit Q Player",
+        name="Player 2",
         type=PlayerType.CPU,
-        factions=rl_player_factions,
-        board=None,  # Board will be set later
+        factions=[blue_faction],
+        board=None,
     )
 
-    total_units = random.randint(2, 5)
-    random_count = random.randint(1, total_units - 1)
-    rl_count = total_units - random_count
+    red_unit = Unit(
+        UUID("a22c90d0-db87-11d0-8c3a-00c04fd708be", version=4),
+        "Red Unit",
+        red_faction,
+        random_player,
+        "Infantry",
+        2,
+        2,
+        6,
+    )
+    red_unit.set_coords(2, 2)
 
-    random_units = _generate_units(random_player, random_count, "Random")
-    rl_units = _generate_units(rl_player, rl_count, "RL")
+    blue_unit = Unit(
+        UUID("c9a440d2-2b0a-4730-b4c6-da394b642c61", version=4),
+        "Blue Unit",
+        blue_faction,
+        rl_player,
+        "Infantry",
+        4,
+        4,
+        4,
+    )
+    blue_unit.set_coords(8, 9)
 
-    return random_player, rl_player, random_units + rl_units
+    blue_two = Unit(
+        uuid.uuid4(),
+        "Blue Two",
+        blue_faction,
+        rl_player,
+        "Scout",
+        2,
+        2,
+        6,
+    )
+    blue_two.set_coords(9, 5)
+
+    units = [red_unit, blue_unit, blue_two]
+
+    return random_player, rl_player, units
 
 
 def main(episodes: int = 5, max_turns: int = 5) -> None:
@@ -110,7 +106,6 @@ def main(episodes: int = 5, max_turns: int = 5) -> None:
         board_size=(10, 10),
         players=[random_player, rl_player],
         units=units,
-        randomize_positions=True,
     )
 
     agent_trainer = AgentTrainer(game_factory, episodes, max_turns=max_turns)
@@ -123,7 +118,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=(
             "Train the multi-unit Q-learning player "
-            "against a random opponent"
+            "against a random opponent in the SampleGame scenario"
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- Align multi-unit Q-learning trainer with SampleGame: fixed factions, players, and units
- Remove random unit generation and position randomization

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `./server-side-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b64a69d7308327b95cf71cbf682c96