### PR TITLE
Add Scenario faction support to GameCreator

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/gamecreator/gamecreator.py
+++ b/battle_hexes_core/src/battle_hexes_core/gamecreator/gamecreator.py
@@ -45,15 +45,26 @@ class GameCreator:
             player1: Player,
             player2: Player
     ) -> None:
+        if not scenario.factions:
+            return
+
+        player_map = {
+            "Player 1": player1,
+            "Player 2": player2,
+            getattr(player1, "name", None): player1,
+            getattr(player2, "name", None): player2,
+        }
+
         for faction_data in scenario.factions:
             faction = Faction(
                 id=faction_data.id,
                 name=faction_data.name,
                 color=faction_data.color,
             )
-            if faction_data.player == 'Player 1':
-                player1.add_faction(faction)
-            elif faction_data.player == 'Player 2':
-                player2.add_faction(faction)
-            else:
-                raise NameError("Unknown player: " + faction_data.player)
+            try:
+                player = player_map[faction_data.player]
+            except KeyError as exc:
+                message = f"Unknown player: {faction_data.player}"
+                raise NameError(message) from exc
+
+            player.add_faction(faction)

--- a/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
+++ b/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
@@ -1,7 +1,42 @@
-from dataclasses import dataclass
+"""Core dataclasses that describe a scenario definition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class ScenarioFaction:
+    """Representation of a faction as defined in a scenario."""
+
+    id: str
+    name: str
+    color: str
+    player: str
+
+
+@dataclass(frozen=True)
+class ScenarioUnit:
+    """Representation of a unit as defined in a scenario."""
+
+    id: str
+    name: str
+    faction: str
+    type: str
+    attack: int
+    defense: int
+    movement: int
+    starting_coords: Tuple[int, int]
 
 
 @dataclass(frozen=True)
 class Scenario:
+    """Container for the data required to configure a game scenario."""
+
     id: str
     name: str
+    description: str | None = None
+    board_size: Tuple[int, int] | None = None
+    factions: tuple[ScenarioFaction, ...] = field(default_factory=tuple)
+    units: tuple[ScenarioUnit, ...] = field(default_factory=tuple)

--- a/battle_hexes_core/src/battle_hexes_core/scenario/scenarioregistry.py
+++ b/battle_hexes_core/src/battle_hexes_core/scenario/scenarioregistry.py
@@ -1,12 +1,11 @@
 from .scenario import Scenario
-from .scenario_loader import iter_scenario_data
+from .scenario_loader import iter_scenarios
 
 
 class ScenarioRegistry:
     def __init__(self):
         self._scenarios = {}
-        for scenario_data in iter_scenario_data():
-            scenario = Scenario(id=scenario_data.id, name=scenario_data.name)
+        for scenario in iter_scenarios():
             self._scenarios[scenario.id] = scenario
 
     def list_scenarios(self):

--- a/battle_hexes_core/tests/gamecreator/test_gamecreator.py
+++ b/battle_hexes_core/tests/gamecreator/test_gamecreator.py
@@ -3,8 +3,8 @@ import unittest
 from unittest.mock import Mock
 
 from battle_hexes_core.gamecreator.gamecreator import GameCreator
-from battle_hexes_core.scenario.scenario import Scenario
-from battle_hexes_core.game.player import Player
+from battle_hexes_core.scenario.scenario import Scenario, ScenarioFaction
+from battle_hexes_core.game.player import Player, PlayerType
 
 
 class TestGameCreator(unittest.TestCase):
@@ -19,6 +19,7 @@ class TestGameCreator(unittest.TestCase):
         # Set up mock scenario with specific board size
         mock_scenario = Mock(spec=Scenario)
         mock_scenario.board_size = (10, 20)
+        mock_scenario.factions = ()
 
         # Set up mock players
         mock_player1 = Mock(spec=Player)
@@ -40,6 +41,7 @@ class TestGameCreator(unittest.TestCase):
         # Set up test fixtures
         mock_scenario = Mock(spec=Scenario)
         mock_scenario.board_size = (8, 8)
+        mock_scenario.factions = ()
         mock_player1 = Mock(spec=Player)
         mock_player2 = Mock(spec=Player)
 
@@ -57,3 +59,53 @@ class TestGameCreator(unittest.TestCase):
 
         # Verify first player is set as current player
         self.assertEqual(game.current_player, mock_player1)
+
+    def test_assign_factions_adds_factions_to_players(self):
+        scenario = Scenario(
+            id="scenario-1",
+            name="Scenario",
+            factions=(
+                ScenarioFaction(
+                    id="faction-1",
+                    name="Faction One",
+                    color="#FF0000",
+                    player="Player 1",
+                ),
+                ScenarioFaction(
+                    id="faction-2",
+                    name="Faction Two",
+                    color="#0000FF",
+                    player="Player 2",
+                ),
+            ),
+        )
+
+        player1 = Player(name="Player 1", type=PlayerType.HUMAN, factions=[])
+        player2 = Player(name="Player 2", type=PlayerType.CPU, factions=[])
+
+        self.creator.assign_factions(scenario, player1, player2)
+
+        self.assertEqual(len(player1.factions), 1)
+        self.assertEqual(len(player2.factions), 1)
+        self.assertEqual(player1.factions[0].id, "faction-1")
+        self.assertEqual(player2.factions[0].id, "faction-2")
+
+    def test_assign_factions_raises_for_unknown_player(self):
+        scenario = Scenario(
+            id="scenario-1",
+            name="Scenario",
+            factions=(
+                ScenarioFaction(
+                    id="faction-1",
+                    name="Faction One",
+                    color="#FF0000",
+                    player="Player 3",
+                ),
+            ),
+        )
+
+        player1 = Player(name="Player 1", type=PlayerType.HUMAN, factions=[])
+        player2 = Player(name="Player 2", type=PlayerType.CPU, factions=[])
+
+        with self.assertRaises(NameError):
+            self.creator.assign_factions(scenario, player1, player2)


### PR DESCRIPTION
## Summary
- extend the core Scenario dataclasses to include faction and unit metadata
- convert scenario loading utilities and registry to build full Scenario objects
- teach GameCreator.assign_factions to map scenario factions to players and cover the behavior with tests

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68f3b667cd608327b05ff585adef57e2