### PR TITLE
Add unit tests for scenario_loader

### DIFF
--- a/battle_hexes_core/tests/scenario/test_scenario_loader.py
+++ b/battle_hexes_core/tests/scenario/test_scenario_loader.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from battle_hexes_core.scenario.scenario_loader import (
+    iter_scenario_data,
+    iter_scenarios,
+    load_scenario,
+    load_scenario_data,
+)
+
+
+def _scenario_dir() -> Path:
+    return (
+        Path(__file__)
+        .resolve()
+        .parents[2]
+        / "src"
+        / "battle_hexes_core"
+        / "scenarios"
+    )
+
+
+def test_load_scenario_data_from_directory():
+    scenario = load_scenario_data(
+        "elim_1", scenario_dir=_scenario_dir()
+    )
+
+    assert scenario.id == "elim_1"
+    assert scenario.board_size == (10, 10)
+    assert scenario.factions[0].name == "Red Faction"
+    assert scenario.units[0].movement == 6
+
+
+def test_load_scenario_data_raises_for_mismatched_id(tmp_path):
+    payload_path = _scenario_dir() / "elim_1.json"
+    payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    scenario_path = tmp_path / "expected.json"
+    scenario_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not match file contents"):
+        load_scenario_data("expected", scenario_dir=tmp_path)
+
+
+def test_load_scenario_converts_core_types():
+    scenario = load_scenario(
+        "elim_1", scenario_dir=_scenario_dir()
+    )
+
+    assert scenario.terrain_default == "open"
+    assert scenario.terrain_types["open"].color == "#C6AA5C"
+    assert scenario.hex_data[0].coords == (5, 5)
+    assert scenario.hex_data[1].units == ("red_unit_1",)
+
+
+def test_iterators_yield_all_scenarios():
+    scenario_ids = {
+        scenario.id
+        for scenario in iter_scenario_data(scenario_dir=_scenario_dir())
+    }
+    core_ids = {
+        scenario.id
+        for scenario in iter_scenarios(scenario_dir=_scenario_dir())
+    }
+
+    assert scenario_ids == {"elim_1", "elim_2"}
+    assert core_ids == {"elim_1", "elim_2"}


### PR DESCRIPTION
### Motivation
- Replace fragile inline test payloads with the repository's canonical scenario JSON to validate the loader against real data.
- Simplify test helpers and ensure tests exercise actual files shipped with the core package.

### Description
- Added a `_scenario_dir()` helper that resolves to `battle_hexes_core/src/.../scenarios` and removed the custom `_scenario_payload` writer.
- Updated `test_load_scenario_data_from_directory`, `test_load_scenario_converts_core_types`, and `test_iterators_yield_all_scenarios` to load `elim_1.json` and assert real-world values (board size, unit movement, terrain color, and hex coords).
- Implemented `test_load_scenario_data_raises_for_mismatched_id` by copying `elim_1.json` into a `tmp_path` and asserting `load_scenario_data` raises on id mismatch.
- Adjusted iterator tests to expect the two shipped scenarios `elim_1` and `elim_2`.

### Testing
- Ran `./battle_hexes_core/checks.sh`, which runs the package test suite and linting, and observed all tests passed (`84 passed`) and checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69762ea1520083279db07d84864448e7)