### PR TITLE
Adjust menu checkbox layout

### DIFF
--- a/battle-hexes-web/src/battle-draw.js
+++ b/battle-hexes-web/src/battle-draw.js
@@ -39,7 +39,12 @@ new p5((p) => {
   const moveSelectionDraw = new MoveSelectionDrawer(hexDraw);
   const moveArrowDraw = new MoveArrowDrawer(p, hexDraw);
   const drawers = [hexDrawWithCoords, combatSelectionDraw, selectionDraw, moveSelectionDraw, unitDraw, moveArrowDraw];
-  
+
+  eventBus.on('hexCoordsVisibilityChanged', (shouldShow) => {
+    hexDrawWithCoords.setShowHexCoords(shouldShow);
+    p.draw();
+  });
+
   let canvas;
 
   p.setup = function() {

--- a/battle-hexes-web/src/battle.html
+++ b/battle-hexes-web/src/battle.html
@@ -26,6 +26,11 @@
       padding: 10px;
     }
 
+    #menu .menu-toggle {
+      display: block;
+      margin: 8px 0;
+    }
+
     #canvas-container {
       flex-grow: 1;
       overflow-y: auto;
@@ -53,7 +58,8 @@
     <br/>
     <button id="endPhaseBtn"></button>
     <h3 id="gameOverLabel" style="display: none;">Game Over</h3>
-    <label><input type="checkbox" id="autoNewGame"> Start new game automatically</label>
+    <label class="menu-toggle"><input type="checkbox" id="showHexCoords" checked> Show hex coordinates</label>
+    <label class="menu-toggle"><input type="checkbox" id="autoNewGame"> Start new game automatically</label>
     <button id="newGameBtn" style="display: none;">New Game</button>
   </div>
   <div id="canvas-container"></div>

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { API_URL } from './model/battle-api.js';
+import { eventBus } from './event-bus.js';
 
 export class Menu {
   #game;
@@ -9,6 +10,7 @@ export class Menu {
   #newGameBtn;
   #gameOverLabel;
   #autoNewGameChk;
+  #showHexCoordsChk;
   #autoReloadScheduled = false;
 
   constructor(game) {
@@ -19,6 +21,7 @@ export class Menu {
     this.#newGameBtn = document.getElementById('newGameBtn');
     this.#gameOverLabel = document.getElementById('gameOverLabel');
     this.#autoNewGameChk = document.getElementById('autoNewGame');
+    this.#showHexCoordsChk = document.getElementById('showHexCoords');
 
     // Initialize checkbox state from URL param
     const params = new URLSearchParams(window.location.search);
@@ -39,6 +42,12 @@ export class Menu {
         this.#showGameOver();
       }
     });
+
+    this.#showHexCoordsChk.checked = true;
+    this.#showHexCoordsChk.addEventListener('change', () => {
+      eventBus.emit('hexCoordsVisibilityChanged', this.#showHexCoordsChk.checked);
+    });
+    eventBus.emit('hexCoordsVisibilityChanged', this.#showHexCoordsChk.checked);
 
     this.#initPhasesInMenu();
     this.#initPhaseEndButton();

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -1,5 +1,12 @@
 /** @jest-environment jsdom */
 import { Menu } from '../../src/menu';
+import { eventBus } from '../../src/event-bus.js';
+
+jest.mock('../../src/event-bus.js', () => ({
+  eventBus: {
+    emit: jest.fn(),
+  },
+}));
 
 describe('auto new game persistence', () => {
   function buildDom() {
@@ -10,6 +17,7 @@ describe('auto new game persistence', () => {
       <button id="newGameBtn"></button>
       <div id="gameOverLabel"></div>
       <input type="checkbox" id="autoNewGame">
+      <input type="checkbox" id="showHexCoords">
       <div id="phasesList"></div>
       <button id="endPhaseBtn"></button>
       <div id="currentTurnLabel"></div>
@@ -30,6 +38,10 @@ describe('auto new game persistence', () => {
     };
   }
 
+  beforeEach(() => {
+    eventBus.emit.mockClear();
+  });
+
   test('checkbox reflects url parameter', () => {
     buildDom();
     history.replaceState(null, '', '?autoNewGame=1');
@@ -48,5 +60,31 @@ describe('auto new game persistence', () => {
     chk.checked = false;
     chk.dispatchEvent(new Event('change'));
     expect(window.location.search).toBe('');
+  });
+
+  test('hex coordinate checkbox defaults to checked and emits initial state', () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+    new Menu(fakeGame());
+    const coordsCheckbox = document.getElementById('showHexCoords');
+    expect(coordsCheckbox.checked).toBe(true);
+    expect(eventBus.emit).toHaveBeenCalledWith('hexCoordsVisibilityChanged', true);
+  });
+
+  test('changing hex coordinate checkbox emits visibility changes', () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+    new Menu(fakeGame());
+    const coordsCheckbox = document.getElementById('showHexCoords');
+
+    eventBus.emit.mockClear();
+    coordsCheckbox.checked = false;
+    coordsCheckbox.dispatchEvent(new Event('change'));
+    expect(eventBus.emit).toHaveBeenCalledWith('hexCoordsVisibilityChanged', false);
+
+    eventBus.emit.mockClear();
+    coordsCheckbox.checked = true;
+    coordsCheckbox.dispatchEvent(new Event('change'));
+    expect(eventBus.emit).toHaveBeenCalledWith('hexCoordsVisibilityChanged', true);
   });
 });


### PR DESCRIPTION
## Summary
- add a menu checkbox to control whether hex coordinates are drawn, defaulting it to on
- hook the menu to the drawing loop via the event bus so the board redraws when toggled
- cover the new checkbox behaviour with unit tests
- display the menu checkboxes on separate lines for clarity

## Testing
- npm run test-and-build

------
https://chatgpt.com/codex/tasks/task_e_68e13c574db48327a9f32ed9c0206018