### PR TITLE
Add battle_agent_rl to PYTHONPATH in API checks script

### DIFF
--- a/battle_hexes_api/checks.sh
+++ b/battle_hexes_api/checks.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Determine repository root directory
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # Add package directories to PYTHONPATH so tests can import them
-export PYTHONPATH="$REPO_ROOT/battle_hexes_core/src:$REPO_ROOT/battle_hexes_api/src:${PYTHONPATH:-}"
+export PYTHONPATH="$REPO_ROOT/battle_hexes_core/src:$REPO_ROOT/battle_agent_rl/src:$REPO_ROOT/battle_hexes_api/src:${PYTHONPATH:-}"
 
 # Run tests for the API package
 cd "$REPO_ROOT/battle_hexes_api"


### PR DESCRIPTION
### Motivation
- The API package tests were failing during collection with `ModuleNotFoundError: No module named 'battle_agent_rl'`, so the checks script needs to expose the `battle_agent_rl` sources on `PYTHONPATH` so tests can import the RL player classes.

### Description
- Updated `battle_hexes_api/checks.sh` to add `$REPO_ROOT/battle_agent_rl/src` to the `PYTHONPATH` alongside the existing core and api source paths.

### Testing
- Ran `./battle_hexes_api/checks.sh`, which executed the test suite and linter and completed successfully with the test run showing `28 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766187e030832791389baa261f932e)