### PR TITLE
Rename SampleGameCreator to GameCreator

### DIFF
--- a/battle_agent_rl/src/battle_agent_rl/qlearningplayer/qlearningtrainer.py
+++ b/battle_agent_rl/src/battle_agent_rl/qlearningplayer/qlearningtrainer.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def build_players() -> tuple[RandomPlayer, QLearningPlayer, List[Unit]]:
-    """Create players and units matching ``SampleGameCreator``."""
+    """Create players and units matching ``GameCreator``."""
 
     scenario = load_scenario_data(DEFAULT_SCENARIO_ID)
 

--- a/battle_agent_rl/src/battle_agent_rl/rltester.py
+++ b/battle_agent_rl/src/battle_agent_rl/rltester.py
@@ -25,7 +25,7 @@ DEFAULT_SCENARIO_ID = "elim_1"
 
 
 def build_players() -> tuple[RandomPlayer, QLearningPlayer, List[Unit]]:
-    """Create players and units matching ``SampleGameCreator``."""
+    """Create players and units matching ``GameCreator``."""
     scenario = load_scenario_data(DEFAULT_SCENARIO_ID)
 
     factions_by_player: dict[str, list[Faction]] = {}

--- a/battle_hexes_api/src/battle_hexes_api/gamecreator.py
+++ b/battle_hexes_api/src/battle_hexes_api/gamecreator.py
@@ -36,7 +36,7 @@ class SampleHumanPlayer(Player):
         return None
 
 
-class SampleGameCreator:
+class GameCreator:
     """Utility class for constructing game instances."""
 
     @staticmethod
@@ -85,7 +85,7 @@ class SampleGameCreator:
         for index, player_name in enumerate(player_order):
             type_id = player_type_ids[index]
             factions = factions_by_player[player_name]
-            player = SampleGameCreator._create_player(
+            player = GameCreator._create_player(
                 type_id,
                 name=player_name,
                 factions=factions,

--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -23,7 +23,7 @@ from battle_hexes_core.scenario.scenarioregistry import (  # noqa: E402
     ScenarioRegistry,
 )
 from battle_hexes_api.player_types import list_player_types  # noqa: E402
-from battle_hexes_api.samplegame import SampleGameCreator  # noqa: E402
+from battle_hexes_api.gamecreator import GameCreator  # noqa: E402
 from battle_hexes_api.schemas import (  # noqa: E402
     CreateGameRequest,
     PlayerTypeModel,
@@ -80,7 +80,7 @@ def create_game(payload: CreateGameRequest):
         ) from exc
 
     try:
-        new_game = SampleGameCreator.create_sample_game(
+        new_game = GameCreator.create_sample_game(
             payload.scenario_id, payload.player_types
         )
     except ValueError as exc:

--- a/battle_hexes_api/tests/test_gamecreator.py
+++ b/battle_hexes_api/tests/test_gamecreator.py
@@ -1,11 +1,11 @@
 import unittest
 
-from battle_hexes_api.samplegame import SampleGameCreator
+from battle_hexes_api.gamecreator import GameCreator
 
 
-class TestSampleGameCreator(unittest.TestCase):
+class TestGameCreator(unittest.TestCase):
     def test_create_sample_game_uses_scenario_data(self):
-        game = SampleGameCreator.create_sample_game(
+        game = GameCreator.create_sample_game(
             "elim_1", ["human", "random"]
         )
 
@@ -41,7 +41,7 @@ class TestSampleGameCreator(unittest.TestCase):
 
     def test_create_sample_game_requires_matching_player_count(self):
         with self.assertRaises(ValueError):
-            SampleGameCreator.create_sample_game("elim_1", ["human"])
+            GameCreator.create_sample_game("elim_1", ["human"])
 
 
 if __name__ == "__main__":  # pragma: no cover - convenience


### PR DESCRIPTION
## Summary
- rename the sample game creator module and class to GameCreator
- update API endpoints, unit tests, and reinforcement learning helpers to reference the new name

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68eac39a55dc8327a208bc7f9ae39ae9