### PR TITLE
Sort Q-learning table logging by value

### DIFF
--- a/battle_agent_rl/src/battle_agent_rl/qlearningplayer.py
+++ b/battle_agent_rl/src/battle_agent_rl/qlearningplayer.py
@@ -701,11 +701,15 @@ class QLearningPlayer(RLPlayer):
             logger.log(level, f"    {unit_id}={pair}")
 
         logger.log(level, "  Q1 table [(s_i, a_i), q_value]")
-        for (state, action), q_value in self._q1.items():
+        for (state, action), q_value in sorted(
+            self._q1.items(), key=lambda item: item[1], reverse=True
+        ):
             logger.log(level, f"    ({state}, {action}) = {q_value:.4f}")
 
         logger.log(level, "  Q2 table [(s_ij, a_i, a_j), q_value]")
-        for (state, action_i, action_j), q_value in self._q2.items():
+        for (state, action_i, action_j), q_value in sorted(
+            self._q2.items(), key=lambda item: item[1], reverse=True
+        ):
             logger.log(
                 level,
                 f"    ({state}, {action_i}, {action_j}) = {q_value:.4f}"


### PR DESCRIPTION
## Summary
- log Q1 and Q2 table entries sorted by their Q-values in descending order

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68cdb485b86c8327b372644d3add9658