### PR TITLE
Refactor game serialization to use GameModel.from_game

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -26,6 +26,7 @@ from battle_hexes_api.player_types import list_player_types  # noqa: E402
 from battle_hexes_api.gamecreator import GameCreator  # noqa: E402
 from battle_hexes_api.schemas import (  # noqa: E402
     CreateGameRequest,
+    GameModel,
     PlayerTypeModel,
     ScenarioModel,
 )
@@ -54,7 +55,7 @@ app.add_middleware(
 def _serialize_game(game) -> dict:
     """Return a JSON-serialisable representation of ``game``."""
 
-    model = game.to_game_model().model_dump()
+    model = GameModel.from_game(game).model_dump()
 
     scenario_id = getattr(game, "scenario_id", None)
     if scenario_id is not None:
@@ -161,7 +162,7 @@ def generate_movement(game_id: str):
     game_repo.update_game(game)
     _call_end_game_callbacks(game)
     return {
-        "game": game.to_game_model(),
+        "game": GameModel.from_game(game).model_dump(),
         "plans": [p.to_dict() for p in plans],
     }
 
@@ -184,4 +185,4 @@ def end_turn(game_id: str, sparse_board: SparseBoard = Body(...)):
 
     game_repo.update_game(game)
     _call_end_game_callbacks(game)
-    return game.to_game_model()
+    return GameModel.from_game(game).model_dump()

--- a/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
@@ -1,7 +1,13 @@
 """Pydantic schemas for the Battle Hexes API."""
 
 from .create_game import CreateGameRequest
+from .game import GameModel
 from .player_type import PlayerTypeModel
 from .scenario import ScenarioModel
 
-__all__ = ["CreateGameRequest", "PlayerTypeModel", "ScenarioModel"]
+__all__ = [
+    "CreateGameRequest",
+    "GameModel",
+    "PlayerTypeModel",
+    "ScenarioModel",
+]

--- a/battle_hexes_api/src/battle_hexes_api/schemas/game.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/game.py
@@ -1,0 +1,31 @@
+"""Pydantic schema representations of core ``Game`` objects."""
+
+from __future__ import annotations
+
+from typing import List, TYPE_CHECKING
+import uuid
+
+from pydantic import BaseModel
+
+from battle_hexes_core.game.board import BoardModel
+from battle_hexes_core.game.player import Player
+
+if TYPE_CHECKING:
+    from battle_hexes_core.game.game import Game
+
+
+class GameModel(BaseModel):
+    """Serializable representation of a core ``Game`` instance."""
+
+    id: uuid.UUID
+    players: List[Player]
+    board: BoardModel
+
+    @classmethod
+    def from_game(cls, game: "Game") -> "GameModel":
+        """Create a ``GameModel`` instance from a ``Game`` object."""
+        return cls(
+            id=game.get_id(),
+            players=game.get_players(),
+            board=game.get_board().to_board_model(),
+        )

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -135,16 +135,19 @@ class TestFastAPI(unittest.TestCase):
         mock_player1.end_game_cb.assert_called_once_with()
         mock_player2.end_game_cb.assert_called_once_with()
 
+    @patch('battle_hexes_api.main.GameModel.from_game')
     @patch('battle_hexes_api.main.game_repo')
-    def test_generate_movement(self, mock_game_repo):
+    def test_generate_movement(self, mock_game_repo, mock_from_game):
         mock_plan = MagicMock()
         mock_player = MagicMock()
         mock_player.movement.return_value = [mock_plan]
         mock_plan.to_dict.return_value = {"plan": 1}
         mock_game = MagicMock()
         mock_game.get_current_player.return_value = mock_player
-        mock_game.to_game_model.return_value = {"id": "game-456"}
         mock_game_repo.get_game.return_value = mock_game
+        mock_from_game.return_value.model_dump.return_value = {
+            "id": "game-456"
+        }
 
         game_id = "game-456"
         response = self.client.post(f"/games/{game_id}/movement")
@@ -152,16 +155,17 @@ class TestFastAPI(unittest.TestCase):
         mock_player.movement.assert_called_once_with()
         mock_game.apply_movement_plans.assert_called_once_with([mock_plan])
         mock_game_repo.update_game.assert_called_once_with(mock_game)
-        mock_game.to_game_model.assert_called_once_with()
+        mock_from_game.assert_called_once_with(mock_game)
         mock_plan.to_dict.assert_called_once_with()
         self.assertEqual(
             response.json(),
             {"game": {"id": "game-456"}, "plans": [{"plan": 1}]},
         )
 
+    @patch('battle_hexes_api.main.GameModel.from_game')
     @patch('battle_hexes_api.main.game_repo')
     def test_end_turn_updates_game_and_returns_game_model(
-        self, mock_game_repo
+        self, mock_game_repo, mock_from_game
     ):
         mock_game = MagicMock()
         mock_old_player = MagicMock()
@@ -170,11 +174,11 @@ class TestFastAPI(unittest.TestCase):
         mock_new_player.name = "Bob"
         mock_game.get_current_player.return_value = mock_old_player
         mock_game.next_player.return_value = mock_new_player
-        mock_game.to_game_model.return_value = {
+        mock_game_repo.get_game.return_value = mock_game
+        mock_from_game.return_value.model_dump.return_value = {
             "id": "game-789",
             "current_player": "Bob"
         }
-        mock_game_repo.get_game.return_value = mock_game
 
         game_id = "game-789"
         sparse_board_data = {"units": []}
@@ -190,16 +194,17 @@ class TestFastAPI(unittest.TestCase):
         mock_game.get_current_player.assert_called_once_with()
         mock_game.next_player.assert_called_once_with()
         mock_game_repo.update_game.assert_called_once_with(mock_game)
-        mock_game.to_game_model.assert_called_once_with()
+        mock_from_game.assert_called_once_with(mock_game)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
             {"id": "game-789", "current_player": "Bob"}
         )
 
+    @patch('battle_hexes_api.main.GameModel.from_game')
     @patch('battle_hexes_api.main.game_repo')
     def test_end_turn_calls_end_game_callback_when_game_over(
-        self, mock_game_repo
+        self, mock_game_repo, mock_from_game
     ):
         mock_player1 = MagicMock()
         mock_player2 = MagicMock()
@@ -208,8 +213,8 @@ class TestFastAPI(unittest.TestCase):
         mock_game.next_player.return_value = MagicMock()
         mock_game.get_players.return_value = [mock_player1, mock_player2]
         mock_game.is_game_over.return_value = True
-        mock_game.to_game_model.return_value = {}
         mock_game_repo.get_game.return_value = mock_game
+        mock_from_game.return_value.model_dump.return_value = {}
 
         game_id = "game-789"
         self.client.post(
@@ -218,6 +223,7 @@ class TestFastAPI(unittest.TestCase):
 
         mock_player1.end_game_cb.assert_called_once_with()
         mock_player2.end_game_cb.assert_called_once_with()
+        mock_from_game.assert_called_once_with(mock_game)
 
     @patch('battle_hexes_api.main.list_player_types')
     def test_get_player_types(self, mock_list_player_types):

--- a/battle_hexes_api/tests/test_schemas_game.py
+++ b/battle_hexes_api/tests/test_schemas_game.py
@@ -1,0 +1,19 @@
+import unittest
+
+from battle_hexes_api.schemas.game import GameModel
+from battle_hexes_core.game.board import Board
+from battle_hexes_core.game.game import Game
+from battle_hexes_core.game.player import Player, PlayerType
+
+
+class TestGameModel(unittest.TestCase):
+    def test_from_game_matches_game_state(self):
+        board = Board(3, 4)
+        player = Player(name="Test", type=PlayerType.HUMAN, factions=[])
+        game = Game([player], board)
+
+        model = GameModel.from_game(game)
+
+        self.assertEqual(model.id, game.get_id())
+        self.assertEqual(model.players, game.get_players())
+        self.assertEqual(model.board, board.to_board_model())

--- a/battle_hexes_core/src/battle_hexes_core/game/game.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/game.py
@@ -1,17 +1,10 @@
-from battle_hexes_core.game.board import Board, BoardModel
+from battle_hexes_core.game.board import Board
 from battle_hexes_core.game.player import Player
 from battle_hexes_core.game.sparseboard import SparseBoard
 from battle_hexes_core.unit.faction import Faction
 from battle_hexes_core.game.unitmovementplan import UnitMovementPlan
-from pydantic import BaseModel
 from typing import List
 import uuid
-
-
-class GameModel(BaseModel):
-    id: uuid.UUID
-    players: List[Player]
-    board: BoardModel
 
 
 class Game:
@@ -53,13 +46,6 @@ class Game:
         idx = self.players.index(self.current_player)
         self.current_player = self.players[(idx + 1) % len(self.players)]
         return self.current_player
-
-    def to_game_model(self) -> GameModel:
-        return GameModel(
-            id=self.id,
-            players=self.players,
-            board=self.board.to_board_model()
-        )
 
     def get_opposing_factions(self, faction: Faction) -> List[Faction]:
         owning_player = self.get_player_for_faction(faction)


### PR DESCRIPTION
## Summary
- add a GameModel.from_game constructor and remove the Game-to-GameModel dependency
- switch API endpoints to serialize games through GameModel.from_game
- move GameModel into the API schemas package and re-export it for consumers
- update unit tests to cover the new conversion flow and relocated schema

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_69053546e5d083278035c6f6f0241a75