### PR TITLE
Decouple core Game class from API sparse board schema

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -145,7 +145,7 @@ def resolve_combat(
 ) -> SparseBoard:
     logger.info("We got game: %s", game_id)
     game = _get_game_or_404(game_id)
-    game.update(sparse_board)
+    sparse_board.apply_to_board(game.get_board())
 
     results = Combat(game).resolve_combat()
     logger.info('Combat results: %s', results)
@@ -179,7 +179,7 @@ def end_turn(game_id: str, sparse_board: SparseBoard = Body(...)):
     game = _get_game_or_404(game_id)
 
     # sync the server-side board state with the client provided one
-    game.update(sparse_board)
+    sparse_board.apply_to_board(game.get_board())
 
     old_player = game.get_current_player()
     new_player = game.next_player()

--- a/battle_hexes_core/src/battle_hexes_core/game/game.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/game.py
@@ -1,7 +1,6 @@
 import uuid
 from typing import List
 
-from battle_hexes_api.schemas.sparseboard import SparseBoard
 from battle_hexes_core.game.board import Board
 from battle_hexes_core.game.player import Player
 from battle_hexes_core.game.unitmovementplan import UnitMovementPlan
@@ -24,9 +23,6 @@ class Game:
 
     def get_board(self):
         return self.board
-
-    def update(self, sparse_board: SparseBoard) -> None:
-        sparse_board.apply_to_board(self.board)
 
     def get_current_player(self) -> Player:
         return self.current_player


### PR DESCRIPTION
## Summary
- remove the SparseBoard dependency from the core Game class
- update API endpoints to apply sparse board updates directly to the board
- adjust FastAPI tests to cover the new synchronization behavior

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_6906071c80b48327aedf3ce61e202bda