### PR TITLE
Add landing page and move game entry to battle page

### DIFF
--- a/battle-hexes-web/README.md
+++ b/battle-hexes-web/README.md
@@ -31,6 +31,10 @@ Build for the dev API deployment:
 
     npm run build:dev
 
+After building, open `dist/index.html` to view the title screen. The game board
+is now served from `dist/battle.html`, which you can reach via the "Enter
+Battle" button on the landing page or by navigating directly to the file.
+
 ### Lint, Test, and Build
 
     npm run test-and-build

--- a/battle-hexes-web/e2e/basic.test.js
+++ b/battle-hexes-web/e2e/basic.test.js
@@ -1,11 +1,20 @@
 import { test, expect } from '@playwright/test';
 import path from 'path';
+import { pathToFileURL } from 'url';
 
 const indexPath = path.join(__dirname, '..', 'dist', 'index.html');
+const battlePath = path.join(__dirname, '..', 'dist', 'battle.html');
+const indexUrl = pathToFileURL(indexPath).href;
+const battleUrl = pathToFileURL(battlePath).href;
 
-// Simple smoke test to ensure the game page loads in the browser
-// This test opens the built application and checks for the main menu.
-test('loads Battle Hexes page', async ({ page }) => {
-  await page.goto('file://' + indexPath);
+test('title screen links to the battle page', async ({ page }) => {
+  await page.goto(indexUrl);
+  await expect(page.locator('h1')).toHaveText('Battle Hexes');
+  await page.locator('a:has-text("Enter Battle")').click();
+  await expect(page).toHaveURL(battleUrl);
+});
+
+test('battle page still loads game menu', async ({ page }) => {
+  await page.goto(battleUrl);
   await expect(page.locator('#menu')).toContainText('Battle Hexes');
 });

--- a/battle-hexes-web/src/battle.html
+++ b/battle-hexes-web/src/battle.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Battle Hexes</title>
+  <style>
+    body {
+      background-color: #5A5A5A;
+      font-family: 'Raleway', sans-serif; 
+      margin: 0;
+      display: flex;
+      flex-direction: row-reverse;
+      height: 100vh;
+    }
+
+    #menu {
+      width: 280px;
+      padding: 10px;
+      overflow-y: auto;
+    }
+
+    #menu button {
+      display: block;
+      width: 100%;
+      padding: 10px;
+    }
+
+    #canvas-container {
+      flex-grow: 1;
+      overflow-y: auto;
+    }
+
+    canvas {
+      display: block;
+      margin: 10px;
+    }
+  </style>
+</head>
+<body>
+  <div id="menu" style="background-color: #F8F8F8;">
+    <h2>Battle Hexes</h2>
+    <div id="selHexContents"></div>
+    <div id="selHexCoord"></div>
+    <div id="unitMovesLeftDiv"></div>
+    <div id="gameStagesMenu">
+      <h3>Game Stages</h3>
+      <div id="phasesList">
+        <!-- phases list is created dynamically -->
+      </div>
+      <div>Current turn: <span id="currentTurnLabel"></span></div>
+    </div>
+    <br/>
+    <button id="endPhaseBtn"></button>
+    <h3 id="gameOverLabel" style="display: none;">Game Over</h3>
+    <label><input type="checkbox" id="autoNewGame"> Start new game automatically</label>
+    <button id="newGameBtn" style="display: none;">New Game</button>
+  </div>
+  <div id="canvas-container"></div>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+</body>
+</html>

--- a/battle-hexes-web/src/index.html
+++ b/battle-hexes-web/src/index.html
@@ -5,58 +5,69 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Battle Hexes</title>
   <style>
+    :root {
+      color-scheme: dark light;
+    }
     body {
-      background-color: #5A5A5A;
-      font-family: 'Raleway', sans-serif; 
       margin: 0;
+      min-height: 100vh;
       display: flex;
-      flex-direction: row-reverse;
-      height: 100vh;
+      align-items: center;
+      justify-content: center;
+      background: radial-gradient(circle at top, #1e2636, #111521 70%);
+      font-family: 'Raleway', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: #f4f6fb;
     }
 
-    #menu {
-      width: 280px;
-      padding: 10px;
-      overflow-y: auto;
+    main {
+      text-align: center;
+      padding: 3rem 2rem;
+      background: rgba(12, 18, 32, 0.85);
+      border-radius: 18px;
+      box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+      max-width: 420px;
+      width: calc(100% - 2rem);
     }
 
-    #menu button {
-      display: block;
-      width: 100%;
-      padding: 10px;
+    h1 {
+      font-size: clamp(2rem, 6vw, 3rem);
+      margin-bottom: 1.5rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
     }
 
-    #canvas-container {
-      flex-grow: 1;
-      overflow-y: auto;
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.85rem 2.5rem;
+      font-size: 1rem;
+      font-weight: 600;
+      text-decoration: none;
+      color: #0b1120;
+      background: linear-gradient(135deg, #f7d774, #f0b94d);
+      border-radius: 999px;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
 
-    canvas {
-      display: block;
-      margin: 10px;
+    a:hover,
+    a:focus-visible {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 24px rgba(240, 185, 77, 0.4);
+    }
+
+    p {
+      margin-bottom: 2rem;
+      color: rgba(244, 246, 251, 0.8);
+      font-size: 1rem;
     }
   </style>
 </head>
 <body>
-  <div id="menu" style="background-color: #F8F8F8;">
-    <h2>Battle Hexes</h2>
-    <div id="selHexContents"></div>
-    <div id="selHexCoord"></div>
-    <div id="unitMovesLeftDiv"></div>
-    <div id="gameStagesMenu">
-      <h3>Game Stages</h3>
-      <div id="phasesList">
-        <!-- phases list is created dynamically -->
-      </div>
-      <div>Current turn: <span id="currentTurnLabel"></span></div>
-    </div>
-    <br/>
-    <button id="endPhaseBtn"></button>
-    <h3 id="gameOverLabel" style="display: none;">Game Over</h3>
-    <label><input type="checkbox" id="autoNewGame"> Start new game automatically</label>
-    <button id="newGameBtn" style="display: none;">New Game</button>
-  </div>
-  <div id="canvas-container"></div>
-  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+  <main>
+    <h1>Battle Hexes</h1>
+    <p>The strategy begins here. Enter the battlefield when you&apos;re ready.</p>
+    <a href="battle.html">Enter Battle</a>
+  </main>
 </body>
 </html>

--- a/battle-hexes-web/webpack.config.js
+++ b/battle-hexes-web/webpack.config.js
@@ -20,8 +20,13 @@ module.exports = (env = {}) => ({
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: path.resolve(__dirname, 'src/index.html'), // Path to your HTML file
-      filename: 'index.html', // The name of the output file in the dist folder
+      template: path.resolve(__dirname, 'src/index.html'), // Placeholder landing page
+      filename: 'index.html',
+      inject: false,
+    }),
+    new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, 'src/battle.html'), // Game boot page
+      filename: 'battle.html',
     }),
     new webpack.DefinePlugin({
       'process.env.API_URL': JSON.stringify(env.API_URL || 'http://localhost:8000'),


### PR DESCRIPTION
## Summary
- move the existing game bootstrap markup into a new src/battle.html page
- add a styled placeholder title screen served from src/index.html and expose both pages via webpack
- refresh e2e coverage and README instructions for the new landing page flow

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e136607c7883279ef47c781b2f70a0