### PR TITLE
Expose cube coordinate helper on Board

### DIFF
--- a/battle_hexes_core/tests/game/test_board.py
+++ b/battle_hexes_core/tests/game/test_board.py
@@ -321,6 +321,18 @@ class TestBoard(unittest.TestCase):
         coords = [(h.row, h.column) for h in path]
         self.assertEqual(coords, [(2, 1), (3, 1)])
 
+    def test_path_towards_prefers_shortest_adjacent_path(self):
+        self.board.add_unit(self.red_unit, 0, 0)
+        self.board.add_unit(self.blue_unit, 1, 2)
+
+        enemy_hex = self.board.get_hex(1, 2)
+        path = self.board.path_towards(
+            self.red_unit, enemy_hex, self.red_unit.get_move()
+        )
+        coords = [(h.row, h.column) for h in path]
+
+        self.assertEqual(coords, [(0, 0), (0, 1)])
+
     def test_path_away_from_increases_distance(self):
         self.board.add_unit(self.red_unit, 2, 1)
         self.board.add_unit(self.blue_unit, 0, 1)


### PR DESCRIPTION
## Summary
- add a Board.to_cube_coords class method for converting hexes to cube coordinates
- reuse the helper in hex_distance and path_towards to avoid nested conversions

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d8605805308327a0f0add750de3f34