### PR TITLE
Add auto restart option to frontend menu

### DIFF
--- a/battle-hexes-web/src/index.html
+++ b/battle-hexes-web/src/index.html
@@ -53,6 +53,7 @@
     <br/>
     <button id="endPhaseBtn"></button>
     <h3 id="gameOverLabel" style="display: none;">Game Over</h3>
+    <label><input type="checkbox" id="autoNewGame"> Start new game automatically</label>
     <button id="newGameBtn" style="display: none;">New Game</button>
   </div>
   <div id="canvas-container"></div>

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -8,6 +8,8 @@ export class Menu {
   #unitMovesLeftDiv;
   #newGameBtn;
   #gameOverLabel;
+  #autoNewGameChk;
+  #autoReloadScheduled = false;
 
   constructor(game) {
     this.#game = game;
@@ -16,8 +18,14 @@ export class Menu {
     this.#unitMovesLeftDiv = document.getElementById('unitMovesLeftDiv');
     this.#newGameBtn = document.getElementById('newGameBtn');
     this.#gameOverLabel = document.getElementById('gameOverLabel');
+    this.#autoNewGameChk = document.getElementById('autoNewGame');
 
     this.#newGameBtn.addEventListener('click', () => location.reload());
+    this.#autoNewGameChk.addEventListener('change', () => {
+      if (this.#game.isGameOver()) {
+        this.#showGameOver();
+      }
+    });
 
     this.#initPhasesInMenu();
     this.#initPhaseEndButton();
@@ -160,7 +168,15 @@ export class Menu {
 
   #showGameOver() {
     this.#gameOverLabel.style.display = 'block';
-    this.#newGameBtn.style.display = 'block';
+    if (this.#autoNewGameChk.checked) {
+      this.#newGameBtn.style.display = 'none';
+      if (!this.#autoReloadScheduled) {
+        this.#autoReloadScheduled = true;
+        setTimeout(() => location.reload(), 2000);
+      }
+    } else {
+      this.#newGameBtn.style.display = 'block';
+    }
   }
 
   #hideGameOver() {


### PR DESCRIPTION
## Summary
- add "Start new game automatically" checkbox to menu
- auto reload the page 2 seconds after game over when enabled
- hide New Game button when auto restart is active

## Testing
- `./server-side-checks.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76d3bf5088327a13426be32e204ca