### PR TITLE
Add player type selection to title screen

### DIFF
--- a/battle-hexes-web/src/index.html
+++ b/battle-hexes-web/src/index.html
@@ -68,7 +68,8 @@
       font-size: 1rem;
     }
 
-    .scenario-picker {
+    .scenario-picker,
+    .player-type-picker {
       display: flex;
       flex-direction: column;
       gap: 0.5rem;
@@ -76,7 +77,8 @@
       text-align: left;
     }
 
-    .scenario-picker label {
+    .scenario-picker label,
+    .player-type-picker label {
       font-size: 0.95rem;
       font-weight: 600;
       letter-spacing: 0.04em;
@@ -84,7 +86,8 @@
       color: rgba(244, 246, 251, 0.9);
     }
 
-    .scenario-picker select {
+    .scenario-picker select,
+    .player-type-picker select {
       appearance: none;
       padding: 0.75rem 1rem;
       border-radius: 12px;
@@ -95,16 +98,36 @@
       transition: border-color 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .scenario-picker select:focus-visible {
+    .scenario-picker select:focus-visible,
+    .player-type-picker select:focus-visible {
       border-color: rgba(240, 185, 77, 0.8);
       box-shadow: 0 0 0 3px rgba(240, 185, 77, 0.25);
       outline: none;
     }
 
-    .scenario-picker__status {
+    .scenario-picker__status,
+    .player-type-picker__status {
       font-size: 0.9rem;
       color: rgba(244, 246, 251, 0.7);
       min-height: 1.4rem;
+    }
+
+    .player-type-picker {
+      gap: 1rem;
+    }
+
+    .player-type-picker__heading {
+      margin: 0;
+      font-size: 1.05rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(244, 246, 251, 0.9);
+    }
+
+    .player-type-picker__group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
     }
 
     #title-background {
@@ -138,6 +161,22 @@
         <option>Loading scenarios…</option>
       </select>
       <p id="scenario-status" class="scenario-picker__status" aria-live="polite">Choose a scenario to customize your battle.</p>
+    </div>
+    <div class="player-type-picker" aria-labelledby="player-type-heading">
+      <h2 id="player-type-heading" class="player-type-picker__heading">Player Types</h2>
+      <div class="player-type-picker__group">
+        <label for="player1-type">Player 1</label>
+        <select id="player1-type" name="player1" aria-describedby="player-type-status">
+          <option>Loading player types…</option>
+        </select>
+      </div>
+      <div class="player-type-picker__group">
+        <label for="player2-type">Player 2</label>
+        <select id="player2-type" name="player2" aria-describedby="player-type-status">
+          <option>Loading player types…</option>
+        </select>
+      </div>
+      <p id="player-type-status" class="player-type-picker__status" aria-live="polite">Choose who commands each side.</p>
     </div>
     <a href="battle.html">Enter Battle</a>
   </main>

--- a/battle-hexes-web/src/title-screen-player-types.js
+++ b/battle-hexes-web/src/title-screen-player-types.js
@@ -1,0 +1,137 @@
+export const LOADING_MESSAGE = 'Loading player types…';
+export const DEFAULT_STATUS_MESSAGE = 'Choose who commands each side.';
+export const UNAVAILABLE_MESSAGE = 'Unable to load player types. Please try again later.';
+export const EMPTY_MESSAGE = 'No player types are available yet.';
+
+const setStatusMessage = (statusElement, message) => {
+  if (!statusElement) {
+    return;
+  }
+
+  statusElement.textContent = message;
+};
+
+export const populatePlayerTypeOptions = (selectElement, playerTypes, selectedId) => {
+  if (!selectElement) {
+    return;
+  }
+
+  selectElement.innerHTML = '';
+
+  playerTypes.forEach((playerType, index) => {
+    const option = document.createElement('option');
+    option.value = playerType.id;
+    option.textContent = playerType.name || playerType.id;
+
+    if (selectedId && selectedId === playerType.id) {
+      option.selected = true;
+    }
+
+    if (!selectedId && index === 0) {
+      option.selected = true;
+    }
+
+    selectElement.append(option);
+  });
+};
+
+const disableSelects = (selectElements) => {
+  selectElements.forEach((select) => {
+    if (!select) {
+      return;
+    }
+
+    select.innerHTML = '<option>Loading player types…</option>';
+    select.disabled = true;
+  });
+};
+
+const setErrorState = (selectElements, message) => {
+  selectElements.forEach((select) => {
+    if (!select) {
+      return;
+    }
+
+    select.innerHTML = `<option>${message}</option>`;
+    select.disabled = true;
+  });
+};
+
+export const loadPlayerTypes = async ({
+  selectElements = [],
+  statusElement,
+  fetchImpl = fetch,
+  apiUrl,
+  defaultSelections = [],
+}) => {
+  const selects = selectElements.filter(Boolean);
+
+  if (selects.length === 0) {
+    return [];
+  }
+
+  disableSelects(selects);
+  setStatusMessage(statusElement, LOADING_MESSAGE);
+
+  try {
+    const response = await fetchImpl(`${apiUrl}/player-types`);
+
+    if (!response.ok) {
+      throw new Error(`Unexpected status code ${response.status}`);
+    }
+
+    const playerTypes = await response.json();
+
+    if (!Array.isArray(playerTypes) || playerTypes.length === 0) {
+      setErrorState(selects, 'No player types available');
+      setStatusMessage(statusElement, EMPTY_MESSAGE);
+      return [];
+    }
+
+    selects.forEach((select, index) => {
+      const defaultSelection = defaultSelections[index];
+      populatePlayerTypeOptions(select, playerTypes, defaultSelection);
+      select.disabled = false;
+
+      if (defaultSelection && select.value !== defaultSelection) {
+        select.value = playerTypes[0]?.id ?? '';
+      }
+    });
+
+    setStatusMessage(statusElement, DEFAULT_STATUS_MESSAGE);
+    return playerTypes;
+  } catch (error) {
+    console.error('Failed to load player types', error);
+    setErrorState(selects, 'Unable to load player types');
+    setStatusMessage(statusElement, UNAVAILABLE_MESSAGE);
+    return [];
+  }
+};
+
+export const initializePlayerTypePicker = ({
+  documentRef = document,
+  fetchImpl = fetch,
+  apiUrl = process.env.API_URL,
+  defaultSelections = ['human', 'q-learning'],
+} = {}) => {
+  const selectElements = [
+    documentRef?.getElementById?.('player1-type'),
+    documentRef?.getElementById?.('player2-type'),
+  ].filter(Boolean);
+
+  if (selectElements.length === 0) {
+    return null;
+  }
+
+  const statusElement = documentRef.getElementById('player-type-status');
+
+  loadPlayerTypes({
+    selectElements,
+    statusElement,
+    fetchImpl,
+    apiUrl,
+    defaultSelections,
+  });
+
+  return { selectElements, statusElement };
+};

--- a/battle-hexes-web/src/title-screen.js
+++ b/battle-hexes-web/src/title-screen.js
@@ -1,5 +1,6 @@
 import p5 from 'p5';
 import { ScrollingHexLandscape, DEFAULT_SCROLL_SPEED } from './animation/scrolling-hex-landscape.js';
+import { initializePlayerTypePicker } from './title-screen-player-types.js';
 import { initializeScenarioPicker } from './title-screen-scenarios.js';
 
 const backgroundElement = document.getElementById('title-background');
@@ -42,3 +43,4 @@ if (backgroundElement) {
 }
 
 initializeScenarioPicker();
+initializePlayerTypePicker();

--- a/battle-hexes-web/tests/title-screen/player-type-loader.test.js
+++ b/battle-hexes-web/tests/title-screen/player-type-loader.test.js
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  DEFAULT_STATUS_MESSAGE,
+  EMPTY_MESSAGE,
+  UNAVAILABLE_MESSAGE,
+  initializePlayerTypePicker,
+  loadPlayerTypes,
+  populatePlayerTypeOptions,
+} from '../../src/title-screen-player-types.js';
+
+describe('title screen player type helpers', () => {
+  let player1Select;
+  let player2Select;
+  let statusElement;
+
+  beforeEach(() => {
+    player1Select = document.createElement('select');
+    player2Select = document.createElement('select');
+    statusElement = document.createElement('p');
+  });
+
+  test('populatePlayerTypeOptions selects provided default id', () => {
+    const types = [
+      { id: 'human', name: 'Human' },
+      { id: 'random', name: 'Random' },
+    ];
+
+    populatePlayerTypeOptions(player1Select, types, 'random');
+
+    expect(player1Select.options).toHaveLength(2);
+    expect(player1Select.value).toBe('random');
+    expect(player1Select.options[0].selected).toBe(false);
+  });
+
+  test('loadPlayerTypes populates both selects and applies defaults', async () => {
+    const playerTypes = [
+      { id: 'human', name: 'Human' },
+      { id: 'random', name: 'Random' },
+    ];
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => playerTypes,
+    });
+
+    const result = await loadPlayerTypes({
+      selectElements: [player1Select, player2Select],
+      statusElement,
+      fetchImpl,
+      apiUrl: 'https://api.example.com',
+      defaultSelections: ['human', 'random'],
+    });
+
+    expect(result).toEqual(playerTypes);
+    expect(player1Select.disabled).toBe(false);
+    expect(player2Select.disabled).toBe(false);
+    expect(player1Select.value).toBe('human');
+    expect(player2Select.value).toBe('random');
+    expect(statusElement.textContent).toBe(DEFAULT_STATUS_MESSAGE);
+  });
+
+  test('loadPlayerTypes falls back to first option when default missing', async () => {
+    const playerTypes = [
+      { id: 'human', name: 'Human' },
+      { id: 'random', name: 'Random' },
+    ];
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => playerTypes,
+    });
+
+    await loadPlayerTypes({
+      selectElements: [player1Select],
+      statusElement,
+      fetchImpl,
+      apiUrl: 'https://api.example.com',
+      defaultSelections: ['q-learning'],
+    });
+
+    expect(player1Select.value).toBe('human');
+  });
+
+  test('loadPlayerTypes handles empty response', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    const result = await loadPlayerTypes({
+      selectElements: [player1Select],
+      statusElement,
+      fetchImpl,
+      apiUrl: 'https://api.example.com',
+    });
+
+    expect(result).toEqual([]);
+    expect(player1Select.disabled).toBe(true);
+    expect(player1Select.innerHTML).toContain('No player types available');
+    expect(statusElement.textContent).toBe(EMPTY_MESSAGE);
+  });
+
+  test('loadPlayerTypes handles failed request', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const result = await loadPlayerTypes({
+      selectElements: [player1Select, player2Select],
+      statusElement,
+      fetchImpl,
+      apiUrl: 'https://api.example.com',
+    });
+
+    expect(result).toEqual([]);
+    expect(player1Select.disabled).toBe(true);
+    expect(player2Select.disabled).toBe(true);
+    expect(player1Select.innerHTML).toContain('Unable to load player types');
+    expect(statusElement.textContent).toBe(UNAVAILABLE_MESSAGE);
+    consoleSpy.mockRestore();
+  });
+
+  test('initializePlayerTypePicker wires up DOM when selects exist', () => {
+    const documentRef = {
+      getElementById: jest.fn((id) => {
+        if (id === 'player1-type') {
+          return player1Select;
+        }
+
+        if (id === 'player2-type') {
+          return player2Select;
+        }
+
+        if (id === 'player-type-status') {
+          return statusElement;
+        }
+
+        return null;
+      }),
+    };
+
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    const result = initializePlayerTypePicker({
+      documentRef,
+      fetchImpl,
+      apiUrl: 'https://api.example.com',
+    });
+
+    expect(result).not.toBeNull();
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+});

