### PR TITLE
Persist hex coordinate menu preference

### DIFF
--- a/battle-hexes-web/src/battle-draw.js
+++ b/battle-hexes-web/src/battle-draw.js
@@ -39,7 +39,12 @@ new p5((p) => {
   const moveSelectionDraw = new MoveSelectionDrawer(hexDraw);
   const moveArrowDraw = new MoveArrowDrawer(p, hexDraw);
   const drawers = [hexDrawWithCoords, combatSelectionDraw, selectionDraw, moveSelectionDraw, unitDraw, moveArrowDraw];
-  
+
+  eventBus.on('hexCoordsVisibilityChanged', (shouldShow) => {
+    hexDrawWithCoords.setShowHexCoords(shouldShow);
+    p.draw();
+  });
+
   let canvas;
 
   p.setup = function() {

--- a/battle-hexes-web/src/battle-draw.js
+++ b/battle-hexes-web/src/battle-draw.js
@@ -30,7 +30,7 @@ new p5((p) => {
   }
 
   const hexDrawWithCoords = new HexDrawer(p, hexRadius);
-  hexDrawWithCoords.setShowHexCoords(true);
+  hexDrawWithCoords.setShowHexCoords(menu.getShowHexCoordsPreference());
   const hexDraw = new HexDrawer(p, hexRadius);
   
   const unitDraw = new UnitDrawer(p, hexDraw);

--- a/battle-hexes-web/src/battle.html
+++ b/battle-hexes-web/src/battle.html
@@ -26,6 +26,11 @@
       padding: 10px;
     }
 
+    #menu .menu-toggle {
+      display: block;
+      margin: 8px 0;
+    }
+
     #canvas-container {
       flex-grow: 1;
       overflow-y: auto;
@@ -53,7 +58,8 @@
     <br/>
     <button id="endPhaseBtn"></button>
     <h3 id="gameOverLabel" style="display: none;">Game Over</h3>
-    <label><input type="checkbox" id="autoNewGame"> Start new game automatically</label>
+    <label class="menu-toggle"><input type="checkbox" id="showHexCoords" checked> Show hex coordinates</label>
+    <label class="menu-toggle"><input type="checkbox" id="autoNewGame"> Start new game automatically</label>
     <button id="newGameBtn" style="display: none;">New Game</button>
   </div>
   <div id="canvas-container"></div>

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -60,6 +60,10 @@ export class Menu {
     this.#updateCombatIndicator();
   }
 
+  getShowHexCoordsPreference() {
+    return this.#showHexCoordsChk.checked;
+  }
+
   #initPhasesInMenu() {
     const phasesElem = document.getElementById('phasesList');
 

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -1,5 +1,12 @@
 /** @jest-environment jsdom */
 import { Menu } from '../../src/menu';
+import { eventBus } from '../../src/event-bus.js';
+
+jest.mock('../../src/event-bus.js', () => ({
+  eventBus: {
+    emit: jest.fn(),
+  },
+}));
 
 describe('auto new game persistence', () => {
   function buildDom() {
@@ -10,6 +17,7 @@ describe('auto new game persistence', () => {
       <button id="newGameBtn"></button>
       <div id="gameOverLabel"></div>
       <input type="checkbox" id="autoNewGame">
+      <input type="checkbox" id="showHexCoords">
       <div id="phasesList"></div>
       <button id="endPhaseBtn"></button>
       <div id="currentTurnLabel"></div>
@@ -30,6 +38,11 @@ describe('auto new game persistence', () => {
     };
   }
 
+  beforeEach(() => {
+    eventBus.emit.mockClear();
+    window.localStorage.clear();
+  });
+
   test('checkbox reflects url parameter', () => {
     buildDom();
     history.replaceState(null, '', '?autoNewGame=1');
@@ -48,5 +61,44 @@ describe('auto new game persistence', () => {
     chk.checked = false;
     chk.dispatchEvent(new Event('change'));
     expect(window.location.search).toBe('');
+  });
+
+  test('hex coordinate checkbox defaults to checked, persists, and emits initial state', () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+    new Menu(fakeGame());
+    const coordsCheckbox = document.getElementById('showHexCoords');
+    expect(coordsCheckbox.checked).toBe(true);
+    expect(eventBus.emit).toHaveBeenCalledWith('hexCoordsVisibilityChanged', true);
+    expect(window.localStorage.getItem('battleHexes.showHexCoords')).toBe('true');
+  });
+
+  test('changing hex coordinate checkbox emits visibility changes', () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+    new Menu(fakeGame());
+    const coordsCheckbox = document.getElementById('showHexCoords');
+
+    eventBus.emit.mockClear();
+    coordsCheckbox.checked = false;
+    coordsCheckbox.dispatchEvent(new Event('change'));
+    expect(eventBus.emit).toHaveBeenCalledWith('hexCoordsVisibilityChanged', false);
+    expect(window.localStorage.getItem('battleHexes.showHexCoords')).toBe('false');
+
+    eventBus.emit.mockClear();
+    coordsCheckbox.checked = true;
+    coordsCheckbox.dispatchEvent(new Event('change'));
+    expect(eventBus.emit).toHaveBeenCalledWith('hexCoordsVisibilityChanged', true);
+    expect(window.localStorage.getItem('battleHexes.showHexCoords')).toBe('true');
+  });
+
+  test('hex coordinate checkbox restores state from localStorage', () => {
+    buildDom();
+    window.localStorage.setItem('battleHexes.showHexCoords', 'false');
+    new Menu(fakeGame());
+
+    const coordsCheckbox = document.getElementById('showHexCoords');
+    expect(coordsCheckbox.checked).toBe(false);
+    expect(eventBus.emit).toHaveBeenCalledWith('hexCoordsVisibilityChanged', false);
   });
 });

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -66,11 +66,12 @@ describe('auto new game persistence', () => {
   test('hex coordinate checkbox defaults to checked, persists, and emits initial state', () => {
     buildDom();
     history.replaceState(null, '', '/');
-    new Menu(fakeGame());
+    const menu = new Menu(fakeGame());
     const coordsCheckbox = document.getElementById('showHexCoords');
     expect(coordsCheckbox.checked).toBe(true);
     expect(eventBus.emit).toHaveBeenCalledWith('hexCoordsVisibilityChanged', true);
     expect(window.localStorage.getItem('battleHexes.showHexCoords')).toBe('true');
+    expect(menu.getShowHexCoordsPreference()).toBe(true);
   });
 
   test('changing hex coordinate checkbox emits visibility changes', () => {
@@ -95,10 +96,11 @@ describe('auto new game persistence', () => {
   test('hex coordinate checkbox restores state from localStorage', () => {
     buildDom();
     window.localStorage.setItem('battleHexes.showHexCoords', 'false');
-    new Menu(fakeGame());
+    const menu = new Menu(fakeGame());
 
     const coordsCheckbox = document.getElementById('showHexCoords');
     expect(coordsCheckbox.checked).toBe(false);
     expect(eventBus.emit).toHaveBeenCalledWith('hexCoordsVisibilityChanged', false);
+    expect(menu.getShowHexCoordsPreference()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- load the show-hex-coordinates checkbox from localStorage and persist changes
- keep emitting menu toggle events while tolerating storage failures
- extend the menu unit tests to cover persistence scenarios

## Testing
- npm run test-and-build

------
https://chatgpt.com/codex/tasks/task_e_68e13c574db48327a9f32ed9c0206018