### PR TITLE
Refactor board schema conversions into API models

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -151,7 +151,7 @@ def resolve_combat(
 
     game_repo.update_game(game)
     _call_end_game_callbacks(game)
-    sparse_board = game.get_board().to_sparse_board()
+    sparse_board = SparseBoard.from_board(game.get_board())
     sparse_board.last_combat_results = results.battles_as_result_schema()
     return sparse_board
 

--- a/battle_hexes_api/src/battle_hexes_api/schemas/board.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/board.py
@@ -1,10 +1,13 @@
 """Board-related Pydantic schemas used by the API."""
 
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from pydantic import BaseModel
 
 from .unit import UnitModel
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from battle_hexes_core.game.board import Board
 
 
 class BoardModel(BaseModel):
@@ -13,3 +16,14 @@ class BoardModel(BaseModel):
     rows: int
     columns: int
     units: List[UnitModel]
+
+    @classmethod
+    def from_board(cls, board: "Board") -> "BoardModel":
+        """Create a ``BoardModel`` from the core ``Board`` instance."""
+
+        units = [unit.to_unit_model() for unit in board.get_units()]
+        return cls(
+            rows=board.get_rows(),
+            columns=board.get_columns(),
+            units=units,
+        )

--- a/battle_hexes_api/src/battle_hexes_api/schemas/sparseboard.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/sparseboard.py
@@ -1,18 +1,21 @@
 """Schemas describing sparse board representations."""
 
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from battle_hexes_core.combat.combatresult import CombatResultSchema
 
 from .unit import SparseUnit
 
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from battle_hexes_core.game.board import Board
+
 
 class SparseBoard(BaseModel):
     """A lightweight representation of the game board used by the API."""
 
-    units: List[SparseUnit] = []
+    units: List[SparseUnit] = Field(default_factory=list)
     last_combat_results: Optional[List[CombatResultSchema]] = None
 
     def add_unit(self, unit: SparseUnit) -> None:
@@ -20,3 +23,18 @@ class SparseBoard(BaseModel):
 
     def get_units(self) -> List[SparseUnit]:
         return self.units
+
+    @classmethod
+    def from_board(cls, board: "Board") -> "SparseBoard":
+        """Create a ``SparseBoard`` from the provided ``Board``."""
+
+        units = [unit.to_sparse_unit() for unit in board.get_units()]
+        return cls(units=units)
+
+    def apply_to_board(self, board: "Board") -> None:
+        """Update ``board`` to match the data contained in this schema."""
+
+        for unit_data in self.units:
+            unit_id = str(unit_data.id)
+            unit = board.get_unit_by_id(unit_id)
+            unit.set_coords(unit_data.row, unit_data.column)

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -91,8 +91,9 @@ class TestFastAPI(unittest.TestCase):
         )
         mock_registry.list_scenarios.assert_called_once_with()
 
+    @patch('battle_hexes_api.main.SparseBoard.from_board')
     @patch('battle_hexes_api.main.game_repo')
