### PR TITLE
Add hex drawer terrain overlay unit tests

### DIFF
--- a/battle-hexes-web/tests/drawer/hex-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/hex-drawer.test.js
@@ -2,6 +2,18 @@ import { HexDrawer } from '../../src/drawer/hex-drawer.js';
 import { Hex } from '../../src/model/hex.js';
 import { Terrain } from '../../src/model/terrain.js';
 
+let mockResolve;
+let mockTerrainDrawerResolverConstructor;
+
+jest.mock('../../src/terraindraw/terrain-drawer-resolver.js', () => {
+  mockTerrainDrawerResolverConstructor = jest.fn();
+  mockResolve = jest.fn();
+  mockTerrainDrawerResolverConstructor.mockImplementation(() => ({
+    resolve: mockResolve
+  }));
+  return { TerrainDrawerResolver: mockTerrainDrawerResolverConstructor };
+});
+
 class TestHexDrawer extends HexDrawer {
   constructor(...args) {
     super(...args);
@@ -39,6 +51,8 @@ describe('HexDrawer.draw', () => {
   beforeEach(() => {
     p5 = createMockP5();
     hexDrawer = new TestHexDrawer(p5, 30);
+    mockResolve.mockReset();
+    mockTerrainDrawerResolverConstructor.mockClear();
   });
 
   test('uses terrain color when hex has terrain', () => {
@@ -59,5 +73,31 @@ describe('HexDrawer.draw', () => {
 
     expect(hexDrawer.drawnHexes).toHaveLength(1);
     expect(hexDrawer.drawnHexes[0].fillColor).toBe('#fffdd0');
+  });
+
+  test('draws terrain overlay when resolver returns a drawer', () => {
+    const hex = new Hex(1, 2);
+    const terrain = new Terrain('village', '#9b8f7a');
+    hex.setTerrain(terrain);
+
+    const terrainDrawer = { draw: jest.fn() };
+    mockResolve.mockReturnValue(terrainDrawer);
+
+    hexDrawer.draw(hex);
+
+    expect(mockResolve).toHaveBeenCalledWith(hex);
+    expect(terrainDrawer.draw).toHaveBeenCalledWith(hex);
+  });
+
+  test('skips terrain overlay when resolver returns null', () => {
+    const hex = new Hex(3, 4);
+    const terrain = new Terrain('village', '#9b8f7a');
+    hex.setTerrain(terrain);
+
+    mockResolve.mockReturnValue(null);
+
+    hexDrawer.draw(hex);
+
+    expect(mockResolve).toHaveBeenCalledWith(hex);
   });
 });


### PR DESCRIPTION
### Motivation

- Ensure the `HexDrawer` integration with the new `TerrainDrawerResolver` is covered by tests to catch regressions in overlay rendering behavior.  
- Verify existing terrain color selection still works and that no overlay is drawn when the resolver returns `null`.

### Description

- Mock the `TerrainDrawerResolver` in `tests/drawer/hex-drawer.test.js` so tests can control resolver behavior.  
- Add a test that confirms a returned terrain drawer's `draw` method is invoked when the resolver returns a drawer.  
- Add a test that confirms the resolver is called and no overlay is drawn when it returns `null`, and keep existing assertions for terrain color and default fill.

### Testing

- Ran `npm test -- tests/drawer/hex-drawer.test.js`, which executed 4 tests and all passed (`4 passed, 4 total`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7226e44c8327a928863e74d49b9f)