### PR TITLE
Refactor unit schema conversion

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/schemas/board.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/board.py
@@ -21,7 +21,7 @@ class BoardModel(BaseModel):
     def from_board(cls, board: "Board") -> "BoardModel":
         """Create a ``BoardModel`` from the core ``Board`` instance."""
 
-        units = [unit.to_unit_model() for unit in board.get_units()]
+        units = [UnitModel.from_unit(unit) for unit in board.get_units()]
         return cls(
             rows=board.get_rows(),
             columns=board.get_columns(),

--- a/battle_hexes_api/src/battle_hexes_api/schemas/unit.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/unit.py
@@ -20,6 +20,22 @@ class UnitModel(BaseModel):
     row: int
     column: int
 
+    @classmethod
+    def from_unit(cls, unit: "Unit") -> "UnitModel":
+        """Create a unit model from a core :class:`Unit`."""
+
+        return cls(
+            id=str(unit.id),
+            name=unit.name,
+            faction_id=unit.faction.id,
+            type=unit.type,
+            attack=unit.attack,
+            defense=unit.defense,
+            move=unit.move,
+            row=unit.row,
+            column=unit.column,
+        )
+
 
 class SparseUnit(BaseModel):
     """Model representing a unit's minimal state for position updates."""

--- a/battle_hexes_api/tests/test_schemas.py
+++ b/battle_hexes_api/tests/test_schemas.py
@@ -1,6 +1,11 @@
 import unittest
 
-from battle_hexes_api.schemas import GameModel, ScenarioModel, SparseUnit
+from battle_hexes_api.schemas import (
+    GameModel,
+    ScenarioModel,
+    SparseUnit,
+    UnitModel,
+)
 from battle_hexes_core.game.board import Board
 from battle_hexes_core.game.game import Game
 from battle_hexes_core.game.player import Player, PlayerType
@@ -82,3 +87,37 @@ class TestSparseUnit(unittest.TestCase):
         self.assertEqual(sparse_unit.id, "u2")
         self.assertEqual(sparse_unit.row, 5)
         self.assertEqual(sparse_unit.column, 7)
+
+
+class TestUnitModel(unittest.TestCase):
+    def test_from_unit(self):
+        faction = Faction(id="f3", name="Faction 3", color="#ff0000")
+        player = Player(
+            name="Charlie",
+            type=PlayerType.HUMAN,
+            factions=[faction],
+        )
+        unit = Unit(
+            id="u3",
+            name="Unit 3",
+            faction=faction,
+            player=player,
+            type="Cavalry",
+            attack=6,
+            defense=4,
+            move=3,
+            row=2,
+            column=4,
+        )
+
+        unit_model = UnitModel.from_unit(unit)
+
+        self.assertEqual(unit_model.id, "u3")
+        self.assertEqual(unit_model.name, "Unit 3")
+        self.assertEqual(unit_model.faction_id, "f3")
+        self.assertEqual(unit_model.type, "Cavalry")
+        self.assertEqual(unit_model.attack, 6)
+        self.assertEqual(unit_model.defense, 4)
+        self.assertEqual(unit_model.move, 3)
+        self.assertEqual(unit_model.row, 2)
+        self.assertEqual(unit_model.column, 4)

--- a/battle_hexes_core/src/battle_hexes_core/unit/unit.py
+++ b/battle_hexes_core/src/battle_hexes_core/unit/unit.py
@@ -1,6 +1,5 @@
 from battle_hexes_core.game.player import Player
 from battle_hexes_core.unit.faction import Faction
-from battle_hexes_api.schemas.unit import UnitModel
 
 
 class Unit:
@@ -153,17 +152,6 @@ class Unit:
             current_cube = next_cube
 
         return True
-
-    def to_unit_model(self) -> UnitModel:
-        return UnitModel(id=self.id,
-                         name=self.name,
-                         faction_id=self.faction.id,
-                         type=self.type,
-                         attack=self.attack,
-                         defense=self.defense,
-                         move=self.move,
-                         row=self.row,
-                         column=self.column)
 
     def __str__(self):
         return f"{self.name} ({self.faction.name}) " + \


### PR DESCRIPTION
## Summary
- move conversion logic from the core Unit class into UnitModel.from_unit
- adjust board serialization to use the new classmethod and expand schema tests

## Testing
- ./server-side-checks.sh

------
https://chatgpt.com/codex/tasks/task_e_69061d5075d48327bcd41828bdae5958