### PR TITLE
Compute ally ETA to unit's enemy

### DIFF
--- a/battle_agent_rl/tests/test_multiunitqlearnplayer.py
+++ b/battle_agent_rl/tests/test_multiunitqlearnplayer.py
@@ -46,7 +46,7 @@ class TestMultiUnitQLearnPlayer(unittest.TestCase):
             "Inf",
             2,
             2,
-            3,
+            1,
         )
         self.enemy = Unit(
             uuid.uuid4(),
@@ -80,7 +80,7 @@ class TestMultiUnitQLearnPlayer(unittest.TestCase):
             self.enemy.get_strength(),
             0,  # eta to enemy (distance 1, move 3)
             self.friend2.get_strength(),
-            0,  # eta to friend (distance 2, move 3)
+            2,  # eta from friend to enemy (distance 3, move 1)
             1,
         )
         self.assertEqual(state, expected)
@@ -93,7 +93,7 @@ class TestMultiUnitQLearnPlayer(unittest.TestCase):
             0,
             0,
             self.friend2.get_strength(),
-            0,  # eta to friend
+            0,  # eta from friend to enemy (no enemy)
             1,
         )
         self.assertEqual(state, expected)


### PR DESCRIPTION
## Summary
- calculate ally ETA using distance to the unit's nearest enemy and the ally's own movement
- adjust unit-state encoding tests to validate new ally ETA logic

## Testing
- `./server-side-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b98652e40c8327810e4014a56f6eec