### PR TITLE
Refactor core player model and add API schema

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -26,7 +26,7 @@ from battle_hexes_api.player_types import list_player_types  # noqa: E402
 from battle_hexes_api.gamecreator import GameCreator  # noqa: E402
 from battle_hexes_api.schemas import (  # noqa: E402
     CreateGameRequest,
-    FactionModel,
+    PlayerModel,
     PlayerTypeModel,
     ScenarioModel,
 )
@@ -57,13 +57,10 @@ def _serialize_game(game) -> dict:
 
     game_model = game.to_game_model()
     model = game_model.model_dump()
-
-    players = model.get("players", [])
-    for player_model, serialized_player in zip(game_model.players, players):
-        serialized_player["factions"] = [
-            FactionModel.from_core(faction).model_dump()
-            for faction in player_model.factions
-        ]
+    model["players"] = [
+        PlayerModel.from_core(player).model_dump()
+        for player in game_model.players
+    ]
 
     scenario_id = getattr(game, "scenario_id", None)
     if scenario_id is not None:

--- a/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
@@ -2,12 +2,14 @@
 
 from .create_game import CreateGameRequest
 from .faction import FactionModel
+from .player import PlayerModel
 from .player_type import PlayerTypeModel
 from .scenario import ScenarioModel
 
 __all__ = [
     "CreateGameRequest",
     "FactionModel",
+    "PlayerModel",
     "PlayerTypeModel",
     "ScenarioModel",
 ]

--- a/battle_hexes_api/src/battle_hexes_api/schemas/player.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/player.py
@@ -1,0 +1,61 @@
+"""Pydantic schema for player resources."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from battle_hexes_core.game.player import Player, PlayerType
+
+from .faction import FactionModel
+
+
+class PlayerModel(BaseModel):
+    """Pydantic representation of a core :class:`Player`."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    name: str
+    type: str
+    factions: list[FactionModel]
+
+    @classmethod
+    def from_core(cls, player: Player) -> "PlayerModel":
+        """Create a ``PlayerModel`` from a core :class:`Player`."""
+
+        player_type = (
+            player.type.value
+            if isinstance(player.type, PlayerType)
+            else str(player.type)
+        )
+        return cls(
+            name=player.name,
+            type=player_type,
+            factions=[
+                FactionModel.from_core(faction)
+                for faction in player.factions
+            ],
+        )
+
+    def to_core(self) -> Player:
+        """Convert the schema back into a core :class:`Player`."""
+
+        factions = [faction.to_core() for faction in self.factions]
+
+        if isinstance(self.type, PlayerType):
+            player_type = self.type
+        elif isinstance(self.type, str):
+            try:
+                player_type = PlayerType(self.type)
+            except ValueError:
+                try:
+                    player_type = PlayerType[self.type]
+                except KeyError as exc:
+                    raise ValueError(
+                        f"Unsupported player type value: {self.type!r}"
+                    ) from exc
+        else:
+            raise TypeError(
+                "PlayerModel.type must be a string or PlayerType instance"
+            )
+
+        return Player(name=self.name, type=player_type, factions=factions)

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from battle_hexes_api.main import app, _serialize_game
 from battle_hexes_api.player_types import PlayerTypeDefinition
+from battle_hexes_core.game.player import Player, PlayerType
 from battle_hexes_core.game.sparseboard import SparseBoard
 from battle_hexes_core.scenario.scenario import Scenario
 from battle_hexes_core.unit.faction import Faction
@@ -243,14 +244,17 @@ class TestFastAPI(unittest.TestCase):
         faction_alpha = Faction(id="alpha", name="Alpha", color="#ff0000")
         faction_beta = Faction(id="beta", name="Beta", color="#00ff00")
 
-        class DummyPlayer:
-            def __init__(self, name, factions):
-                self.name = name
-                self.factions = factions
-
         players = [
-            DummyPlayer("Alice", [faction_alpha]),
-            DummyPlayer("Bob", [faction_beta]),
+            Player(
+                name="Alice",
+                type=PlayerType.HUMAN,
+                factions=[faction_alpha],
+            ),
+            Player(
+                name="Bob",
+                type=PlayerType.CPU,
+                factions=[faction_beta],
+            ),
         ]
 
         class DummyGameModel:
