### PR TITLE
Restrict RL combat rewards to battle participants

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/combat/combat.py
+++ b/battle_hexes_core/src/battle_hexes_core/combat/combat.py
@@ -42,6 +42,7 @@ class Combat:
             attack_factor,
             defense_factor
         )
+        combat_result.set_participants(attackers, defenders)
         self.__update_board_for_result((attackers, defenders), combat_result)
         return combat_result
 

--- a/battle_hexes_core/src/battle_hexes_core/combat/combatresult.py
+++ b/battle_hexes_core/src/battle_hexes_core/combat/combatresult.py
@@ -1,6 +1,13 @@
 from enum import Enum
-from typing import Tuple
+from typing import Iterable, Optional, Tuple, TYPE_CHECKING
+
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from battle_hexes_core.unit.unit import Unit
+
+
+BattleParticipants = Tuple[Tuple['Unit', ...], Tuple['Unit', ...]]
 
 
 class CombatResult(Enum):
@@ -13,13 +20,21 @@ class CombatResult(Enum):
 
 class CombatResultData:
     def __init__(
-            self,
-            odds: tuple,
-            die_roll: int,
-            combat_result: CombatResult):
+        self,
+        odds: tuple,
+        die_roll: int,
+        combat_result: CombatResult,
+        participants: Optional[
+            Tuple[Iterable['Unit'], Iterable['Unit']]
+        ] = None,
+    ):
         self.odds = odds
         self.die_roll = die_roll
         self.combat_result = combat_result
+        self._participants: Optional[BattleParticipants] = None
+        if participants is not None:
+            attackers, defenders = participants
+            self.set_participants(attackers, defenders)
 
     def get_odds(self) -> tuple:
         return self.odds
@@ -29,6 +44,16 @@ class CombatResultData:
 
     def get_combat_result(self) -> CombatResult:
         return self.combat_result
+
+    def set_participants(
+        self,
+        attackers: Iterable['Unit'],
+        defenders: Iterable['Unit'],
+    ) -> None:
+        self._participants = (tuple(attackers), tuple(defenders))
+
+    def get_participants(self) -> Optional[BattleParticipants]:
+        return self._participants
 
     def to_schema(self):
         return CombatResultSchema(

--- a/battle_hexes_core/tests/combat/test_combat.py
+++ b/battle_hexes_core/tests/combat/test_combat.py
@@ -99,6 +99,19 @@ class TestCombat(unittest.TestCase):
             combat_result.get_combat_result()
         )
 
+    def test_combat_result_includes_participants(self):
+        self.board.add_unit(self.red_unit, 6, 4)
+        self.board.add_unit(self.blue_unit, 6, 5)
+        self.combat.set_static_die_roll(6)
+
+        combat_result = self.combat.resolve_combat().get_battles()[0]
+
+        participants = combat_result.get_participants()
+        self.assertIsNotNone(participants)
+        attackers, defenders = participants
+        self.assertCountEqual(attackers, [self.red_unit])
+        self.assertCountEqual(defenders, [self.blue_unit])
+
     def test_board_defender_elim_leaves_one_unit_on_the_board(self):
         self.board.add_unit(self.red_unit, 6, 4)
         self.board.add_unit(self.blue_unit, 5, 5)

--- a/battle_hexes_core/tests/combat/test_combatresults.py
+++ b/battle_hexes_core/tests/combat/test_combatresults.py
@@ -1,8 +1,13 @@
+import uuid
+
 from battle_hexes_core.combat.combatresult import (
     CombatResult,
     CombatResultData,
 )
 from battle_hexes_core.combat.combatresults import CombatResults
+from battle_hexes_core.game.player import Player, PlayerType
+from battle_hexes_core.unit.faction import Faction
+from battle_hexes_core.unit.unit import Unit
 
 
 def test_combat_results_stores_data() -> None:
@@ -10,3 +15,41 @@ def test_combat_results_stores_data() -> None:
     data = CombatResultData((1, 1), 2, CombatResult.DEFENDER_ELIMINATED)
     results.add_battle(data)
     assert results.get_battles() == [data]
+
+
+def test_combat_result_data_tracks_participants() -> None:
+    faction = Faction(id=uuid.uuid4(), name="Faction", color="red")
+    player = Player(name="Player", type=PlayerType.CPU, factions=[faction])
+    attacker = Unit(
+        uuid.uuid4(),
+        "Attacker",
+        faction,
+        player,
+        "Inf",
+        3,
+        2,
+        3,
+    )
+    defender = Unit(
+        uuid.uuid4(),
+        "Defender",
+        faction,
+        player,
+        "Inf",
+        2,
+        3,
+        3,
+    )
+
+    data = CombatResultData(
+        (1, 1),
+        3,
+        CombatResult.DEFENDER_ELIMINATED,
+        participants=((attacker,), (defender,)),
+    )
+
+    participants = data.get_participants()
+    assert participants is not None
+    attackers, defenders = participants
+    assert attackers == (attacker,)
+    assert defenders == (defender,)


### PR DESCRIPTION
## Summary
- add participant tracking to combat results and set participants when resolving combat
- update the Q-learning agent to award combat rewards only to units that fought
- extend core and agent tests to cover combat participants and reward handling

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68cf5a682d6483278b97fd249ef5507d