### PR TITLE
Refactor sparse unit creation

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/schemas/sparseboard.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/sparseboard.py
@@ -28,7 +28,7 @@ class SparseBoard(BaseModel):
     def from_board(cls, board: "Board") -> "SparseBoard":
         """Create a ``SparseBoard`` from the provided ``Board``."""
 
-        units = [unit.to_sparse_unit() for unit in board.get_units()]
+        units = [SparseUnit.from_unit(unit) for unit in board.get_units()]
         return cls(units=units)
 
     def apply_to_board(self, board: "Board") -> None:

--- a/battle_hexes_api/src/battle_hexes_api/schemas/unit.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/unit.py
@@ -1,6 +1,11 @@
 """Pydantic models for unit entities."""
 
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from battle_hexes_core.unit.unit import Unit
 
 
 class UnitModel(BaseModel):
@@ -21,3 +26,9 @@ class SparseUnit(BaseModel):
     id: str
     row: int
     column: int
+
+    @classmethod
+    def from_unit(cls, unit: "Unit") -> "SparseUnit":
+        """Create a sparse unit model from a core :class:`Unit`."""
+
+        return cls(id=str(unit.id), row=unit.row, column=unit.column)

--- a/battle_hexes_api/tests/test_schemas.py
+++ b/battle_hexes_api/tests/test_schemas.py
@@ -1,6 +1,6 @@
 import unittest
 
-from battle_hexes_api.schemas import GameModel, ScenarioModel
+from battle_hexes_api.schemas import GameModel, ScenarioModel, SparseUnit
 from battle_hexes_core.game.board import Board
 from battle_hexes_core.game.game import Game
 from battle_hexes_core.game.player import Player, PlayerType
@@ -54,3 +54,31 @@ class TestGameModel(unittest.TestCase):
         self.assertEqual(unit_model.id, "u1")
         self.assertEqual(unit_model.row, 0)
         self.assertEqual(unit_model.column, 1)
+
+
+class TestSparseUnit(unittest.TestCase):
+    def test_from_unit(self):
+        faction = Faction(id="f2", name="Faction 2", color="#000000")
+        player = Player(
+            name="Bob",
+            type=PlayerType.HUMAN,
+            factions=[faction],
+        )
+        unit = Unit(
+            id="u2",
+            name="Unit 2",
+            faction=faction,
+            player=player,
+            type="Infantry",
+            attack=4,
+            defense=3,
+            move=2,
+            row=5,
+            column=7,
+        )
+
+        sparse_unit = SparseUnit.from_unit(unit)
+
+        self.assertEqual(sparse_unit.id, "u2")
+        self.assertEqual(sparse_unit.row, 5)
+        self.assertEqual(sparse_unit.column, 7)

--- a/battle_hexes_core/src/battle_hexes_core/unit/unit.py
+++ b/battle_hexes_core/src/battle_hexes_core/unit/unit.py
@@ -1,6 +1,6 @@
 from battle_hexes_core.game.player import Player
 from battle_hexes_core.unit.faction import Faction
-from battle_hexes_api.schemas.unit import UnitModel, SparseUnit
+from battle_hexes_api.schemas.unit import UnitModel
 
 
 class Unit:
@@ -164,9 +164,6 @@ class Unit:
                          move=self.move,
                          row=self.row,
                          column=self.column)
-
-    def to_sparse_unit(self) -> SparseUnit:
-        return SparseUnit(id=str(self.id), row=self.row, column=self.column)
 
     def __str__(self):
         return f"{self.name} ({self.faction.name}) " + \


### PR DESCRIPTION
## Summary
- add a `SparseUnit.from_unit` helper and update the API schemas to use it
- remove the `Unit.to_sparse_unit` method from the core package to centralize sparse conversions
- expand schema tests to cover the new conversion helper

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_69061bab20888327afe13b1f1817e536