-    def test_resolve_combat_placeholder(self, mock_game_repo):
+    def test_resolve_combat_placeholder(self, mock_game_repo, mock_from_board):
         mock_board = MagicMock()
         sparse_board_data = {
             "units": []
@@ -103,6 +104,7 @@ class TestFastAPI(unittest.TestCase):
         mock_game.id = game_id
         mock_game_repo.get_game.return_value = mock_game
         mock_game.get_board.return_value = mock_board
+        mock_from_board.return_value = MagicMock()
 
         self.client.post(
             f"/games/{game_id}/combat", json=sparse_board_data)
@@ -110,12 +112,13 @@ class TestFastAPI(unittest.TestCase):
         mock_game.update.assert_called_once_with(
             SparseBoard(**sparse_board_data))
         mock_game_repo.update_game.assert_called_once_with(mock_game)
-        mock_board.to_sparse_board.assert_called_once()
+        mock_from_board.assert_called_once_with(mock_board)
 
+    @patch('battle_hexes_api.main.SparseBoard.from_board')
     @patch('battle_hexes_api.main.Combat')
     @patch('battle_hexes_api.main.game_repo')
     def test_resolve_combat_calls_end_game_callback_when_game_over(
-        self, mock_game_repo, mock_combat
+        self, mock_game_repo, mock_combat, mock_from_board
     ):
         mock_board = MagicMock()
         mock_game = MagicMock()
@@ -129,6 +132,8 @@ class TestFastAPI(unittest.TestCase):
 
         game_id = "game-123"
         sparse_board_data = {"units": []}
+
+        mock_from_board.return_value = MagicMock()
 
         self.client.post(
             f"/games/{game_id}/combat", json=sparse_board_data

--- a/battle_hexes_core/src/battle_hexes_core/game/board.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/board.py
@@ -4,8 +4,6 @@ from typing import List, Set, Tuple
 
 from battle_hexes_core.game.hex import Hex
 from battle_hexes_core.unit.unit import Unit
-from battle_hexes_api.schemas.board import BoardModel
-from battle_hexes_api.schemas.sparseboard import SparseBoard
 
 
 class Board:
@@ -89,12 +87,6 @@ class Board:
         if not unit:
             raise KeyError(f"No unit found with ID {unit_id}")
         return unit
-
-    def update(self, sparse_board: SparseBoard) -> None:
-        for unit_data in sparse_board.units:
-            unit_id = str(unit_data.id)
-            unit = self.get_unit_by_id(unit_id)
-            unit.set_coords(unit_data.row, unit_data.column)
 
     def find_units(self, factions) -> List[Unit]:
         if isinstance(factions, Iterable):
@@ -358,11 +350,3 @@ class Board:
             if unit.get_coords() in hexes:
                 units.append(unit)
         return units
-
-    def to_board_model(self) -> BoardModel:
-        units = [unit.to_unit_model() for unit in self.get_units()]
-        return BoardModel(rows=self.rows, columns=self.columns, units=units)
-
-    def to_sparse_board(self) -> SparseBoard:
-        units = [unit.to_sparse_unit() for unit in self.get_units()]
-        return SparseBoard(units=units)

--- a/battle_hexes_core/src/battle_hexes_core/game/game.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/game.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import List
 
+from battle_hexes_api.schemas.board import BoardModel
 from battle_hexes_api.schemas.game import GameModel
 from battle_hexes_api.schemas.sparseboard import SparseBoard
 from battle_hexes_core.game.board import Board
@@ -27,7 +28,7 @@ class Game:
         return self.board
 
     def update(self, sparse_board: SparseBoard) -> None:
-        self.board.update(sparse_board)
+        sparse_board.apply_to_board(self.board)
 
     def get_current_player(self) -> Player:
         return self.current_player
@@ -53,7 +54,7 @@ class Game:
         return GameModel(
             id=self.id,
             players=self.players,
-            board=self.board.to_board_model()
+            board=BoardModel.from_board(self.board)
         )
 
     def get_opposing_factions(self, faction: Faction) -> List[Faction]:

--- a/battle_hexes_core/tests/game/test_board.py
+++ b/battle_hexes_core/tests/game/test_board.py
@@ -70,7 +70,7 @@ class TestBoard(unittest.TestCase):
                 {"id": str(self.blue_unit.get_id()), "row": 3, "column": 2},
             ]
         }
-        self.board.update(SparseBoard(**sparse_board_data))
+        SparseBoard(**sparse_board_data).apply_to_board(self.board)
 
         self.assertEqual(self.red_unit.get_coords(), (2, 3))
         self.assertEqual(self.blue_unit.get_coords(), (3, 2))
@@ -164,7 +164,7 @@ class TestBoard(unittest.TestCase):
     def test_to_board_model_returns_schema(self):
         self.board.add_unit(self.red_unit, 0, 0)
 
-        board_model = self.board.to_board_model()
+        board_model = BoardModel.from_board(self.board)
 
         self.assertIsInstance(board_model, BoardModel)
         self.assertEqual(board_model.rows, self.board.get_rows())


### PR DESCRIPTION
## Summary
- add factory and update helpers to the API board schemas so they operate directly on the core board
- remove serialization logic from the core Board class and update the Game facade and API entry points
- refresh unit tests to exercise the new helper methods and expectations

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68f57b1f492c8327bb73456969e329d6