### PR TITLE
Refine title screen scenario picker logic

### DIFF
--- a/battle-hexes-web/src/index.html
+++ b/battle-hexes-web/src/index.html
@@ -68,6 +68,45 @@
       font-size: 1rem;
     }
 
+    .scenario-picker {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      margin-bottom: 2.5rem;
+      text-align: left;
+    }
+
+    .scenario-picker label {
+      font-size: 0.95rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: rgba(244, 246, 251, 0.9);
+    }
+
+    .scenario-picker select {
+      appearance: none;
+      padding: 0.75rem 1rem;
+      border-radius: 12px;
+      border: 1px solid rgba(244, 246, 251, 0.2);
+      background: rgba(11, 17, 32, 0.85);
+      color: #f4f6fb;
+      font-size: 1rem;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .scenario-picker select:focus-visible {
+      border-color: rgba(240, 185, 77, 0.8);
+      box-shadow: 0 0 0 3px rgba(240, 185, 77, 0.25);
+      outline: none;
+    }
+
+    .scenario-picker__status {
+      font-size: 0.9rem;
+      color: rgba(244, 246, 251, 0.7);
+      min-height: 1.4rem;
+    }
+
     #title-background {
       position: fixed;
       inset: 0;
@@ -93,6 +132,13 @@
   <main>
     <h1>Battle Hexes</h1>
     <p>The strategy begins here. Enter the battlefield when you&apos;re ready.</p>
+    <div class="scenario-picker">
+      <label for="scenario-select">Scenario</label>
+      <select id="scenario-select" name="scenario" aria-describedby="scenario-status">
+        <option>Loading scenarios…</option>
+      </select>
+      <p id="scenario-status" class="scenario-picker__status" aria-live="polite">Choose a scenario to customize your battle.</p>
+    </div>
     <a href="battle.html">Enter Battle</a>
   </main>
   <!-- Script injected by Webpack build -->

--- a/battle-hexes-web/src/title-screen-scenarios.js
+++ b/battle-hexes-web/src/title-screen-scenarios.js
@@ -1,0 +1,92 @@
+export const LOADING_MESSAGE = 'Loading scenarios…';
+export const DEFAULT_STATUS_MESSAGE = 'Choose a scenario to customize your battle.';
+export const UNAVAILABLE_MESSAGE = 'Unable to load scenarios. Please try again later.';
+export const EMPTY_MESSAGE = 'No scenarios are available yet.';
+
+const setStatusMessage = (statusElement, message) => {
+  if (!statusElement) {
+    return;
+  }
+
+  statusElement.textContent = message;
+};
+
+export const populateScenarioOptions = (selectElement, scenarios) => {
+  if (!selectElement) {
+    return;
+  }
+
+  selectElement.innerHTML = '';
+
+  scenarios.forEach((scenario, index) => {
+    const option = document.createElement('option');
+    option.value = scenario.id;
+    option.textContent = scenario.name || scenario.id;
+
+    if (index === 0) {
+      option.selected = true;
+    }
+
+    selectElement.append(option);
+  });
+};
+
+export const loadScenarios = async ({
+  selectElement,
+  statusElement,
+  fetchImpl = fetch,
+  apiUrl,
+}) => {
+  if (!selectElement) {
+    return [];
+  }
+
+  selectElement.disabled = true;
+  setStatusMessage(statusElement, LOADING_MESSAGE);
+
+  try {
+    const response = await fetchImpl(`${apiUrl}/scenarios`);
+
+    if (!response.ok) {
+      throw new Error(`Unexpected status code ${response.status}`);
+    }
+
+    const scenarios = await response.json();
+
+    if (!Array.isArray(scenarios) || scenarios.length === 0) {
+      selectElement.innerHTML = '<option>No scenarios available</option>';
+      selectElement.disabled = true;
+      setStatusMessage(statusElement, EMPTY_MESSAGE);
+      return [];
+    }
+
+    populateScenarioOptions(selectElement, scenarios);
+    selectElement.disabled = false;
+    setStatusMessage(statusElement, DEFAULT_STATUS_MESSAGE);
+    return scenarios;
+  } catch (error) {
+    console.error('Failed to load scenarios', error);
+    selectElement.innerHTML = '<option>Unable to load scenarios</option>';
+    selectElement.disabled = true;
+    setStatusMessage(statusElement, UNAVAILABLE_MESSAGE);
+    return [];
+  }
+};
+
+export const initializeScenarioPicker = ({
+  documentRef = document,
+  fetchImpl = fetch,
+  apiUrl = process.env.API_URL,
+} = {}) => {
+  const selectElement = documentRef?.getElementById?.('scenario-select');
+
+  if (!selectElement) {
+    return null;
+  }
+
+  const statusElement = documentRef.getElementById('scenario-status');
+
+  loadScenarios({ selectElement, statusElement, fetchImpl, apiUrl });
+
+  return { selectElement, statusElement };
+};

--- a/battle-hexes-web/src/title-screen.js
+++ b/battle-hexes-web/src/title-screen.js
@@ -1,5 +1,6 @@
 import p5 from 'p5';
 import { ScrollingHexLandscape, DEFAULT_SCROLL_SPEED } from './animation/scrolling-hex-landscape.js';
+import { initializeScenarioPicker } from './title-screen-scenarios.js';
 
 const backgroundElement = document.getElementById('title-background');
 
@@ -39,3 +40,5 @@ if (backgroundElement) {
     };
   }, backgroundElement);
 }
