### PR TITLE
Include objectives in game serialization and apply scenario objectives to board

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
@@ -5,6 +5,7 @@ from .combat import CombatResultSchema
 from .create_game import CreateGameRequest
 from .faction import FactionModel
 from .game_model import GameModel
+from .objective import ObjectiveModel
 from .player import PlayerModel
 from .player_type import PlayerTypeModel
 from .scenario import ScenarioModel
@@ -18,6 +19,7 @@ __all__ = [
     "CreateGameRequest",
     "FactionModel",
     "GameModel",
+    "ObjectiveModel",
     "PlayerModel",
     "PlayerTypeModel",
     "ScenarioModel",

--- a/battle_hexes_api/src/battle_hexes_api/schemas/game_model.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/game_model.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict
 from battle_hexes_core.game.player import Player
 
 from .board import BoardModel
+from .objective import ObjectiveModel
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from battle_hexes_core.game.game import Game
@@ -22,6 +23,7 @@ class GameModel(BaseModel):
     id: uuid.UUID
     players: List[Player]
     board: BoardModel
+    objectives: List[ObjectiveModel]
 
     @classmethod
     def from_game(
@@ -33,4 +35,8 @@ class GameModel(BaseModel):
             id=game.get_id(),
             players=list(game.get_players()),
             board=BoardModel.from_board(game.get_board(), scenario),
+            objectives=[
+                ObjectiveModel.from_objective(objective)
+                for objective in game.get_board().get_objectives()
+            ],
         )

--- a/battle_hexes_api/src/battle_hexes_api/schemas/objective.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/objective.py
@@ -1,0 +1,28 @@
+"""Objective-related schema definitions."""
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from battle_hexes_core.game.objective import Objective
+
+
+class ObjectiveModel(BaseModel):
+    """Serialized representation of a board objective."""
+
+    row: int
+    column: int
+    points: int
+    type: str
+
+    @classmethod
+    def from_objective(cls, objective: "Objective") -> "ObjectiveModel":
+        """Create an ``ObjectiveModel`` from a core objective."""
+        row, column = objective.coords
+        return cls(
+            row=row,
+            column=column,
+            points=objective.points,
+            type=objective.type,
+        )

--- a/battle_hexes_api/tests/test_schemas.py
+++ b/battle_hexes_api/tests/test_schemas.py
@@ -8,6 +8,7 @@ from battle_hexes_api.schemas import (
 )
 from battle_hexes_core.game.board import Board
 from battle_hexes_core.game.game import Game
+from battle_hexes_core.game.objective import Objective
 from battle_hexes_core.game.player import Player, PlayerType
 from battle_hexes_core.game.terrain import Terrain
 from battle_hexes_core.scenario.scenario import Scenario
@@ -48,6 +49,9 @@ class TestGameModel(unittest.TestCase):
         )
         board.add_unit(unit, 0, 1)
         board.get_hex(0, 0).set_terrain(Terrain("open", "#C6AA5C"))
+        board.get_hex(0, 0).objectives.append(
+            Objective(coords=(0, 0), points=2, type="hold")
+        )
         game = Game([player], board)
         scenario = Scenario(
             id="scenario-1",
@@ -63,6 +67,12 @@ class TestGameModel(unittest.TestCase):
         self.assertEqual(model.board.columns, 2)
         self.assertEqual(len(model.board.units), 1)
         self.assertEqual(model.board.terrain.default, "open")
+        self.assertEqual(len(model.objectives), 1)
+        objective_model = model.objectives[0]
+        self.assertEqual(objective_model.row, 0)
+        self.assertEqual(objective_model.column, 0)
+        self.assertEqual(objective_model.points, 2)
+        self.assertEqual(objective_model.type, "hold")
         unit_model = model.board.units[0]
         self.assertEqual(unit_model.id, "u1")
         self.assertEqual(unit_model.row, 0)

--- a/battle_hexes_core/src/battle_hexes_core/game/board.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/board.py
@@ -3,6 +3,7 @@ from collections import deque
 from typing import List, Set, Tuple
 
 from battle_hexes_core.game.hex import Hex
+from battle_hexes_core.game.objective import Objective
 from battle_hexes_core.unit.unit import Unit
 
 
@@ -350,3 +351,10 @@ class Board:
             if unit.get_coords() in hexes:
                 units.append(unit)
         return units
+
+    def get_objectives(self) -> list[Objective]:
+        """Return all objectives currently stored on the board."""
+        objectives: list[Objective] = []
+        for hex_tile in self.hexes:
+            objectives.extend(hex_tile.objectives)
+        return objectives

--- a/battle_hexes_core/src/battle_hexes_core/gamecreator/gamecreator.py
+++ b/battle_hexes_core/src/battle_hexes_core/gamecreator/gamecreator.py
@@ -78,6 +78,7 @@ class GameCreator:
             faction_by_id,
             player_by_faction_id,
         )
