### PR TITLE
Add Objective dataclass and load objectives into hexes

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/game/hex.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/hex.py
@@ -1,4 +1,5 @@
 from battle_hexes_core.game.terrain import Terrain
+from battle_hexes_core.game.objective import Objective
 
 
 class Hex:
@@ -7,10 +8,12 @@ class Hex:
         row: int,
         column: int,
         terrain: Terrain | None = None,
+        objectives: list[Objective] | None = None,
     ):
         self._row = row
         self._column = column
         self._terrain = terrain
+        self._objectives = list(objectives) if objectives else []
 
     @property
     def row(self) -> int:
@@ -23,6 +26,10 @@ class Hex:
     @property
     def terrain(self) -> Terrain | None:
         return self._terrain
+
+    @property
+    def objectives(self) -> list[Objective]:
+        return self._objectives
 
     def set_terrain(self, terrain: Terrain | None) -> None:
         self._terrain = terrain

--- a/battle_hexes_core/src/battle_hexes_core/game/objective.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/objective.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Objective:
+    """Representation of a hex objective."""
+
+    coords: tuple[int, int]
+    points: int
+    type: str

--- a/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
+++ b/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Tuple
 
+from battle_hexes_core.game.objective import Objective
+
 
 @dataclass(frozen=True)
 class ScenarioFaction:
@@ -38,6 +40,7 @@ class ScenarioHexData:
     coords: tuple[int, int]
     terrain: str | None = None
     units: Tuple[str, ...] | None = None
+    objectives: tuple[Objective, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)

--- a/battle_hexes_core/tests/game/test_hex.py
+++ b/battle_hexes_core/tests/game/test_hex.py
@@ -1,0 +1,15 @@
+from battle_hexes_core.game.hex import Hex
+from battle_hexes_core.game.objective import Objective
+
+
+def test_hex_defaults_to_no_objectives():
+    hex_tile = Hex(1, 2)
+
+    assert hex_tile.objectives == []
+
+
+def test_hex_accepts_objectives():
+    objective = Objective(coords=(1, 2), points=2, type="hold")
+    hex_tile = Hex(1, 2, objectives=[objective])
+
+    assert hex_tile.objectives == [objective]

--- a/battle_hexes_core/tests/scenario/test_scenario_loader.py
+++ b/battle_hexes_core/tests/scenario/test_scenario_loader.py
@@ -52,6 +52,24 @@ def test_load_scenario_converts_core_types():
     assert scenario.terrain_types["open"].color == "#C6AA5C"
     assert scenario.hex_data[0].coords == (5, 5)
     assert scenario.hex_data[1].units == ("red_unit_1",)
+    assert scenario.hex_data[0].objectives[0].type == "hold"
+    assert scenario.hex_data[0].objectives[0].points == 3
+
+
+def test_load_scenario_assigns_objectives_to_hexes():
+    scenario = load_scenario(
+        "elim_2", scenario_dir=_scenario_dir()
+    )
+
+    objective_hex = next(
+        hex_entry
+        for hex_entry in scenario.hex_data
+        if hex_entry.coords == (2, 3)
+    )
+    assert objective_hex.terrain is None
+    assert objective_hex.units is None
+    assert objective_hex.objectives[0].type == "hold"
+    assert objective_hex.objectives[0].points == 1
 
 
 def test_iterators_yield_all_scenarios():


### PR DESCRIPTION
### Motivation
- Scenario JSON now contains `objectives` and the core model needs a stable, frozen representation for objectives.
- Hex tiles should be able to store any objectives that belong to their coordinates so game creation and scoring can consume them.

### Description
- Added a frozen `Objective` dataclass at `battle_hexes_core/src/battle_hexes_core/game/objective.py` that uses `coords: tuple[int, int]` for coordinate immutability. 
- Extended `ScenarioHexData` to include `objectives: tuple[Objective, ...]` and updated `Scenario` types in `battle_hexes_core/src/battle_hexes_core/scenario/scenario.py`.
- Updated `scenario_loader.py` to define `ScenarioObjectiveEntry`, parse `objectives` from scenario JSON, and attach objectives to existing hex entries or create objective-only hex entries when needed.
- Updated `Hex` in `battle_hexes_core/src/battle_hexes_core/game/hex.py` to hold a list of `Objective` instances with a default empty list and added an `objectives` property.
- Added and updated unit tests: new `battle_hexes_core/tests/game/test_hex.py` and updated `battle_hexes_core/tests/scenario/test_scenario_loader.py` to validate loading and association of objectives.

### Testing
- Installed `flake8` and ran `./server-side-checks.sh` to run tests and linting.
- All automated tests passed: core package tests `88 passed`, RL agent tests `17 passed`, and API tests `28 passed`, and the full server-side checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876ca4efac8327a30cfeab719bf218)