### PR TITLE
Add animated hex background to title screen

### DIFF
--- a/battle-hexes-web/src/animation/scrolling-hex-landscape.js
+++ b/battle-hexes-web/src/animation/scrolling-hex-landscape.js
@@ -51,8 +51,8 @@ export class ScrollingHexLandscape {
   }
 
   resize(width, height) {
-    this.#visibleColumnCount = Math.ceil((width + this.#horizontalSpacing) / this.#horizontalSpacing);
-    this.#visibleRowCount = Math.ceil((height + this.#hexHeight) / this.#hexHeight);
+    this.#visibleColumnCount = Math.ceil(width / this.#horizontalSpacing) + 2;
+    this.#visibleRowCount = Math.ceil(height / this.#hexHeight) + 2;
   }
 
   getVisibleGridSize() {
@@ -74,18 +74,11 @@ export class ScrollingHexLandscape {
     this.#totalScrollX += deltaX;
     this.#totalScrollY += deltaY;
 
-    if (this.#totalScrollX >= Number.MAX_SAFE_INTEGER / 2) {
-      this.#totalScrollX = 0;
-    }
-    if (this.#totalScrollY >= Number.MAX_SAFE_INTEGER / 2) {
-      this.#totalScrollY = 0;
-    }
-
     this.#baseColumnOffset = Math.floor(this.#totalScrollX / this.#horizontalSpacing);
     this.#baseRowOffset = Math.floor(this.#totalScrollY / this.#hexHeight);
 
-    const fractionalOffsetX = this.#totalScrollX - this.#baseColumnOffset * this.#horizontalSpacing;
-    const fractionalOffsetY = this.#totalScrollY - this.#baseRowOffset * this.#hexHeight;
+    const translateX = -(this.#totalScrollX);
+    const translateY = -(this.#totalScrollY);
 
     const startColumn = this.#baseColumnOffset - GRID_BUFFER;
     const endColumn = startColumn + this.#visibleColumnCount + GRID_BUFFER * 2;
@@ -93,7 +86,7 @@ export class ScrollingHexLandscape {
     const endRow = startRow + this.#visibleRowCount + GRID_BUFFER * 2;
 
     this.#p.push();
-    this.#p.translate(-fractionalOffsetX, -fractionalOffsetY);
+    this.#p.translate(translateX, translateY);
 
     for (let column = startColumn; column < endColumn; column++) {
       for (let row = startRow; row < endRow; row++) {

--- a/battle-hexes-web/src/animation/scrolling-hex-landscape.js
+++ b/battle-hexes-web/src/animation/scrolling-hex-landscape.js
@@ -1,0 +1,114 @@
+import { HexDrawer } from '../drawer/hex-drawer.js';
+
+export const DEFAULT_SCROLL_SPEED = 22;
+
+const SCROLL_DIRECTION = normalizeDirection({ x: 1, y: 0.32 });
+const GRID_BUFFER = 3;
+const STROKE_COLOR = 'rgba(132, 173, 218, 0.22)';
+const STROKE_WEIGHT = 1.5;
+const FILL_COLOR = 'rgba(24, 39, 58, 0.55)';
+
+export class ScrollingHexLandscape {
+  #p;
+  #hexDrawer;
+  #hexRadius;
+  #hexHeight;
+  #hexDiameter;
+  #horizontalSpacing;
+  #scrollSpeed;
+  #totalScrollX;
+  #totalScrollY;
+  #baseColumnOffset;
+  #baseRowOffset;
+  #visibleColumnCount;
+  #visibleRowCount;
+
+  constructor(p, { hexRadius = 64, scrollSpeed = DEFAULT_SCROLL_SPEED, hexDrawer } = {}) {
+    this.#p = p;
+    this.#hexRadius = hexRadius;
+    this.#hexHeight = Math.sqrt(3) * hexRadius;
+    this.#hexDiameter = hexRadius * 2;
+    this.#horizontalSpacing = this.#hexDiameter - (this.#hexRadius / 2);
+    this.#hexDrawer = hexDrawer ?? new HexDrawer(p, hexRadius);
+    if (typeof this.#hexDrawer.setShowHexCoords === 'function') {
+      this.#hexDrawer.setShowHexCoords(false);
+    }
+    this.#scrollSpeed = scrollSpeed;
+    this.#totalScrollX = 0;
+    this.#totalScrollY = 0;
+    this.#baseColumnOffset = 0;
+    this.#baseRowOffset = 0;
+    this.#visibleColumnCount = 0;
+    this.#visibleRowCount = 0;
+  }
+
+  setScrollSpeed(speed) {
+    this.#scrollSpeed = speed;
+  }
+
+  getScrollSpeed() {
+    return this.#scrollSpeed;
+  }
+
+  resize(width, height) {
+    this.#visibleColumnCount = Math.ceil((width + this.#horizontalSpacing) / this.#horizontalSpacing);
+    this.#visibleRowCount = Math.ceil((height + this.#hexHeight) / this.#hexHeight);
+  }
+
+  getVisibleGridSize() {
+    return {
+      rows: this.#visibleRowCount,
+      columns: this.#visibleColumnCount,
+    };
+  }
+
+  draw(deltaTimeMs) {
+    if (!this.#visibleColumnCount || !this.#visibleRowCount) {
+      return;
+    }
+
+    const deltaSeconds = (Number.isFinite(deltaTimeMs) ? deltaTimeMs : 16.67) / 1000;
+    const deltaX = SCROLL_DIRECTION.x * this.#scrollSpeed * deltaSeconds;
+    const deltaY = SCROLL_DIRECTION.y * this.#scrollSpeed * deltaSeconds;
+
+    this.#totalScrollX += deltaX;
+    this.#totalScrollY += deltaY;
+
+    if (this.#totalScrollX >= Number.MAX_SAFE_INTEGER / 2) {
+      this.#totalScrollX = 0;
+    }
+    if (this.#totalScrollY >= Number.MAX_SAFE_INTEGER / 2) {
+      this.#totalScrollY = 0;
+    }
+
+    this.#baseColumnOffset = Math.floor(this.#totalScrollX / this.#horizontalSpacing);
+    this.#baseRowOffset = Math.floor(this.#totalScrollY / this.#hexHeight);
+
+    const fractionalOffsetX = this.#totalScrollX - this.#baseColumnOffset * this.#horizontalSpacing;
+    const fractionalOffsetY = this.#totalScrollY - this.#baseRowOffset * this.#hexHeight;
+
+    const startColumn = this.#baseColumnOffset - GRID_BUFFER;
+    const endColumn = startColumn + this.#visibleColumnCount + GRID_BUFFER * 2;
+    const startRow = this.#baseRowOffset - GRID_BUFFER;
+    const endRow = startRow + this.#visibleRowCount + GRID_BUFFER * 2;
+
+    this.#p.push();
+    this.#p.translate(-fractionalOffsetX, -fractionalOffsetY);
+
+    for (let column = startColumn; column < endColumn; column++) {
+      for (let row = startRow; row < endRow; row++) {
+        this.#hexDrawer.drawHex({ row, column }, STROKE_COLOR, STROKE_WEIGHT, FILL_COLOR);
+      }
+    }
+
+    this.#p.pop();
+  }
+}
+
+function normalizeDirection(direction) {
+  const magnitude = Math.hypot(direction.x, direction.y) || 1;
+  return {
+    x: direction.x / magnitude,
+    y: direction.y / magnitude,
+  };
+}

--- a/battle-hexes-web/src/index.html
+++ b/battle-hexes-web/src/index.html
@@ -8,25 +8,31 @@
     :root {
       color-scheme: dark light;
     }
+
     body {
       margin: 0;
       min-height: 100vh;
       display: flex;
       align-items: center;
       justify-content: center;
-      background: radial-gradient(circle at top, #1e2636, #111521 70%);
       font-family: 'Raleway', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       color: #f4f6fb;
+      background: #0b1120;
+      overflow: hidden;
+      position: relative;
     }
 
     main {
       text-align: center;
       padding: 3rem 2rem;
-      background: rgba(12, 18, 32, 0.85);
+      background: rgba(12, 18, 32, 0.82);
       border-radius: 18px;
-      box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+      box-shadow: 0 18px 45px rgba(0, 0, 0, 0.4);
       max-width: 420px;
       width: calc(100% - 2rem);
+      position: relative;
+      z-index: 1;
+      backdrop-filter: blur(6px);
     }
 
     h1 {
@@ -58,16 +64,37 @@
 
     p {
       margin-bottom: 2rem;
-      color: rgba(244, 246, 251, 0.8);
+      color: rgba(244, 246, 251, 0.82);
       font-size: 1rem;
+    }
+
+    #title-background {
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      overflow: hidden;
+      pointer-events: none;
+      background: radial-gradient(circle at 10% -20%, rgba(49, 73, 108, 0.4), transparent 55%),
+        radial-gradient(circle at 90% 20%, rgba(41, 65, 104, 0.35), transparent 60%),
+        linear-gradient(180deg, #0c1422 0%, #0b1120 45%, #070b13 100%);
+    }
+
+    #title-background canvas {
+      position: absolute !important;
+      inset: 0;
+      width: 100% !important;
+      height: 100% !important;
+      display: block;
     }
   </style>
 </head>
 <body>
+  <div id="title-background" aria-hidden="true"></div>
   <main>
     <h1>Battle Hexes</h1>
     <p>The strategy begins here. Enter the battlefield when you&apos;re ready.</p>
     <a href="battle.html">Enter Battle</a>
   </main>
+  <!-- Script injected by Webpack build -->
 </body>
 </html>

--- a/battle-hexes-web/src/title-screen.js
+++ b/battle-hexes-web/src/title-screen.js
@@ -19,7 +19,7 @@ if (backgroundElement) {
       canvas.elt.style.height = '100%';
       p.pixelDensity(Math.min(window.devicePixelRatio || 1, 2));
 
-      landscape = new ScrollingHexLandscape(p, { hexRadius: 70, scrollSpeed: DEFAULT_SCROLL_SPEED });
+      landscape = new ScrollingHexLandscape(p, { hexRadius: 58, scrollSpeed: DEFAULT_SCROLL_SPEED });
       landscape.resize(p.width, p.height);
       p.frameRate(60);
     };

--- a/battle-hexes-web/src/title-screen.js
+++ b/battle-hexes-web/src/title-screen.js
@@ -1,0 +1,41 @@
+import p5 from 'p5';
+import { ScrollingHexLandscape, DEFAULT_SCROLL_SPEED } from './animation/scrolling-hex-landscape.js';
+
+const backgroundElement = document.getElementById('title-background');
+
+if (backgroundElement) {
+  new p5((p) => {
+    let landscape;
+
+    p.setup = () => {
+      const canvas = p.createCanvas(window.innerWidth, window.innerHeight);
+      canvas.parent(backgroundElement);
+      canvas.elt.classList.add('title-screen__canvas');
+      canvas.elt.style.pointerEvents = 'none';
+      canvas.elt.style.position = 'absolute';
+      canvas.elt.style.top = '0';
+      canvas.elt.style.left = '0';
+      canvas.elt.style.width = '100%';
+      canvas.elt.style.height = '100%';
+      p.pixelDensity(Math.min(window.devicePixelRatio || 1, 2));
+
+      landscape = new ScrollingHexLandscape(p, { hexRadius: 70, scrollSpeed: DEFAULT_SCROLL_SPEED });
+      landscape.resize(p.width, p.height);
+      p.frameRate(60);
+    };
+
+    p.draw = () => {
+      if (!landscape) {
+        return;
+      }
+
+      p.clear(0, 0, 0, 0);
+      landscape.draw(p.deltaTime);
+    };
+
+    p.windowResized = () => {
+      p.resizeCanvas(window.innerWidth, window.innerHeight);
+      landscape.resize(p.width, p.height);
+    };
+  }, backgroundElement);
+}

--- a/battle-hexes-web/tests/animation/scrolling-hex-landscape.test.js
+++ b/battle-hexes-web/tests/animation/scrolling-hex-landscape.test.js
@@ -1,0 +1,58 @@
+import { ScrollingHexLandscape, DEFAULT_SCROLL_SPEED } from '../../src/animation/scrolling-hex-landscape.js';
+
+describe('ScrollingHexLandscape', () => {
+  let p;
+  let hexDrawer;
+
+  beforeEach(() => {
+    p = {
+      push: jest.fn(),
+      pop: jest.fn(),
+      translate: jest.fn(),
+    };
+
+    hexDrawer = {
+      drawHex: jest.fn(),
+      setShowHexCoords: jest.fn(),
+    };
+  });
+
+  test('initial resize calculates a grid that covers the viewport', () => {
+    const landscape = new ScrollingHexLandscape(p, { hexRadius: 50, hexDrawer });
+    landscape.resize(800, 600);
+
+    const gridSize = landscape.getVisibleGridSize();
+
+    expect(gridSize.columns).toBeGreaterThan(0);
+    expect(gridSize.rows).toBeGreaterThan(0);
+    expect(hexDrawer.setShowHexCoords).toHaveBeenCalledWith(false);
+  });
+
+  test('draw renders the grid using the supplied drawer', () => {
+    const landscape = new ScrollingHexLandscape(p, { hexRadius: 40, hexDrawer });
+    landscape.resize(200, 160);
+
+    landscape.draw(16);
+
+    expect(p.push).toHaveBeenCalled();
+    expect(p.pop).toHaveBeenCalled();
+    expect(hexDrawer.drawHex).toHaveBeenCalled();
+  });
+
+  test('scroll speed can be tuned for animation pacing', () => {
+    const landscape = new ScrollingHexLandscape(p, { hexRadius: 40, hexDrawer });
+    landscape.resize(200, 160);
+
+    landscape.draw(1000);
+    const firstTranslateCall = p.translate.mock.calls.at(-1);
+
+    landscape.setScrollSpeed(0);
+    landscape.draw(1000);
+    const secondTranslateCall = p.translate.mock.calls.at(-1);
+
+    expect(firstTranslateCall[0]).not.toBeCloseTo(0);
+    expect(secondTranslateCall[0]).toBeCloseTo(firstTranslateCall[0]);
+    expect(landscape.getScrollSpeed()).toBe(0);
+    expect(DEFAULT_SCROLL_SPEED).toBeGreaterThan(0);
+  });
+});

--- a/battle-hexes-web/webpack.config.js
+++ b/battle-hexes-web/webpack.config.js
@@ -4,9 +4,12 @@ const webpack = require('webpack');
 
 module.exports = (env = {}) => ({
   mode: 'development',
-  entry: './src/battle-draw.js',
+  entry: {
+    battle: './src/battle-draw.js',
+    title: './src/title-screen.js',
+  },
   output: {
-    filename: 'main.[contenthash:8].js',
+    filename: '[name].[contenthash:8].js',
     path: path.resolve(__dirname, 'dist'),
     clean: true,
   },
@@ -22,11 +25,13 @@ module.exports = (env = {}) => ({
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, 'src/index.html'), // Placeholder landing page
       filename: 'index.html',
-      inject: false,
+      chunks: ['title'],
+      inject: 'body',
     }),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, 'src/battle.html'), // Game boot page
       filename: 'battle.html',
+      chunks: ['battle'],
     }),
     new webpack.DefinePlugin({
       'process.env.API_URL': JSON.stringify(env.API_URL || 'http://localhost:8000'),


### PR DESCRIPTION
## Summary
- add a p5-powered scrolling hex landscape behind the landing page while keeping the call-to-action visible
- reuse the existing HexDrawer through a scrolling landscape helper with an adjustable scroll speed constant
- update the webpack build to emit a dedicated title bundle and add unit coverage for the new animation helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e154b8ffb0832785578352d31c0d6f

Refs #105 