### PR TITLE
Use CombatResultData in CombatResults and clean up flake8 warnings

### DIFF
--- a/battle_agent_rl/src/battle_agent_rl/qlearningplayer.py
+++ b/battle_agent_rl/src/battle_agent_rl/qlearningplayer.py
@@ -87,11 +87,11 @@ class QLearningPlayer(RLPlayer):
     ) -> None:
         """
         Initialize a (Q-learning) player.
-        
+
             Args:
             name (str): Human-readable name for the player (used in logs/UI).
             type (PlayerType): What kind of player this is (e.g., HUMAN, AI).
-            factions (List[Faction]): One or more factions this player 
+            factions (List[Faction]): One or more factions this player
             controls.
             board (Board): The game board instance the player will interact
                 with.
@@ -106,7 +106,7 @@ class QLearningPlayer(RLPlayer):
                 action); with probability 1−ε it exploits the best known
                 action. Default: 0.1.
             turn_penalty (float, optional): Per-turn negative reward applied to
-                discourage stalling and incentivize faster resolution. 
+                discourage stalling and incentivize faster resolution.
                 Typically a small positive number that is subtracted each turn.
                 Default: 0.1.
         """
@@ -126,7 +126,7 @@ class QLearningPlayer(RLPlayer):
         """Disable learning for the agent."""
         self._learn = False
         self._alpha = 0.0
-    
+
     def disable_exploration(self) -> None:
         """Disable exploration for the agent."""
         self._explore = False
@@ -275,7 +275,7 @@ class QLearningPlayer(RLPlayer):
     ) -> None:
         if not self._learn:
             return
-        
+
         next_q_values = [
             self._q_table.get((next_state, a), 0.0) for a in next_actions
         ]

--- a/battle_agent_rl/src/battle_agent_rl/rltester.py
+++ b/battle_agent_rl/src/battle_agent_rl/rltester.py
@@ -118,7 +118,7 @@ def main(episodes: int = 5, max_turns: int = 5) -> None:
     exchanges = game_results.count_exchanges()
     total = wins + losses + draws + exchanges
     pct = (lambda c: (c / total * 100) if total else 0.0)
-    # numeric percentage values (used for score calculation) and formatted strings
+    # numeric percentage values and formatted strings for score calculation
     wins_pct = pct(wins)
     losses_pct = pct(losses)
     draws_pct = pct(draws)
@@ -133,7 +133,10 @@ def main(episodes: int = 5, max_turns: int = 5) -> None:
     print(f"{'Wins':<9}: {wins:>3} ({pct_strs['Wins']:>{pct_width}})")
     print(f"{'Losses':<9}: {losses:>3} ({pct_strs['Losses']:>{pct_width}})")
     print(f"{'Draws':<9}: {draws:>3} ({pct_strs['Draws']:>{pct_width}})")
-    print(f"{'Exchanges':<9}: {exchanges:>3} ({pct_strs['Exchanges']:>{pct_width}})")
+    print(
+        f"{'Exchanges':<9}: {exchanges:>3} "
+        f"({pct_strs['Exchanges']:>{pct_width}})"
+    )
 
     # score based on percentage points:
     # +2 points per win percentage point, -2 per loss percentage point,

--- a/battle_hexes_core/src/battle_hexes_core/combat/combatresults.py
+++ b/battle_hexes_core/src/battle_hexes_core/combat/combatresults.py
@@ -1,24 +1,26 @@
 from typing import List
-from battle_hexes_core.combat.combatresult import CombatResult
+from battle_hexes_core.combat.combatresult import CombatResultData
 
 
 class CombatResults:
-    def __init__(self):
-        self.battles: List[CombatResult] = []
+    def __init__(self) -> None:
+        self.battles: List[CombatResultData] = []
 
-    def add_battle(self, battle: CombatResult) -> None:
+    def add_battle(self, battle: CombatResultData) -> None:
         self.battles.append(battle)
 