@@ -261,10 +265,7 @@ class TestFastAPI(unittest.TestCase):
                 return {
                     "id": "game-123",
                     "board": {"hexes": []},
-                    "players": [
-                        {"name": player.name, "factions": ["placeholder"]}
-                        for player in self.players
-                    ],
+                    "players": [{} for _ in self.players],
                 }
 
         class DummyGame:
@@ -290,12 +291,14 @@ class TestFastAPI(unittest.TestCase):
             [
                 {
                     "name": "Alice",
+                    "type": PlayerType.HUMAN.value,
                     "factions": [
                         {"id": "alpha", "name": "Alpha", "color": "#ff0000"}
                     ],
                 },
                 {
                     "name": "Bob",
+                    "type": PlayerType.CPU.value,
                     "factions": [
                         {"id": "beta", "name": "Beta", "color": "#00ff00"}
                     ],

--- a/battle_hexes_api/tests/test_schemas_player.py
+++ b/battle_hexes_api/tests/test_schemas_player.py
@@ -1,0 +1,75 @@
+"""Tests for the :mod:`battle_hexes_api.schemas.player` module."""
+
+import pytest
+
+from battle_hexes_api.schemas import FactionModel, PlayerModel
+from battle_hexes_core.game.player import Player, PlayerType
+from battle_hexes_core.unit.faction import Faction
+
+
+def test_player_model_from_core_serializes_factions_and_type():
+    faction = Faction(id="alpha", name="Alpha", color="#ff0000")
+    player = Player(name="Alice", type=PlayerType.HUMAN, factions=[faction])
+
+    model = PlayerModel.from_core(player)
+
+    assert model.name == "Alice"
+    assert model.type == PlayerType.HUMAN.value
+    assert len(model.factions) == 1
+    assert model.factions[0].model_dump() == {
+        "id": "alpha",
+        "name": "Alpha",
+        "color": "#ff0000",
+    }
+
+    assert model.model_dump() == {
+        "name": "Alice",
+        "type": PlayerType.HUMAN.value,
+        "factions": [
+            {"id": "alpha", "name": "Alpha", "color": "#ff0000"},
+        ],
+    }
+
+
+def test_player_model_to_core_round_trip():
+    faction = Faction(id="beta", name="Beta", color="#00ff00")
+    player = Player(name="Bob", type=PlayerType.CPU, factions=[faction])
+
+    model = PlayerModel.from_core(player)
+    rebuilt = model.to_core()
+
+    assert rebuilt.name == "Bob"
+    assert rebuilt.type == PlayerType.CPU
+    assert rebuilt.factions == [faction]
+    assert rebuilt is not player
+
+
+def test_player_model_to_core_accepts_enum_type():
+    faction = Faction(id="gamma", name="Gamma", color="#0000ff")
+    faction_model = FactionModel.from_core(faction)
+
+    model = PlayerModel(
+        name="Carol",
+        type=PlayerType.HUMAN,
+        factions=[faction_model],
+    )
+
+    rebuilt = model.to_core()
+
+    assert rebuilt.name == "Carol"
+    assert rebuilt.type == PlayerType.HUMAN
+    assert rebuilt.factions == [faction]
+
+
+def test_player_model_to_core_invalid_type_raises_value_error():
+    faction = Faction(id="zeta", name="Zeta", color="#abcdef")
+    faction_model = FactionModel.from_core(faction)
+
+    model = PlayerModel(
+        name="Dana",
+        type="Unknown",
+        factions=[faction_model],
+    )
+
+    with pytest.raises(ValueError):
+        model.to_core()

--- a/battle_hexes_core/src/battle_hexes_core/game/game.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/game.py
@@ -3,12 +3,14 @@ from battle_hexes_core.game.player import Player
 from battle_hexes_core.game.sparseboard import SparseBoard
 from battle_hexes_core.unit.faction import Faction
 from battle_hexes_core.game.unitmovementplan import UnitMovementPlan
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import List
 import uuid
 
 
 class GameModel(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     id: uuid.UUID
     players: List[Player]
     board: BoardModel

--- a/battle_hexes_core/src/battle_hexes_core/game/player.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/player.py
@@ -1,6 +1,6 @@
-from pydantic import BaseModel, ConfigDict
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import List
+from typing import Iterable, List
 from battle_hexes_core.combat.combatresults import CombatResults
 from battle_hexes_core.unit.faction import Faction
 from battle_hexes_core.game.unitmovementplan import UnitMovementPlan
@@ -11,12 +11,15 @@ class PlayerType(Enum):
     CPU = "Computer"
 
 
-class Player(BaseModel):
+@dataclass
+class Player:
     name: str
     type: PlayerType
-    factions: List[Faction]
+    factions: List[Faction] = field(default_factory=list)
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    def __post_init__(self) -> None:
+        # Store factions as a concrete list to match the previous behaviour.
+        self.factions = list(self.factions)
 
     def add_faction(self, faction: Faction) -> None:
         self.factions.append(faction)
@@ -27,7 +30,7 @@ class Player(BaseModel):
     def owns(self, unit) -> bool:
         return unit.faction in self.factions
 
-    def own_units(self, units) -> List:
+    def own_units(self, units: Iterable) -> List:
         return [unit for unit in units if self.owns(unit)]
 
     def movement(self) -> List[UnitMovementPlan]:

--- a/battle_hexes_core/tests/game/test_player.py
+++ b/battle_hexes_core/tests/game/test_player.py
@@ -1,5 +1,7 @@
 import unittest
+
 from battle_hexes_core.game.player import Player, PlayerType
+from battle_hexes_core.unit.faction import Faction
 
 
 class TestPlayer(unittest.TestCase):
@@ -7,3 +9,52 @@ class TestPlayer(unittest.TestCase):
         player = Player(name='P1', type=PlayerType.HUMAN, factions=[])
         with self.assertRaises(NotImplementedError):
             player.movement()
+
+    def test_owns_and_own_units(self):
+        faction = Faction(id="alpha", name="Alpha", color="#ff0000")
+        other_faction = Faction(id="beta", name="Beta", color="#00ff00")
+        player = Player(
+            name="Commander",
+            type=PlayerType.HUMAN,
+            factions=[faction],
+        )
+
+        owned_unit = type("Unit", (), {"faction": faction})()
+        enemy_unit = type("Unit", (), {"faction": other_faction})()
+
+        self.assertTrue(player.owns(owned_unit))
+        self.assertFalse(player.owns(enemy_unit))
+        self.assertEqual(
+            [owned_unit],
+            player.own_units([owned_unit, enemy_unit]),
+        )
+
+    def test_factions_iterable_is_copied(self):
+        faction = Faction(id="gamma", name="Gamma", color="#0000ff")
+        player = Player(
+            name="Strategist",
+            type=PlayerType.CPU,
+            factions=(faction,),
+        )
+
+        self.assertEqual([faction], player.factions)
+        self.assertIsInstance(player.factions, list)
+
+    def test_player_factions_are_independent_from_source(self):
+        faction = Faction(id="delta", name="Delta", color="#ffff00")
+        other_faction = Faction(id="epsilon", name="Epsilon", color="#123456")
+        factions = [faction]
+        player = Player(
+            name="Tactician",
+            type=PlayerType.HUMAN,
+            factions=factions,
+        )
+
+        self.assertIsNot(player.factions, factions)
+
+        player.factions.append(other_faction)
+        self.assertEqual([faction], factions)
+
+        factions.append(other_faction)
+        self.assertEqual([faction, other_faction], factions)
+        self.assertEqual([faction, other_faction], player.factions)


### PR DESCRIPTION
## Summary
- replace the core Player BaseModel with a dataclass and adjust GameModel configuration to allow storing core players without Pydantic
- add a PlayerModel schema for the API and update game serialization to rely on it for player and faction data
- expand unit tests for both the core player logic and the new API schema

## Testing
- ./server-side-checks.sh

Refs #130 

------
https://chatgpt.com/codex/tasks/task_e_68f4ef473b5c83279302049e8ba2cc7c