### PR TITLE
Restore q_table when scores drop

### DIFF
--- a/battle_agent_rl/dosometraining.sh
+++ b/battle_agent_rl/dosometraining.sh
@@ -21,22 +21,28 @@ update_best() {
     return
   fi
 
-  is_better=$(awk -v current="$TEST_SCORE" -v best="$BEST_SCORE" '
+  comparison=$(awk -v current="$TEST_SCORE" -v best="$BEST_SCORE" '
     BEGIN {
       if (best == "") {
-        print 1
+        print "better"
       } else if (current > best) {
-        print 1
+        print "better"
+      } else if (current < best) {
+        print "worse"
       } else {
-        print 0
+        print "equal"
       }
     }
   ')
 
-  if [ "$is_better" -eq 1 ]; then
+  if [ "$comparison" = "better" ]; then
     BEST_SCORE="$TEST_SCORE"
     if [ -f "q_table.pkl" ]; then
       cp "q_table.pkl" "$BEST_Q_TABLE"
+    fi
+  elif [ "$comparison" = "worse" ]; then
+    if [ -f "$BEST_Q_TABLE" ]; then
+      cp "$BEST_Q_TABLE" "q_table.pkl"
     fi
   fi
 }


### PR DESCRIPTION
## Summary
- update the training helper to classify score comparisons and persist the best snapshot
- restore `q_table.pkl` from the best snapshot when a test run regresses

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d06fa8520c832795b0f04c332fed32