+
+initializeScenarioPicker();

--- a/battle-hexes-web/tests/title-screen/scenario-loader.test.js
+++ b/battle-hexes-web/tests/title-screen/scenario-loader.test.js
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  DEFAULT_STATUS_MESSAGE,
+  EMPTY_MESSAGE,
+  LOADING_MESSAGE,
+  UNAVAILABLE_MESSAGE,
+  loadScenarios,
+  populateScenarioOptions,
+} from '../../src/title-screen-scenarios.js';
+
+describe('title screen scenario helpers', () => {
+  let selectElement;
+  let statusElement;
+
+  beforeEach(() => {
+    selectElement = document.createElement('select');
+    statusElement = document.createElement('p');
+  });
+
+  test('populateScenarioOptions fills select and selects first entry', () => {
+    populateScenarioOptions(selectElement, [
+      { id: 'alpha', name: 'Alpha Strike' },
+      { id: 'beta' },
+    ]);
+
+    expect(selectElement.options).toHaveLength(2);
+    expect(selectElement.options[0].value).toBe('alpha');
+    expect(selectElement.options[0].selected).toBe(true);
+    expect(selectElement.options[1].textContent).toBe('beta');
+  });
+
+  test('loadScenarios populates select with fetched scenarios', async () => {
+    const scenarios = [
+      { id: 'alpha', name: 'Alpha Strike' },
+      { id: 'beta', name: 'Beta Shield' },
+    ];
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => scenarios,
+    });
+
+    const loadPromise = loadScenarios({
+      selectElement,
+      statusElement,
+      fetchImpl,
+      apiUrl: 'https://api.example.com',
+    });
+
+    expect(statusElement.textContent).toBe(LOADING_MESSAGE);
+
+    const result = await loadPromise;
+
+    expect(result).toEqual(scenarios);
+    expect(selectElement.disabled).toBe(false);
+    expect(selectElement.value).toBe('alpha');
+    expect(statusElement.textContent).toBe(DEFAULT_STATUS_MESSAGE);
+  });
+
+  test('loadScenarios handles empty response', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    const result = await loadScenarios({
+      selectElement,
+      statusElement,
+      fetchImpl,
+      apiUrl: 'https://api.example.com',
+    });
+
+    expect(result).toEqual([]);
+    expect(selectElement.disabled).toBe(true);
+    expect(selectElement.innerHTML).toContain('No scenarios available');
+    expect(statusElement.textContent).toBe(EMPTY_MESSAGE);
+  });
+
+  test('loadScenarios handles failed request', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const result = await loadScenarios({
+      selectElement,
+      statusElement,
+      fetchImpl,
+      apiUrl: 'https://api.example.com',
+    });
+
+    expect(result).toEqual([]);
+    expect(selectElement.innerHTML).toContain('Unable to load scenarios');
+    expect(selectElement.disabled).toBe(true);
+    expect(statusElement.textContent).toBe(UNAVAILABLE_MESSAGE);
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add a styled scenario picker to the landing page
- load the available scenarios from the API and default to the first option
- refactor scenario loading into testable helpers and add unit coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5ba12bdd48327ad8e6fbaa0037dc6