### PR TITLE
Fix combat participant filtering

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/combat/combat.py
+++ b/battle_hexes_core/src/battle_hexes_core/combat/combat.py
@@ -131,9 +131,19 @@ class Combat:
     def find_combat(self) -> list:
         results = []
         units = self.board.get_units()
+        engaged_units = [
+            u for u in units
+            if any(
+                (
+                    u.get_coords() == other.get_coords()
+                    or u.is_adjacent(other)
+                ) and not u.is_friendly(other)
+                for other in units
+            )
+        ]
         visited: set[object] = set()
 
-        for unit in units:
+        for unit in engaged_units:
             if unit in visited:
                 continue
 
@@ -145,7 +155,7 @@ class Combat:
                     continue
                 visited.add(current)
                 component.append(current)
-                for other in units:
+                for other in engaged_units:
                     if other in visited:
                         continue
                     if (

--- a/battle_hexes_core/tests/combat/test_combat.py
+++ b/battle_hexes_core/tests/combat/test_combat.py
@@ -165,13 +165,46 @@ class TestCombat(unittest.TestCase):
         self.board.add_unit(self.red_unit, 6, 4)
         self.board.add_unit(red_unit2, 7, 4)
         self.board.add_unit(self.blue_unit, 6, 5)
-        self.board.add_unit(blue_unit2, 6, 6)
+        self.board.add_unit(blue_unit2, 5, 5)
 
         battles = self.combat.find_combat()
         self.assertEqual(1, len(battles))
         attackers, defenders = battles[0]
         self.assertCountEqual(attackers, [self.red_unit, red_unit2])
         self.assertCountEqual(defenders, [self.blue_unit, blue_unit2])
+
+    def test_find_combat_excludes_units_not_adjacent_to_enemy(self):
+        red_unit2 = Unit(
+            id=uuid.uuid4(),
+            name='Red Unit 2',
+            faction=self.red_faction,
+            player=self.red_player,
+            type='Infantry',
+            attack=3,
+            defense=3,
+            move=4,
+        )
+        blue_unit2 = Unit(
+            id=uuid.uuid4(),
+            name='Blue Unit 2',
+            faction=self.blue_faction,
+            player=self.blue_player,
+            type='Recon',
+            attack=2,
+            defense=2,
+            move=6,
+        )
+
+        self.board.add_unit(self.red_unit, 6, 4)
+        self.board.add_unit(self.blue_unit, 6, 5)
+        self.board.add_unit(red_unit2, 5, 4)
+        self.board.add_unit(blue_unit2, 7, 5)
+
+        battles = self.combat.find_combat()
+        self.assertEqual(1, len(battles))
+        attackers, defenders = battles[0]
+        self.assertCountEqual(attackers, [self.red_unit])
+        self.assertCountEqual(defenders, [self.blue_unit])
 
     def test_a_back_2_from_lower_left_moves_attacker(self):
         self.board.add_unit(self.red_unit, 4, 4)


### PR DESCRIPTION
## Summary
- ensure `Combat.find_combat` only includes units adjacent to an enemy
- add regression test for excluding non-engaged units

## Testing
- `./server-side-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b774ccc9748327af8ecb7cb685005e