### PR TITLE
Improve scenario schema mapping

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -19,7 +19,11 @@ logger.info("sys.path: %s", sys.path)
 from battle_hexes_core.combat.combat import Combat  # noqa: E402
 from battle_hexes_core.game.gamerepo import GameRepository  # noqa: E402
 from battle_hexes_core.game.sparseboard import SparseBoard  # noqa: E402
+from battle_hexes_core.scenario.scenarioregistry import (  # noqa: E402
+    ScenarioRegistry,
+)
 from battle_hexes_api.samplegame import SampleGameCreator  # noqa: E402
+from battle_hexes_api.schemas import ScenarioModel  # noqa: E402
 
 app = FastAPI()
 
@@ -31,6 +35,7 @@ def health():
 
 
 game_repo = GameRepository()
+scenario_registry = ScenarioRegistry()
 
 app.add_middleware(
     CORSMiddleware,
@@ -47,6 +52,14 @@ def create_game():
     new_game = SampleGameCreator.create_sample_game()
     game_repo.update_game(new_game)
     return new_game.to_game_model()
+
+
+@app.get("/scenarios", response_model=list[ScenarioModel])
+def list_scenarios() -> list[ScenarioModel]:
+    """Return the available scenarios registered in the core package."""
+
+    scenarios = scenario_registry.list_scenarios()
+    return [ScenarioModel.from_core(s) for s in scenarios]
 
 
 def _get_game_or_404(game_id: str):

--- a/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
@@ -1,0 +1,5 @@
+"""Pydantic schemas for the Battle Hexes API."""
+
+from .scenario import ScenarioModel
+
+__all__ = ["ScenarioModel"]

--- a/battle_hexes_api/src/battle_hexes_api/schemas/scenario.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/scenario.py
@@ -1,0 +1,27 @@
+"""Pydantic schema for scenario resources."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from battle_hexes_core.scenario.scenario import Scenario
+
+
+class ScenarioModel(BaseModel):
+    """Pydantic representation of :class:`Scenario`."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    name: str
+
+    @classmethod
+    def from_core(cls, scenario: Scenario) -> "ScenarioModel":
+        """Create a ``ScenarioModel`` from a core :class:`Scenario`."""
+
+        return cls.model_validate(scenario)
+
+    def to_core(self) -> Scenario:
+        """Convert the Pydantic model back into a core :class:`Scenario`."""
+
+        return Scenario(**self.model_dump())

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from battle_hexes_api.main import app
 from battle_hexes_core.game.sparseboard import SparseBoard
+from battle_hexes_core.scenario.scenario import Scenario
 
 
 class TestFastAPI(unittest.TestCase):
@@ -32,6 +33,25 @@ class TestFastAPI(unittest.TestCase):
         missing_id = uuid4()
         response = self.client.get(f'/games/{missing_id}')
         self.assertEqual(response.status_code, 404)
+
+    @patch('battle_hexes_api.main.scenario_registry')
+    def test_list_scenarios(self, mock_registry):
+        mock_registry.list_scenarios.return_value = [
+            Scenario(id="test-1", name="Test Scenario"),
+            Scenario(id="test-2", name="Another Scenario"),
+        ]
+
+        response = self.client.get('/scenarios')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            [
+                {"id": "test-1", "name": "Test Scenario"},
+                {"id": "test-2", "name": "Another Scenario"},
+            ],
+        )
+        mock_registry.list_scenarios.assert_called_once_with()
 
     @patch('battle_hexes_api.main.game_repo')
     def test_resolve_combat_placeholder(self, mock_game_repo):

--- a/battle_hexes_api/tests/test_schemas.py
+++ b/battle_hexes_api/tests/test_schemas.py
@@ -1,0 +1,16 @@
+import unittest
+
+from battle_hexes_api.schemas import ScenarioModel
+from battle_hexes_core.scenario.scenario import Scenario
+
+
+class TestScenarioModel(unittest.TestCase):
+    def test_round_trip(self):
+        core_scenario = Scenario(id="s1", name="Scenario 1")
+
+        model = ScenarioModel.from_core(core_scenario)
+        self.assertEqual(model.id, "s1")
+        self.assertEqual(model.name, "Scenario 1")
+
+        converted = model.to_core()
+        self.assertEqual(converted, core_scenario)


### PR DESCRIPTION
## Summary
- configure the ScenarioModel schema to load core Scenario dataclasses via from_attributes
- simplify the converters by relying on Pydantic's model_dump/model_validate helpers

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68e5b28f3f748327889aaedacebab973