### PR TITLE
Keep GameCreator stateless while adding units

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/gamecreator/gamecreator.py
+++ b/battle_hexes_core/src/battle_hexes_core/gamecreator/gamecreator.py
@@ -2,7 +2,8 @@ from battle_hexes_core.game.board import Board
 from battle_hexes_core.game.game import Game
 from battle_hexes_core.game.player import Player
 from battle_hexes_core.unit.faction import Faction
-from battle_hexes_core.scenario.scenario import Scenario
+from battle_hexes_core.unit.unit import Unit
+from battle_hexes_core.scenario.scenario import Scenario, ScenarioUnit
 
 
 class GameCreator:
@@ -11,10 +12,6 @@ class GameCreator:
     This class will be responsible for handling game creation and
     initialization.
     """
-
-    def __init__(self):
-        """Initialize a new GameCreator instance."""
-        pass
 
     def create_game(
         self,
@@ -34,8 +31,17 @@ class GameCreator:
             Game: A new game instance with the specified configuration.
         """
         board = Board(*scenario.board_size)
-        self.assign_factions(scenario, player1, player2)
-        self.add_units(board, scenario.units)
+        faction_by_id, player_by_faction_id = self.assign_factions(
+            scenario,
+            player1,
+            player2,
+        )
+        self.add_units(
+            board,
+            scenario.units,
+            faction_by_id,
+            player_by_faction_id,
+        )
         return Game(
             players=[player1, player2],
             board=board
@@ -46,9 +52,11 @@ class GameCreator:
             scenario: Scenario,
             player1: Player,
             player2: Player
-    ) -> None:
+    ) -> tuple[dict[str, Faction], dict[str, Player]]:
+        faction_by_id: dict[str, Faction] = {}
+        player_by_faction_id: dict[str, Player] = {}
         if not scenario.factions:
-            return
+            return faction_by_id, player_by_faction_id
 
         player_map = {
             "Player 1": player1,
@@ -69,8 +77,37 @@ class GameCreator:
                 message = f"Unknown player: {faction_data.player}"
                 raise NameError(message) from exc
 
+            faction_by_id[faction.id] = faction
+            player_by_faction_id[faction.id] = player
             player.add_faction(faction)
 
-    def add_units(self, board: Board, units):
-        # TODO implement me and add a type hint to the units parameter
-        pass
+        return faction_by_id, player_by_faction_id
+
+    def add_units(
+        self,
+        board: Board,
+        units: tuple[ScenarioUnit, ...],
+        faction_by_id: dict[str, Faction],
+        player_by_faction_id: dict[str, Player],
+    ) -> None:
+        for unit_data in units:
+            try:
+                faction = faction_by_id[unit_data.faction]
+                owner = player_by_faction_id[unit_data.faction]
+            except KeyError as exc:
+                message = f"Unknown faction: {unit_data.faction}"
+                raise NameError(message) from exc
+
+            unit = Unit(
+                unit_data.id,
+                unit_data.name,
+                faction,
+                owner,
+                unit_data.type,
+                unit_data.attack,
+                unit_data.defense,
+                unit_data.movement,
+            )
+
+            row, column = unit_data.starting_coords
+            board.add_unit(unit, row, column)


### PR DESCRIPTION
## Summary
- remove GameCreator's internal faction caches and return mappings from `assign_factions`
- pass faction/player mappings into `add_units` and extend tests to cover the new contract

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68f3bfd43f488327a944ba7b754e4487

Refs #130 