### PR TITLE
Refactor Q-learning settings loading into reusable helper

### DIFF
--- a/battle_agent_rl/src/battle_agent_rl/qlearningtrainer.py
+++ b/battle_agent_rl/src/battle_agent_rl/qlearningtrainer.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import List
 
 from battle_agent_rl.qlearningplayer import QLearningPlayer
+from battle_agent_rl.qlsettings_loader import QLearningSettingsLoader
 from battle_hexes_core.game.gamefactory import GameFactory
 from battle_hexes_core.game.randomplayer import RandomPlayer
 from battle_hexes_core.game.player import PlayerType
@@ -41,11 +42,13 @@ def build_players() -> tuple[RandomPlayer, QLearningPlayer, List[Unit]]:
         board=None,
     )
 
+    rl_settings = QLearningSettingsLoader(logger=logger).load()
     rl_player = QLearningPlayer(
         name="Player 2",
         type=PlayerType.CPU,
         factions=[blue_faction],
         board=None,
+        **rl_settings,
     )
 
     red_unit = Unit(

--- a/battle_agent_rl/src/battle_agent_rl/qlsettings_loader.py
+++ b/battle_agent_rl/src/battle_agent_rl/qlsettings_loader.py
@@ -1,0 +1,112 @@
+"""Utility helpers for loading Q-learning configuration."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from battle_agent_rl.qlearningplayer import QLearningPlayer
+
+
+class QLearningSettingsLoader:
+    """Load ``QLearningPlayer`` keyword arguments from an optional JSON file.
+
+    The loader inspects :class:`QLearningPlayer` to discover its configurable
+    keyword arguments and default values. When :meth:`load` is called it reads
+    a ``qlsettings.json`` file (or a custom path), merges any provided values
+    with those defaults, and logs which settings are used. Missing or
+    unrecognized values automatically fall back to the class defaults so the
+    caller always receives a complete, valid configuration dictionary.
+    """
+
+    _IGNORED_PARAMETERS = {"self", "name", "type", "factions", "board"}
+
+    def __init__(
+        self,
+        settings_path: Path | str = Path("qlsettings.json"),
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._settings_path = Path(settings_path)
+        self._logger = logger or logging.getLogger(__name__)
+        self._defaults = self._collect_defaults()
+
+    def load(self) -> Dict[str, Any]:
+        """Return the merged Q-learning settings from disk and defaults."""
+
+        defaults = self.defaults
+        if not self._settings_path.exists():
+            self._logger.info(
+                "No qlsettings.json found at %s; using defaults.",
+                self._settings_path,
+            )
+            self._log_default_settings()
+            return defaults
+
+        try:
+            with self._settings_path.open(encoding="utf-8") as settings_file:
+                raw_settings = json.load(settings_file)
+        except json.JSONDecodeError as exc:
+            self._logger.warning(
+                "Failed to parse qlsettings.json at %s (%s); using defaults.",
+                self._settings_path,
+                exc,
+            )
+            self._log_default_settings()
+            return defaults
+
+        if not isinstance(raw_settings, dict):
+            self._logger.warning(
+                "Expected qlsettings.json at %s to contain an object; "
+                "using defaults.",
+                self._settings_path,
+            )
+            self._log_default_settings()
+            return defaults
+
+        for key, value in raw_settings.items():
+            if key in self._defaults:
+                defaults[key] = value
+            else:
+                self._logger.warning(
+                    "Ignoring unrecognized Q-learning setting '%s'", key
+                )
+
+        missing_keys = sorted(set(self._defaults) - raw_settings.keys())
+        if missing_keys:
+            self._logger.info(
+                "Using default values for missing Q-learning settings: %s",
+                ", ".join(missing_keys),
+            )
+
+        self._logger.info(
+            "Using Q-learning settings from %s: %s",
+            self._settings_path,
+            defaults,
+        )
+        return defaults
+
+    @property
+    def defaults(self) -> Dict[str, Any]:
+        """Return a copy of the default Q-learning keyword arguments."""
+
+        return self._defaults.copy()
+
+    def _collect_defaults(self) -> Dict[str, Any]:
+        defaults: Dict[str, Any] = {}
+        signature = inspect.signature(QLearningPlayer)
+        for name, parameter in signature.parameters.items():
+            if name in self._IGNORED_PARAMETERS:
+                continue
+            if parameter.default is inspect._empty:
+                continue
+            defaults[name] = parameter.default
+        return defaults
+
+    def _log_default_settings(self) -> None:
+        self._logger.info("Using Q-learning settings: %s", self._defaults)
+
+
+__all__ = ["QLearningSettingsLoader"]

--- a/battle_agent_rl/src/battle_agent_rl/rltester.py
+++ b/battle_agent_rl/src/battle_agent_rl/rltester.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import List
 
 from battle_agent_rl.qlearningplayer import QLearningPlayer
+from battle_agent_rl.qlsettings_loader import QLearningSettingsLoader
 from battle_hexes_core.game.gamefactory import GameFactory
 from battle_hexes_core.game.randomplayer import RandomPlayer
 from battle_hexes_core.game.player import PlayerType
@@ -41,11 +42,13 @@ def build_players() -> tuple[RandomPlayer, QLearningPlayer, List[Unit]]:
         board=None,
     )
 
+    rl_settings = QLearningSettingsLoader(logger=logger).load()
     rl_player = QLearningPlayer(
         name="Player 2",
         type=PlayerType.CPU,
         factions=[blue_faction],
         board=None,
+        **rl_settings,
     )
     rl_player.disable_exploration()
     rl_player.disable_learning()

--- a/battle_agent_rl/tests/test_qlsettings_loader.py
+++ b/battle_agent_rl/tests/test_qlsettings_loader.py
@@ -1,0 +1,70 @@
+import json
+import logging
+
+from battle_agent_rl.qlsettings_loader import QLearningSettingsLoader
+
+
+def test_missing_settings_file_returns_defaults_and_logs(tmp_path, caplog):
+    settings_path = tmp_path / "qlsettings.json"
+    loader = QLearningSettingsLoader(settings_path=settings_path)
+
+    caplog.set_level(logging.INFO, logger="battle_agent_rl.qlsettings_loader")
+
+    settings = loader.load()
+
+    assert settings == loader.defaults
+    assert "No qlsettings.json found" in caplog.text
+    assert "Using Q-learning settings:" in caplog.text
+
+
+def test_partial_settings_override_defaults(tmp_path, caplog):
+    settings_path = tmp_path / "qlsettings.json"
+    settings_path.write_text(
+        json.dumps({"alpha": 0.5, "epsilon": 0.02, "unknown": 42}),
+        encoding="utf-8",
+    )
+    loader = QLearningSettingsLoader(settings_path=settings_path)
+
+    caplog.set_level(logging.INFO, logger="battle_agent_rl.qlsettings_loader")
+
+    settings = loader.load()
+    defaults = loader.defaults
+
+    assert settings["alpha"] == 0.5
+    assert settings["epsilon"] == 0.02
+    for key, value in defaults.items():
+        if key not in {"alpha", "epsilon"}:
+            assert settings[key] == value
+
+    assert (
+        "Ignoring unrecognized Q-learning setting 'unknown'" in caplog.text
+    )
+    assert (
+        "Using default values for missing Q-learning settings" in caplog.text
+    )
+
+
+def test_invalid_json_uses_defaults(tmp_path, caplog):
+    settings_path = tmp_path / "qlsettings.json"
+    settings_path.write_text("{invalid", encoding="utf-8")
+    loader = QLearningSettingsLoader(settings_path=settings_path)
+
+    caplog.set_level(logging.INFO, logger="battle_agent_rl.qlsettings_loader")
+
+    settings = loader.load()
+
+    assert settings == loader.defaults
+    assert "Failed to parse qlsettings.json" in caplog.text
+
+
+def test_non_mapping_json_uses_defaults(tmp_path, caplog):
+    settings_path = tmp_path / "qlsettings.json"
+    settings_path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    loader = QLearningSettingsLoader(settings_path=settings_path)
+
+    caplog.set_level(logging.INFO, logger="battle_agent_rl.qlsettings_loader")
+
+    settings = loader.load()
+
+    assert settings == loader.defaults
+    assert "Expected qlsettings.json" in caplog.text


### PR DESCRIPTION
## Summary
- extract the JSON configuration loading logic into a reusable `QLearningSettingsLoader`
- update `qlearningtrainer.py` and `rltester.py` to consume the new helper
- cover the loader with pytest cases for missing, partial, and invalid settings files

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d068804c7c832786c290022196213f