### PR TITLE
Add favicon to Battle Hexes web pages

### DIFF
--- a/battle-hexes-web/src/battle.html
+++ b/battle-hexes-web/src/battle.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <title>Battle Hexes</title>
   <style>
     body {

--- a/battle-hexes-web/src/index.html
+++ b/battle-hexes-web/src/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <title>Battle Hexes</title>
   <style>
     :root {

--- a/battle-hexes-web/webpack.config.js
+++ b/battle-hexes-web/webpack.config.js
@@ -27,11 +27,13 @@ module.exports = (env = {}) => ({
       filename: 'index.html',
       chunks: ['title'],
       inject: 'body',
+      favicon: path.resolve(__dirname, '../favicon.ico'),
     }),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, 'src/battle.html'), // Game boot page
       filename: 'battle.html',
       chunks: ['battle'],
+      favicon: path.resolve(__dirname, '../favicon.ico'),
     }),
     new webpack.DefinePlugin({
       'process.env.API_URL': JSON.stringify(env.API_URL || 'http://localhost:8000'),


### PR DESCRIPTION
## Summary
- include the shared favicon in both HTML entry points for the web client
- configure Webpack to bundle the favicon so it is available in built assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e97618fd3083278a5b592fcd77a549