--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -22,8 +22,12 @@ from battle_hexes_core.game.sparseboard import SparseBoard  # noqa: E402
 from battle_hexes_core.scenario.scenarioregistry import (  # noqa: E402
     ScenarioRegistry,
 )
+from battle_hexes_api.player_types import list_player_types  # noqa: E402
 from battle_hexes_api.samplegame import SampleGameCreator  # noqa: E402
-from battle_hexes_api.schemas import ScenarioModel  # noqa: E402
+from battle_hexes_api.schemas import (  # noqa: E402
+    PlayerTypeModel,
+    ScenarioModel,
+)
 
 app = FastAPI()
 
@@ -60,6 +64,16 @@ def list_scenarios() -> list[ScenarioModel]:
 
     scenarios = scenario_registry.list_scenarios()
     return [ScenarioModel.from_core(s) for s in scenarios]
+
+
+@app.get("/player-types", response_model=list[PlayerTypeModel])
+def get_player_types() -> list[PlayerTypeModel]:
+    """Return the supported player types available on the platform."""
+
+    return [
+        PlayerTypeModel.from_definition(definition)
+        for definition in list_player_types()
+    ]
 
 
 def _get_game_or_404(game_id: str):

--- a/battle_hexes_api/src/battle_hexes_api/player_types.py
+++ b/battle_hexes_api/src/battle_hexes_api/player_types.py
@@ -1,0 +1,26 @@
+"""Definitions for the player types exposed by the public API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PlayerTypeDefinition:
+    """Describe a player type option that can be selected on the frontend."""
+
+    id: str
+    name: str
+
+
+SUPPORTED_PLAYER_TYPES: tuple[PlayerTypeDefinition, ...] = (
+    PlayerTypeDefinition(id="human", name="Human"),
+    PlayerTypeDefinition(id="random", name="Random Player"),
+    PlayerTypeDefinition(id="q-learning", name="Q-Learning Player"),
+)
+
+
+def list_player_types() -> tuple[PlayerTypeDefinition, ...]:
+    """Return the supported player type definitions."""
+
+    return SUPPORTED_PLAYER_TYPES

--- a/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
@@ -1,5 +1,6 @@
 """Pydantic schemas for the Battle Hexes API."""
 
+from .player_type import PlayerTypeModel
 from .scenario import ScenarioModel
 
-__all__ = ["ScenarioModel"]
+__all__ = ["PlayerTypeModel", "ScenarioModel"]

--- a/battle_hexes_api/src/battle_hexes_api/schemas/player_type.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/player_type.py
@@ -1,0 +1,22 @@
+"""Pydantic models for player type information returned by the API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from battle_hexes_api.player_types import PlayerTypeDefinition
+
+
+class PlayerTypeModel(BaseModel):
+    """Serialize player type definitions for API responses."""
+
+    id: str
+    name: str
+
+    @classmethod
+    def from_definition(
+        cls, definition: PlayerTypeDefinition
+    ) -> "PlayerTypeModel":
+        """Create a :class:`PlayerTypeModel` from a definition dataclass."""
+
+        return cls(id=definition.id, name=definition.name)

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 from fastapi.testclient import TestClient
 
 from battle_hexes_api.main import app
+from battle_hexes_api.player_types import PlayerTypeDefinition
 from battle_hexes_core.game.sparseboard import SparseBoard
 from battle_hexes_core.scenario.scenario import Scenario
 
@@ -182,3 +183,22 @@ class TestFastAPI(unittest.TestCase):
 
         mock_player1.end_game_cb.assert_called_once_with()
         mock_player2.end_game_cb.assert_called_once_with()
+
+    @patch('battle_hexes_api.main.list_player_types')
+    def test_get_player_types(self, mock_list_player_types):
+        mock_list_player_types.return_value = (
+            PlayerTypeDefinition(id="human", name="Human"),
+            PlayerTypeDefinition(id="random", name="Random"),
+        )
+
+        response = self.client.get('/player-types')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            [
+                {"id": "human", "name": "Human"},
+                {"id": "random", "name": "Random"},
+            ],
+        )
+        mock_list_player_types.assert_called_once_with()


### PR DESCRIPTION
## Summary
- add a FastAPI endpoint and schema for listing supported player types
- load player type options from the API on the title screen with human and Q-learning defaults
- cover the new picker logic with unit tests for both the frontend and API

## Testing
- npm test
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68e97116f97883278980e1b9f2e47266

Refs #105 