### PR TITLE
Track eliminated units that failed to retreat

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/combat/combat.py
+++ b/battle_hexes_core/src/battle_hexes_core/combat/combat.py
@@ -65,13 +65,12 @@ class Combat:
                 origin = defenders[0].get_coords()
                 removed = []
                 for attacker in attackers:
-                    attacker.forced_move(origin, 2)
-                    if not self.board.is_in_bounds(
-                            attacker.row, attacker.column
-                    ):
+                    success = attacker.forced_move(self.board, origin, 2)
+                    if not success:
                         removed.append(attacker)
                 if removed:
                     self.board.remove_units(removed)
+                    combat_result.add_no_retreat_units(removed)
                     if len(removed) == len(attackers):
                         combat_result.combat_result = (
                             CombatResult.ATTACKER_ELIMINATED
@@ -82,13 +81,12 @@ class Combat:
                 origin = attackers[0].get_coords()
                 removed = []
                 for defender in defenders:
-                    defender.forced_move(origin, 2)
-                    if not self.board.is_in_bounds(
-                            defender.row, defender.column
-                    ):
+                    success = defender.forced_move(self.board, origin, 2)
+                    if not success:
                         removed.append(defender)
                 if removed:
                     self.board.remove_units(removed)
+                    combat_result.add_no_retreat_units(removed)
                     if len(removed) == len(defenders):
                         combat_result.combat_result = (
                             CombatResult.DEFENDER_ELIMINATED

--- a/battle_hexes_core/src/battle_hexes_core/combat/combatresult.py
+++ b/battle_hexes_core/src/battle_hexes_core/combat/combatresult.py
@@ -26,6 +26,7 @@ class CombatResultData:
                     Sequence['Unit'],
                 ]
             ] = None,
+            no_retreat: Optional[Sequence['Unit']] = None,
     ):
         self.odds = odds
         self.die_roll = die_roll
@@ -33,8 +34,11 @@ class CombatResultData:
         self._battle_participants: Optional[
             Tuple[Tuple['Unit', ...], Tuple['Unit', ...]]
         ] = None
+        self._no_retreat: tuple['Unit', ...] = ()
         if battle_participants is not None:
             self.set_battle_participants(battle_participants)
+        if no_retreat is not None:
+            self.set_no_retreat_units(no_retreat)
 
     def get_odds(self) -> tuple:
         return self.odds
@@ -63,12 +67,28 @@ class CombatResultData:
     ) -> Optional[Tuple[Tuple['Unit', ...], Tuple['Unit', ...]]]:
         return self._battle_participants
 
+    def set_no_retreat_units(self, units: Sequence['Unit']) -> None:
+        self._no_retreat = tuple(units)
+
+    def add_no_retreat_units(self, units: Sequence['Unit']) -> None:
+        combined = list(self._no_retreat)
+        for unit in units:
+            if unit not in combined:
+                combined.append(unit)
+        self._no_retreat = tuple(combined)
+
+    def get_no_retreat_units(self) -> Tuple['Unit', ...]:
+        return self._no_retreat
+
     def to_schema(self):
         return CombatResultSchema(
             combat_result_code=self.combat_result.name,
             combat_result_text=self.combat_result.value,
             odds=self.odds,
-            die_roll=self.die_roll
+            die_roll=self.die_roll,
+            no_retreat_unit_ids=tuple(
+                str(unit.get_id()) for unit in self._no_retreat
+            ),
         )
 
 
@@ -77,3 +97,4 @@ class CombatResultSchema(BaseModel):
     combat_result_text: str
     odds: Tuple[int, int]
     die_roll: int
+    no_retreat_unit_ids: Tuple[str, ...] = ()

--- a/battle_hexes_core/src/battle_hexes_core/game/board.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/board.py
@@ -81,6 +81,13 @@ class Board:
     def get_units(self) -> List[Unit]:
         return list(self.units.values())
 
+    def get_unit_at(self, row: int, column: int) -> Unit | None:
+        """Return the unit occupying ``(row, column)`` if one exists."""
+        for unit in self.units.values():
+            if unit.get_coords() == (row, column):
+                return unit
+        return None
+
     def get_unit_by_id(self, unit_id: UUID) -> Unit:
         if not isinstance(unit_id, UUID):
             unit_id = UUID(unit_id)

--- a/battle_hexes_core/tests/unit/test_unit.py
+++ b/battle_hexes_core/tests/unit/test_unit.py
@@ -1,5 +1,6 @@
 import unittest
 import uuid
+from battle_hexes_core.game.board import Board
 from battle_hexes_core.unit.unit import Unit
 from battle_hexes_core.game.player import Player, PlayerType
 from battle_hexes_core.unit.faction import Faction
@@ -64,3 +65,45 @@ class TestUnit(unittest.TestCase):
 
     def test_is_friendly_different_player(self):
         self.assertFalse(self.unit1.is_friendly(self.unit3))
+
+    def test_forced_move_success(self):
+        board = Board(6, 6)
+        board.add_unit(self.unit1, 2, 2)
+        board.add_unit(self.unit3, 2, 3)
+
+        result = self.unit1.forced_move(board, self.unit3.get_coords(), 2)
+
+        self.assertTrue(result)
+        self.assertEqual((1, 0), self.unit1.get_coords())
+
+    def test_forced_move_blocked_restores_position(self):
+        board = Board(6, 6)
+        board.add_unit(self.unit1, 2, 2)
+
+        enemy = Unit(
+            id=uuid.uuid4(),
+            name="Enemy",
+            player=self.player2,
+            faction=self.faction2,
+            type="Infantry",
+            attack=5,
+            defense=5,
+            move=3,
+        )
+        blocker = Unit(
+            id=uuid.uuid4(),
+            name="Blocker",
+            player=self.player2,
+            faction=self.faction2,
+            type="Infantry",
+            attack=5,
+            defense=5,
+            move=3,
+        )
+        board.add_unit(enemy, 2, 3)
+        board.add_unit(blocker, 1, 0)
+
+        result = self.unit1.forced_move(board, enemy.get_coords(), 2)
+
+        self.assertFalse(result)
+        self.assertEqual((2, 2), self.unit1.get_coords())


### PR DESCRIPTION
## Summary
- extend combat results to record units that could not complete a retreat
- update combat resolution to store failed retreats and avoid unnecessary off-board removal
- cover the new no-retreat tracking with combat tests

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d84ee41eac8327bfd76a1933194d15