### PR TITLE
Add terrain and refactor starting position in scenario data models

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
+++ b/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
@@ -35,8 +35,9 @@ class ScenarioHexData:
     Sparse description of hexes, such as terrain type and occupying units.
     """
 
-    terrain: ScenarioTerrainType | None = None
-    units: Tuple[ScenarioUnit] | None = None
+    coords: tuple[int, int]
+    terrain: str | None = None
+    units: Tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)

--- a/battle_hexes_core/src/battle_hexes_core/scenario/scenario_loader.py
+++ b/battle_hexes_core/src/battle_hexes_core/scenario/scenario_loader.py
@@ -7,7 +7,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator
 
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+)
 
 from .scenario import (
     Scenario,
@@ -69,7 +75,10 @@ class ScenarioHexDataEntry(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     coords: tuple[int, int]
-    terrain: str | None = None
+    terrain: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("terrain", "type"),
+    )
     units: list[str] | None = None
 
 
@@ -130,6 +139,7 @@ class ScenarioData(BaseModel):
             hex_data=(
                 tuple(
                     ScenarioHexData(
+                        coords=entry.coords,
                         terrain=entry.terrain,
                         units=tuple(entry.units) if entry.units else None,
                     )

--- a/battle_hexes_core/tests/gamecreator/test_gamecreator.py
+++ b/battle_hexes_core/tests/gamecreator/test_gamecreator.py
@@ -6,6 +6,7 @@ from battle_hexes_core.gamecreator.gamecreator import GameCreator
 from battle_hexes_core.scenario.scenario import (
     Scenario,
     ScenarioFaction,
+    ScenarioHexData,
     ScenarioUnit,
 )
 from battle_hexes_core.game.player import Player, PlayerType
@@ -150,6 +151,12 @@ class TestGameCreator(unittest.TestCase):
                     movement=5,
                 ),
             ),
+            hex_data=(
+                ScenarioHexData(
+                    coords=(1, 2),
+                    units=("unit-1",),
+                ),
+            ),
         )
 
         player1 = Player(name="Player 1", type=PlayerType.HUMAN, factions=[])
@@ -188,6 +195,12 @@ class TestGameCreator(unittest.TestCase):
                     attack=3,
                     defense=2,
                     movement=5
+                ),
+            ),
+            hex_data=(
+                ScenarioHexData(
+                    coords=(0, 0),
+                    units=("unit-1",),
                 ),
             ),
         )
@@ -236,6 +249,16 @@ class TestGameCreator(unittest.TestCase):
                     attack=2,
                     defense=1,
                     movement=6
+                ),
+            ),
+            hex_data=(
+                ScenarioHexData(
+                    coords=(0, 0),
+                    units=("unit-1",),
+                ),
+                ScenarioHexData(
+                    coords=(1, 2),
+                    units=("unit-2",),
                 ),
             ),
         )


### PR DESCRIPTION
### Motivation
- Preserve backward compatibility with scenario files that use the legacy `"type"` key for hex terrain while supporting the new `hex_data` model that stores `coords` and unit ids. 
- Ensure unit placement uses the scenario `hex_data` entries rather than removed `starting_coords` fields. 
- Keep imports flake8-compliant to avoid style failures.

### Description
- Allow `ScenarioHexDataEntry.terrain` to accept either `"terrain"` or legacy `"type"` via `pydantic.Field` with `AliasChoices` and keep the model frozen. 
- Populate `coords`, `terrain`, and `units` when converting `ScenarioData` to core `Scenario` instances in `to_core`. 
- Rework `GameCreator.add_units` to iterate `scenario.hex_data`, look up unit definitions by id, validate factions, construct `Unit` instances and add them to the `Board` at the `coords`. 
- Update unit tests in `tests/gamecreator/test_gamecreator.py` to include `hex_data` entries and format pydantic imports to satisfy `flake8` line-length rules.

### Testing
- Ran the repository checks with `./server-side-checks.sh` and all automated tests passed across packages. 
- `battle_hexes_core` tests: `80 passed`. 
- `battle_agent_rl` tests: `17 passed`. 
- `battle_hexes_api` tests: `27 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976264f7f2c832791981fea08e6a514)