### PR TITLE
Refine Objective getters and tests

### DIFF
--- a/battle-hexes-web/AGENTS.md
+++ b/battle-hexes-web/AGENTS.md
@@ -5,3 +5,6 @@ When making code changes in this web project, run:
 ```
 npm run test-and-build
 ```
+
+When adding new models, use idiomatic JavaScript getters (the `get` keyword)
+instead of Java-like `getX()` methods.

--- a/battle-hexes-web/src/battle.html
+++ b/battle-hexes-web/src/battle.html
@@ -62,6 +62,7 @@
     <div id="selHexContents"></div>
     <div id="selHexCoord"></div>
     <div id="selHexTerrain"></div>
+    <div id="selHexObjectives"></div>
     <div id="unitMovesLeftDiv"></div>
     <div id="gameStagesMenu">
       <h3>Game Stages</h3>

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -7,6 +7,7 @@ export class Menu {
   #selHexContentsDiv;
   #selHexCoordDiv;
   #selHexTerrainDiv;
+  #selHexObjectivesDiv;
   #unitMovesLeftDiv;
   #newGameBtn;
   #gameOverLabel;
@@ -21,6 +22,7 @@ export class Menu {
     this.#selHexContentsDiv = document.getElementById('selHexContents');
     this.#selHexCoordDiv = document.getElementById('selHexCoord');
     this.#selHexTerrainDiv = document.getElementById('selHexTerrain');
+    this.#selHexObjectivesDiv = document.getElementById('selHexObjectives');
     this.#unitMovesLeftDiv = document.getElementById('unitMovesLeftDiv');
     this.#newGameBtn = document.getElementById('newGameBtn');
     this.#gameOverLabel = document.getElementById('gameOverLabel');
@@ -106,6 +108,7 @@ export class Menu {
       this.#selHexContentsDiv.innerHTML = '';
       this.#selHexCoordDiv.innerHTML = '';
       this.#selHexTerrainDiv.innerHTML = '';
+      this.#selHexObjectivesDiv.innerHTML = '';
     } else if (selectedHex.isEmpty()) {
       this.#selHexContentsDiv.innerHTML = 'Empty Hex';
       this.#selHexCoordDiv.innerHTML = `Hex Coord: (${selectedHex.row}, ${selectedHex.column})`;
@@ -117,6 +120,7 @@ export class Menu {
     if (selectedHex) {
       const terrain = selectedHex.getTerrain();
       this.#selHexTerrainDiv.innerHTML = terrain ? `Terrain: ${terrain.name}` : '';
+      this.#selHexObjectivesDiv.innerHTML = this.#formatObjectives(selectedHex);
     }
 
     if (this.#game.getBoard().isOwnHexSelected()) {
@@ -137,6 +141,20 @@ export class Menu {
     } else {
       this.#hideGameOver();
     }
+  }
+
+  #formatObjectives(selectedHex) {
+    if (!selectedHex?.hasObjectives?.() || selectedHex.getObjectives().length === 0) {
+      return '';
+    }
+
+    return selectedHex.getObjectives()
+      .map((objective) => {
+        const points = objective.points;
+        const pointsLabel = points === 1 ? 'pt/turn' : 'pts/turn';
+        return `🚩 ${objective.displayName} (${points} ${pointsLabel})`;
+      })
+      .join('<br/>');
   }
 
   #updateCombatIndicator() {

--- a/battle-hexes-web/src/model/game-creator.js
+++ b/battle-hexes-web/src/model/game-creator.js
@@ -5,6 +5,7 @@ import { Players } from "../player/player";
 import { PlayerFactory } from "../player/player-factory";
 import { Unit } from "./unit";
 import { Terrain } from "./terrain";
+import { Objective } from "./objective";
 
 export class GameCreator {
   createGame(gameData) {
@@ -24,6 +25,7 @@ export class GameCreator {
     );
     this.#addTerrain(board, gameData.board);
     this.#addUnits(board, game.getPlayers(), gameData.board);
+    this.#addObjectives(board, gameData);
     return game;
   }
 
@@ -129,5 +131,22 @@ export class GameCreator {
       }
     }
     return factionMap;
+  }
+
+  #addObjectives(board, gameData) {
+    const objectivesData = gameData?.objectives;
+    if (!Array.isArray(objectivesData)) {
+      return;
+    }
+
+    for (const objectiveData of objectivesData) {
+      const targetHex = board.getHex(objectiveData.row, objectiveData.column);
+      if (!targetHex) {
+        continue;
+      }
+      const type = typeof objectiveData.type === 'string' ? objectiveData.type : '';
+      const points = Number.isFinite(objectiveData.points) ? objectiveData.points : 0;
+      targetHex.addObjective(new Objective(type, points));
+    }
   }
 }