+        self.add_objectives(board, scenario_obj)
 
         game = Game(
             players=players_list,
@@ -244,3 +245,20 @@ class GameCreator:
                 )
 
                 board.add_unit(unit, row, column)
+
+    def add_objectives(self, board: Board, scenario: Scenario) -> None:
+        """Apply scenario objectives to the board hexes."""
+        if not scenario.hex_data:
+            return
+
+        for hex_entry in scenario.hex_data:
+            if not hex_entry.objectives:
+                continue
+
+            row, column = hex_entry.coords
+            hex_tile = board.get_hex(row, column)
+            if hex_tile is None:
+                raise ValueError(
+                    f"Hex coords out of bounds: {hex_entry.coords}"
+                )
+            hex_tile.objectives.extend(hex_entry.objectives)

--- a/battle_hexes_core/tests/game/test_board.py
+++ b/battle_hexes_core/tests/game/test_board.py
@@ -1,6 +1,7 @@
 import unittest
 import uuid
 from battle_hexes_core.game.board import Board
+from battle_hexes_core.game.objective import Objective
 from battle_hexes_core.game.player import Player, PlayerType
 from battle_hexes_core.unit.faction import Faction
 from battle_hexes_core.unit.unit import Unit
@@ -75,6 +76,16 @@ class TestBoard(unittest.TestCase):
             actual_coords, expected_coords,
             "Neighboring hexes should match expected coordinates"
         )
+
+    def test_get_objectives(self):
+        objective_one = Objective(coords=(0, 1), points=1, type="hold")
+        objective_two = Objective(coords=(2, 3), points=3, type="hold")
+        self.board.get_hex(0, 1).objectives.append(objective_one)
+        self.board.get_hex(2, 3).objectives.append(objective_two)
+
+        objectives = self.board.get_objectives()
+
+        self.assertCountEqual(objectives, [objective_one, objective_two])
 
     def test_get_neighboring_hexes_center_hex_odd(self):
         self.board.add_unit(self.red_unit, 1, 3)

--- a/battle_hexes_core/tests/gamecreator/test_gamecreator.py
+++ b/battle_hexes_core/tests/gamecreator/test_gamecreator.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from battle_hexes_core.gamecreator.gamecreator import GameCreator
+from battle_hexes_core.game.objective import Objective
 from battle_hexes_core.scenario.scenario import (
     Scenario,
     ScenarioFaction,
@@ -250,6 +251,28 @@ class TestGameCreator(unittest.TestCase):
         self.assertEqual(default_hex.terrain.hex_color, "#C6AA5C")
         self.assertEqual(override_hex.terrain.name, "village")
         self.assertEqual(override_hex.terrain.hex_color, "#9A8F7A")
+
+    def test_add_objectives_populates_board_hexes(self):
+        objective = Objective(coords=(0, 1), points=2, type="hold")
+        scenario = Scenario(
+            id="scenario-1",
+            name="Scenario",
+            board_size=(2, 2),
+            hex_data=(
+                ScenarioHexData(
+                    coords=(0, 1),
+                    objectives=(objective,),
+                ),
+            ),
+        )
+
+        player1 = Player(name="Player 1", type=PlayerType.HUMAN, factions=[])
+        player2 = Player(name="Player 2", type=PlayerType.CPU, factions=[])
+
+        game = self.creator.create_game(scenario, player1, player2)
+
+        target_hex = game.board.get_hex(0, 1)
+        self.assertEqual(target_hex.objectives, [objective])
 
     @patch("battle_hexes_core.gamecreator.gamecreator.load_scenario")
     def test_build_game_components_from_scenario_id(self, mock_load_scenario):


### PR DESCRIPTION
### Motivation

- Expose scenario objectives in the API game payload so clients can display and score objectives alongside units and terrain.
- Ensure scenario-defined objectives are applied to board hexes when a game is created so core logic and tests can access them.

### Description

- Added `Board.get_objectives()` to collect objectives from every `Hex` on the board.
- Added `GameCreator.add_objectives()` and call it during game construction to apply `ScenarioHexData.objectives` to the corresponding hexes on the board.
- Introduced `ObjectiveModel` schema and updated `GameModel` to include a top-level `objectives` list derived from `game.get_board().get_objectives()`.
- Updated and added unit tests to cover board objective aggregation, scenario objective application in game creation, and game serialization of objectives (tests in `battle_hexes_core/tests/...` and `battle_hexes_api/tests/test_schemas.py`).

### Testing

- Ran the project test suite and linter via `./server-side-checks.sh`; all automated tests passed across packages: core tests (90 passed), agent tests (17 passed), and API tests (28 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987780f1ae083279922fc25a521679b)