### PR TITLE
Use Terrain property access (.name/.color) and add web AGENTS.md

### DIFF
--- a/battle-hexes-web/AGENTS.md
+++ b/battle-hexes-web/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md — Battle Hexes Web
+
+When making code changes in this web project, run:
+
+```
+npm run test-and-build
+```

--- a/battle-hexes-web/src/drawer/hex-drawer.js
+++ b/battle-hexes-web/src/drawer/hex-drawer.js
@@ -20,7 +20,7 @@ export class HexDrawer {
 
   draw(hexToDraw) {
     const terrain = hexToDraw.getTerrain();
-    const fillColor = terrain ? terrain.getColor() : '#fffdd0';
+    const fillColor = terrain ? terrain.color : '#fffdd0';
     this.drawHex(hexToDraw, '#202020', 2, fillColor);
     this.#terrainDrawerResolver.resolve(hexToDraw)?.draw(hexToDraw);
   }

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -116,7 +116,7 @@ export class Menu {
 
     if (selectedHex) {
       const terrain = selectedHex.getTerrain();
-      this.#selHexTerrainDiv.innerHTML = terrain ? `Terrain: ${terrain.getName()}` : '';
+      this.#selHexTerrainDiv.innerHTML = terrain ? `Terrain: ${terrain.name}` : '';
     }
 
     if (this.#game.getBoard().isOwnHexSelected()) {

--- a/battle-hexes-web/src/model/terrain.js
+++ b/battle-hexes-web/src/model/terrain.js
@@ -7,11 +7,11 @@ export class Terrain {
     this.#color = color;
   }
 
-  getName() {
+  get name() {
     return this.#name;
   }
 
-  getColor() {
+  get color() {
     return this.#color;
   }
 }

--- a/battle-hexes-web/src/terraindraw/terrain-drawer-resolver.js
+++ b/battle-hexes-web/src/terraindraw/terrain-drawer-resolver.js
@@ -10,7 +10,7 @@ export class TerrainDrawerResolver {
   }
 
   resolve(aHex) {
-    const terrainName = aHex.getTerrain()?.getName();
+    const terrainName = aHex.getTerrain()?.name;
     return this.#terrainMap.get(terrainName) ?? null;
   }
 }

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -176,7 +176,7 @@ describe('auto new game persistence', () => {
       column: 2,
       isEmpty: () => true,
       getTerrain: () => ({
-        getName: () => 'open',
+        name: 'open',
       }),
     };
 

--- a/battle-hexes-web/tests/model/game-creator.test.js
+++ b/battle-hexes-web/tests/model/game-creator.test.js
@@ -110,21 +110,21 @@ describe("createGame", () => {
     const terrainGame = gameCreator.createGame(gameData);
     const terrainHex = terrainGame.getBoard().getHex(0, 0);
 
-    expect(terrainHex.getTerrain().getName()).toBe('default');
-    expect(terrainHex.getTerrain().getColor()).toBe('#F0F0F0');
+    expect(terrainHex.getTerrain().name).toBe('default');
+    expect(terrainHex.getTerrain().color).toBe('#F0F0F0');
   });
 
   test('board assigns default terrain to unspecified hexes', () => {
     const defaultHex = game.getBoard().getHex(0, 0);
 
-    expect(defaultHex.getTerrain().getName()).toBe('open');
-    expect(defaultHex.getTerrain().getColor()).toBe('#C6AA5C');
+    expect(defaultHex.getTerrain().name).toBe('open');
+    expect(defaultHex.getTerrain().color).toBe('#C6AA5C');
   });
 
   test('board assigns terrain overrides to specified hexes', () => {
     const terrainHex = game.getBoard().getHex(6, 4);
 
-    expect(terrainHex.getTerrain().getName()).toBe('village');
-    expect(terrainHex.getTerrain().getColor()).toBe('#9A8F7A');
+    expect(terrainHex.getTerrain().name).toBe('village');
+    expect(terrainHex.getTerrain().color).toBe('#9A8F7A');
   });
 });


### PR DESCRIPTION
### Motivation

- Modernize the Terrain API by exposing `name` and `color` as ES6 property getters instead of `getName()`/`getColor()` to simplify call sites.
- Provide guidance for agents working on the web project to run the build+tests before submitting changes.

### Description

- Add `battle-hexes-web/AGENTS.md` that instructs agents to run `npm run test-and-build` when making code changes.
- Change `Terrain` to expose `name` and `color` via getters in `battle-hexes-web/src/model/terrain.js` instead of `getName()`/`getColor()`.
- Update call sites to use the new properties in `battle-hexes-web/src/drawer/hex-drawer.js`, `battle-hexes-web/src/menu.js`, and `battle-hexes-web/src/terraindraw/terrain-drawer-resolver.js`.
- Update unit tests to reflect the API change in `battle-hexes-web/tests/menu/menu.test.js` and `battle-hexes-web/tests/model/game-creator.test.js`.

### Testing

- Automated tests and linters were not executed as part of this change; please run `npm run test-and-build` in `battle-hexes-web` or `./server-side-checks.sh` from the repository root to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987827131d48327b3e06b98a3919890)