--- a/battle-hexes-web/src/model/hex.js
+++ b/battle-hexes-web/src/model/hex.js
@@ -4,6 +4,7 @@ export class Hex {
   #selected;
   #moveHoverFromHex;
   #terrain;
+  #objectives;
 
   constructor(row, column) {
     this.row = row;
@@ -12,6 +13,7 @@ export class Hex {
     this.#selected = false;
     this.#moveHoverFromHex = undefined;
     this.#terrain = undefined;
+    this.#objectives = [];
 
     if (column % 2 === 0) {
       this.#adjacentHexCoords = new Set([
@@ -100,6 +102,18 @@ export class Hex {
 
   getTerrain() {
     return this.#terrain;
+  }
+
+  addObjective(objective) {
+    this.#objectives.push(objective);
+  }
+
+  getObjectives() {
+    return [...this.#objectives];
+  }
+
+  hasObjectives() {
+    return this.#objectives.length > 0;
   }
 
   hasUnitMoves() {

--- a/battle-hexes-web/src/model/objective.js
+++ b/battle-hexes-web/src/model/objective.js
@@ -1,0 +1,25 @@
+export class Objective {
+  #type;
+  #points;
+
+  constructor(type, points) {
+    this.#type = type;
+    this.#points = points;
+    Object.freeze(this);
+  }
+
+  get type() {
+    return this.#type;
+  }
+
+  get points() {
+    return this.#points;
+  }
+
+  get displayName() {
+    if (!this.#type) {
+      return '';
+    }
+    return this.#type.charAt(0).toUpperCase() + this.#type.slice(1);
+  }
+}

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -14,6 +14,7 @@ describe('auto new game persistence', () => {
       <div id="selHexContents"></div>
       <div id="selHexCoord"></div>
       <div id="selHexTerrain"></div>
+      <div id="selHexObjectives"></div>
       <div id="unitMovesLeftDiv"></div>
       <button id="newGameBtn"></button>
       <div id="gameOverLabel"></div>
@@ -191,5 +192,36 @@ describe('auto new game persistence', () => {
     menu.updateMenu();
 
     expect(document.getElementById('selHexTerrain').innerHTML).toBe('Terrain: open');
+  });
+
+  test('shows objective details when present on selected hex', () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+
+    const selectedHex = {
+      row: 4,
+      column: 7,
+      isEmpty: () => true,
+      getTerrain: () => null,
+      hasObjectives: () => true,
+      getObjectives: () => [
+        {
+          points: 3,
+          displayName: 'Hold',
+        },
+      ],
+    };
+
+    const menu = new Menu(fakeGame({
+      getBoard: () => ({
+        getSelectedHex: () => selectedHex,
+        isOwnHexSelected: () => false,
+        hasCombat: () => false,
+      }),
+    }));
+
+    menu.updateMenu();
+
+    expect(document.getElementById('selHexObjectives').innerHTML).toBe('🚩 Hold (3 pts/turn)');
   });
 });

--- a/battle-hexes-web/tests/model/game-creator.test.js
+++ b/battle-hexes-web/tests/model/game-creator.test.js
@@ -14,7 +14,8 @@ beforeEach(() => {
     '"board":{"rows":10,"columns":10,"units":[' +
     '{"id":"a22c90d0-db87-41d0-8c3a-00c04fd708be","name":"Red Unit","faction_id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","type":"Infantry","attack":2,"defense":2,"move":6,"row":6,"column":4},' +
     '{"id":"c9a440d2-2b0a-4730-b4c6-da394b642c61","name":"Blue Unit","faction_id":"38400000-8cf0-41bd-b23e-10b96e4ef00d","type":"Infantry","attack":4,"defense":4,"move":4,"row":3,"column":5}],' +
-    '"terrain":{"default":"open","types":{"open":{"name":"open","color":"#C6AA5C"},"village":{"name":"village","color":"#9A8F7A"}},"hexes":[{"row":6,"column":4,"terrain":"village"}]}}}'
+    '"terrain":{"default":"open","types":{"open":{"name":"open","color":"#C6AA5C"},"village":{"name":"village","color":"#9A8F7A"}},"hexes":[{"row":6,"column":4,"terrain":"village"}]}},' +
+    '"objectives":[{"row":6,"column":4,"points":3,"type":"hold"}]}'
   );
   game = gameCreator.createGame(gameData);
 });
@@ -126,5 +127,13 @@ describe("createGame", () => {
 
     expect(terrainHex.getTerrain().name).toBe('village');
     expect(terrainHex.getTerrain().color).toBe('#9A8F7A');
+  });
+
+  test('board assigns objectives to specified hexes', () => {
+    const objectiveHex = game.getBoard().getHex(6, 4);
+    const objective = objectiveHex.getObjectives()[0];
+
+    expect(objective.type).toBe('hold');
+    expect(objective.points).toBe(3);
   });
 });

--- a/battle-hexes-web/tests/model/hex.test.js
+++ b/battle-hexes-web/tests/model/hex.test.js
@@ -1,4 +1,5 @@
 import { Hex } from '../../src/model/hex.js';
+import { Objective } from '../../src/model/objective.js';
 import { Terrain } from '../../src/model/terrain.js';
 import { Unit } from '../../src/model/unit.js';
 
@@ -38,5 +39,25 @@ describe('terrain', () => {
     hex.setTerrain(terrain);
 
     expect(hex.getTerrain()).toBe(terrain);
+  });
+});
+
+describe('objectives', () => {
+  test('stores objectives assigned to the hex', () => {
+    const objective = new Objective('hold', 3);
+
+    hex.addObjective(objective);
+
+    expect(hex.getObjectives()).toEqual([objective]);
+  });
+
+  test('returns a copy of objectives', () => {
+    const objective = new Objective('hold', 3);
+    hex.addObjective(objective);
+
+    const objectives = hex.getObjectives();
+    objectives.push(new Objective('hold', 1));
+
+    expect(hex.getObjectives()).toEqual([objective]);
   });
 });

--- a/battle-hexes-web/tests/model/objective.test.js
+++ b/battle-hexes-web/tests/model/objective.test.js
@@ -1,0 +1,22 @@
+import { Objective } from '../../src/model/objective.js';
+
+describe('Objective', () => {
+  test('exposes type and points via getters', () => {
+    const objective = new Objective('hold', 3);
+
+    expect(objective.type).toBe('hold');
+    expect(objective.points).toBe(3);
+  });
+
+  test('formats display name with leading capital', () => {
+    const objective = new Objective('hold', 3);
+
+    expect(objective.displayName).toBe('Hold');
+  });
+
+  test('returns empty display name when type is missing', () => {
+    const objective = new Objective('', 3);
+
+    expect(objective.displayName).toBe('');
+  });
+});


### PR DESCRIPTION
### Motivation
- Move the new Objective model to idiomatic JavaScript style using `get` property accessors rather than Java-like `getX()` methods for clearer, more idiomatic API usage. 
- Surface objectives on hexes and in the UI so objectives provided in game data are represented and displayed consistently.

### Description
- Add `Objective` class with private fields and JavaScript getters `type`, `points`, and `displayName`, and freeze instances for immutability (`src/model/objective.js`).
- Extend `Hex` with `addObjective`, `getObjectives`, and `hasObjectives` to store and expose objectives (`src/model/hex.js`).
- Update `GameCreator` to parse `objectives` from game JSON and place `Objective` instances onto board hexes (`src/model/game-creator.js`).
- Update `Menu` to include a `#selHexObjectivesDiv`, format objectives via getters, and render them in the menu (`src/menu.js` and `src/battle.html`).
- Update unit tests to use the new getters and add coverage for display name logic and hex objective behavior, including `tests/model/objective.test.js`, updates to `tests/model/hex.test.js`, `tests/model/game-creator.test.js`, and `tests/menu/menu.test.js`.
- Document the getter convention in `battle-hexes-web/AGENTS.md` advising contributors to use the `get` keyword instead of `getX()` methods.

### Testing
- Ran `npm run test-and-build`, which runs linting, Jest tests, and the webpack build, and completed successfully with all test suites passing ("Test Suites: 17 passed, 17 total" and "Tests: 92 passed, 92 total").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69878a994aec8327a5c72b44493d5fca)