### PR TITLE
Adjust CloudFront HTML caching and expose distribution id

### DIFF
--- a/battle-hexes-web/cloudformation-template.yml
+++ b/battle-hexes-web/cloudformation-template.yml
@@ -72,8 +72,10 @@ Resources:
           DefaultTTL: 0
           MinTTL: 0
           MaxTTL: 31536000
+        # HTML should be revalidated every request while hashed assets get long cache.
+        # Exposing the distribution ID lets GitHub Actions invalidate /index.html and /battle.html on demand.
         CacheBehaviors:
-          - PathPattern: 'index.html'
+          - PathPattern: '*.html'
             TargetOriginId: WebsiteOrigin
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods: [GET, HEAD]
@@ -113,6 +115,9 @@ Outputs:
   CloudFrontURL:
     Description: "CloudFront distribution URL"
     Value: !Sub "https://${WebsiteDistribution.DomainName}"
+  CloudFrontDistributionId:
+    Description: "CloudFront distribution ID"
+    Value: !Ref WebsiteDistribution
   WebUrl:
     Description: Public URL for the website
     Value: !Sub "https://${WebDomainName}"


### PR DESCRIPTION
## Summary
- configure CloudFront to match all HTML objects with zero TTLs for cache revalidation
- document the reasoning in-line and expose the distribution ID output for CI-driven invalidations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4fed8370c8327bcd01e3b255a9983