### PR TITLE
Implement pair state encoding for QLearningPlayer

### DIFF
--- a/battle_agent_rl/tests/test_qlearningplayer.py
+++ b/battle_agent_rl/tests/test_qlearningplayer.py
@@ -267,6 +267,101 @@ class TestQLearningPlayerMovePlan(unittest.TestCase):
         self.assertEqual(self.player._distance_to_eta_bin(20, move), 3)
 
 
+class TestQLearningPlayerEncodePairState(unittest.TestCase):
+    def setUp(self):
+        self.board = Board(5, 5)
+        self.friendly_faction = Faction(
+            id=uuid.uuid4(), name="Friendly", color="red"
+        )
+        self.enemy_faction = Faction(
+            id=uuid.uuid4(), name="Enemy", color="blue"
+        )
+        self.player = QLearningPlayer(
+            name="AI",
+            type=PlayerType.CPU,
+            factions=[self.friendly_faction],
+            board=self.board,
+            turn_penalty=0,
+        )
+        self.enemy_player = Player(
+            name="Opponent",
+            type=PlayerType.CPU,
+            factions=[self.enemy_faction],
+        )
+
+    def test_eta_and_power_bins(self):
+        ui = Unit(
+            uuid.uuid4(),
+            "U1",
+            self.friendly_faction,
+            self.player,
+            "Inf",
+            3,
+            3,
+            3,
+        )
+        uj = Unit(
+            uuid.uuid4(),
+            "U2",
+            self.friendly_faction,
+            self.player,
+            "Inf",
+            3,
+            3,
+            1,
+        )
+        enemy = Unit(
+            uuid.uuid4(),
+            "E1",
+            self.enemy_faction,
+            self.enemy_player,
+            "Inf",
+            4,
+            4,
+            3,
+        )
+        self.board.add_unit(ui, 0, 0)
+        self.board.add_unit(uj, 0, 2)
+        self.board.add_unit(enemy, 3, 0)
+        self.assertEqual(self.player._encode_pair_state(ui, uj), (2, 1))
+
+    def test_negative_bins(self):
+        ui = Unit(
+            uuid.uuid4(),
+            "U1",
+            self.friendly_faction,
+            self.player,
+            "Inf",
+            2,
+            2,
+            1,
+        )
+        uj = Unit(
+            uuid.uuid4(),
+            "U2",
+            self.friendly_faction,
+            self.player,
+            "Inf",
+            1,
+            1,
+            3,
+        )
+        enemy = Unit(
+            uuid.uuid4(),
+            "E1",
+            self.enemy_faction,
+            self.enemy_player,
+            "Inf",
+            6,
+            6,
+            3,
+        )
+        self.board.add_unit(ui, 0, 0)
+        self.board.add_unit(uj, 0, 2)
+        self.board.add_unit(enemy, 3, 0)
+        self.assertEqual(self.player._encode_pair_state(ui, uj), (-1, -1))
+
+
 class TestQLearningPlayerSaveLoad(unittest.TestCase):
     def setUp(self):
         self.board = Board(1, 1)


### PR DESCRIPTION
## Summary
- Implement `_encode_pair_state` to compute ETA and power differences between allied units relative to nearest enemy
- Add unit tests covering positive and negative binning scenarios

## Testing
- `flake8 battle_agent_rl/src/battle_agent_rl/qlearningplayer.py`
- `flake8 battle_agent_rl/tests/test_qlearningplayer.py`
- `./server-side-checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0d332da5c8327af6f39a8c42aab09