### PR TITLE
Fix menu initialization rendering

### DIFF
--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -72,6 +72,7 @@ export class Menu {
     this.#initPhaseEndButton();
     this.#setCurrentTurn();
     this.#updateCombatIndicator();
+    this.updateMenu();
   }
 
   getShowHexCoordsPreference() {
@@ -108,7 +109,7 @@ export class Menu {
     const selectedHex = this.#game.getBoard().getSelectedHex();
 
     if (!selectedHex) {
-      this.#selHexContentsDiv.innerHTML = '';
+      this.#selHexContentsDiv.innerHTML = '<em>No selection</em>';
       this.#selHexCoordDiv.innerHTML = '';
       this.#selHexTerrainDiv.innerHTML = '';
       this.#selHexObjectivesDiv.innerHTML = '';

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -199,6 +199,15 @@ describe('auto new game persistence', () => {
     expect(document.getElementById('selHexTerrain').innerHTML).toBe('Terrain: open');
   });
 
+  test('shows no selection message when no hex is selected', () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+
+    new Menu(fakeGame());
+
+    expect(document.getElementById('selHexContents').innerHTML).toBe('<em>No selection</em>');
+  });
+
   test('shows objective details when present on selected hex', () => {
     buildDom();
     history.replaceState(null, '', '/');
@@ -230,7 +239,7 @@ describe('auto new game persistence', () => {
     expect(document.getElementById('selHexObjectives').innerHTML).toBe('🚩 Hold (3 pts/turn)');
   });
 
-  test('renders victory points with faction colors and scores', () => {
+  test('renders victory points with faction colors and scores on initialization', () => {
     buildDom();
     history.replaceState(null, '', '/');
 
@@ -245,7 +254,7 @@ describe('auto new game persistence', () => {
       },
     ];
 
-    const menu = new Menu(fakeGame({
+    new Menu(fakeGame({
       getPlayers: () => ({
         getAllPlayers: () => players,
       }),
@@ -254,8 +263,6 @@ describe('auto new game persistence', () => {
         'Player 2': 1,
       }),
     }));
-
-    menu.updateMenu();
 
     const rows = document.querySelectorAll('.victory-row');
     expect(rows).toHaveLength(2);


### PR DESCRIPTION
### Motivation
- The menu did not render victory points or selected-hex content on initial load, leaving the Victory Points area empty until a hex was clicked. 
- When no hex is selected the UI should explicitly show a placeholder message for the Selected Hex section to make the empty state clear.

### Description
- Call `updateMenu()` from the `Menu` constructor so victory points and menu state are rendered on initialization.
- Show an italicized no-selection placeholder by setting `#selHexContentsDiv.innerHTML = '<em>No selection</em>'` when no hex is selected.
- Update unit tests in `tests/menu/menu.test.js` to assert the new no-selection message and to verify victory points render on initialization.

### Testing
- Ran `npm run test-and-build`, which runs lint, unit tests, and a build, and completed successfully. 
- Jest unit tests: 17 test suites and 96 tests passed. 
- Webpack build succeeded and produced the `dist` assets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987d8da0c808327a67f60dd8da2a3f3)