-    def get_battles(self):
+    def get_battles(self) -> List[CombatResultData]:
         return self.battles
 
     def battles_as_result_schema(self):
         return [battle.to_schema() for battle in self.battles]
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = f'{len(self.battles)} Battles\n'
         for battle in self.battles:
-            s += f'Result: {battle.get_combat_result()}, '
-            s += f'Odds: {battle.get_odds()[0]}:{battle.get_odds()[1]}, '
-            s += f'Roll: {battle.get_die_roll()}'
+            s += (
+                f'Result: {battle.get_combat_result()}, '
+                f'Odds: {battle.get_odds()[0]}:{battle.get_odds()[1]}, '
+                f'Roll: {battle.get_die_roll()}'
+            )
         return s

--- a/battle_hexes_core/src/battle_hexes_core/training/agenttrainer.py
+++ b/battle_hexes_core/src/battle_hexes_core/training/agenttrainer.py
@@ -4,7 +4,6 @@ import logging
 
 from battle_hexes_core.game.gamefactory import GameFactory
 from battle_hexes_core.game.gameplayer import GamePlayer
-from typing import Tuple
 
 
 logger = logging.getLogger(__name__)
@@ -27,24 +26,29 @@ class AgentTrainer:
         for episode in range(self.episodes):
             game = self.gamefactory.create_game()
             logger.info("")
-            logger.info("Starting game %d/%d", episode + 1, self.episodes)
+            logger.info(
+                "Starting game %d/%d", episode + 1, self.episodes
+            )
             GamePlayer(game).play(max_turns=self.max_turns)
             results.add_result(GameResult(self.evaluate_game(game), 1))
         return results
-            
+
     def evaluate_game(self, game) -> GameOutcome:
         if not game.is_game_over():
             return GameOutcome.DRAW
-        
+
         # Gather active units on the board
-        units = [u for u in game.get_board().get_units() if u.get_coords() is not None]
+        units = [
+            u for u in game.get_board().get_units()
+            if u.get_coords() is not None
+        ]
 
         players = game.get_players()
-        player1, player2 = players[0], players[1]
+        player2 = players[1]
 
-        # p1_count = sum(1 for u in units if u.player == player1)
+        # p1_count = sum(1 for u in units if u.player == players[0])
         p2_count = sum(1 for u in units if u.player == player2)
-        
+
         # Game is over: decide outcome from player2's perspective
         # TODO hard-coded unit counts
         if p2_count == 2:
@@ -53,7 +57,7 @@ class AgentTrainer:
             outcome = GameOutcome.LOSS
         else:
             outcome = GameOutcome.EXCHANGE
-        
+
         return outcome
 
 
@@ -90,7 +94,10 @@ class GameResults:
         return len([r for r in self.results if r.outcome == GameOutcome.DRAW])
 
     def count_exchanges(self):
-        return len([r for r in self.results if r.outcome == GameOutcome.EXCHANGE])
+        return len([
+            r for r in self.results
+            if r.outcome == GameOutcome.EXCHANGE
+        ])
 
     def get_avg_turns(self):
         if not self.results:

--- a/battle_hexes_core/tests/combat/test_combatresults.py
+++ b/battle_hexes_core/tests/combat/test_combatresults.py
@@ -1,0 +1,12 @@
+from battle_hexes_core.combat.combatresult import (
+    CombatResult,
+    CombatResultData,
+)
+from battle_hexes_core.combat.combatresults import CombatResults
+
+
+def test_combat_results_stores_data() -> None:
+    results = CombatResults()
+    data = CombatResultData((1, 1), 2, CombatResult.DEFENDER_ELIMINATED)
+    results.add_battle(data)
+    assert results.get_battles() == [data]


### PR DESCRIPTION
## Summary
- store `CombatResultData` objects inside `CombatResults`
- add unit test for `CombatResults`
- fix flake8 warnings in RL and training modules

## Testing
- `./server-side-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8baa2940c83279029f59c3e14699e