### PR TITLE
Refresh victory points after server scoring

### DIFF
--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -241,7 +241,10 @@ export class Menu {
       axios.post(
         `${API_URL}/games/${this.#game.getId()}/end-movement`,
         this.#game.getBoard().sparseBoard()
-      ).catch(err => console.error('Failed to update movement state', err));
+      ).then((response) => {
+        this.#game.updateScores?.(response?.data?.scores);
+        this.updateMenu();
+      }).catch(err => console.error('Failed to update movement state', err));
     }
     const switchedPlayers = this.#game.endPhase();
     this.updateMenu();
@@ -251,7 +254,10 @@ export class Menu {
       axios.post(
         `${API_URL}/games/${this.#game.getId()}/end-turn`,
         this.#game.getBoard().sparseBoard()
-      ).catch(err => console.error('Failed to update game state', err))
+      ).then((response) => {
+        this.#game.updateScores?.(response?.data?.scores);
+        this.updateMenu();
+      }).catch(err => console.error('Failed to update game state', err))
        .finally(() => {
          if (!this.#game.isGameOver()) {
            this.#game.getCurrentPlayer().play(this.#game);

--- a/battle-hexes-web/src/model/game.js
+++ b/battle-hexes-web/src/model/game.js
@@ -89,6 +89,20 @@ export class Game {
     return { ...this.#scores };
   }
 
+  updateScores(scores = {}) {
+    if (!scores || typeof scores !== 'object') {
+      this.#scores = {};
+      return;
+    }
+
+    const entries = Object.entries(scores).map(([playerName, value]) => {
+      const safeValue = Number.isFinite(value) ? value : 0;
+      return [playerName, safeValue];
+    });
+
+    this.#scores = Object.fromEntries(entries);
+  }
+
   isGameOver() {
     const owners = new Set();
     for (const unit of this.#board.getUnits()) {

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -1,6 +1,9 @@
 /** @jest-environment jsdom */
+import axios from 'axios';
 import { Menu } from '../../src/menu';
 import { eventBus } from '../../src/event-bus.js';
+
+jest.mock('axios');
 
 jest.mock('../../src/event-bus.js', () => ({
   eventBus: {
@@ -9,6 +12,8 @@ jest.mock('../../src/event-bus.js', () => ({
 }));
 
 describe('auto new game persistence', () => {
+  const flushPromises = () => new Promise((resolve) => queueMicrotask(resolve));
+
   function buildDom() {
     document.body.innerHTML = `
       <div id="selHexContents"></div>
@@ -55,6 +60,7 @@ describe('auto new game persistence', () => {
   beforeEach(() => {
     eventBus.emit.mockClear();
     window.localStorage.clear();
+    axios.post.mockReset();
   });
 
   test('checkbox reflects url parameter', () => {
@@ -119,8 +125,6 @@ describe('auto new game persistence', () => {
   });
 
   describe('new game button behaviour', () => {
-    const flushPromises = () => new Promise((resolve) => queueMicrotask(resolve));
-
     test('disables button during request and re-enables afterwards', async () => {
       buildDom();
       history.replaceState(null, '', '/');
@@ -300,5 +304,52 @@ describe('auto new game persistence', () => {
     expect(row.querySelector('.victory-name').textContent).toBe('Player 3');
     expect(row.querySelector('.victory-score').textContent).toBe('0');
     expect(row.querySelector('.victory-swatch').style.backgroundColor).toBe('rgb(176, 176, 176)');
+  });
+
+  test('updates victory points after end of movement response', async () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+
+    const players = [
+      {
+        getName: () => 'Player 1',
+        getFactions: () => [{ getCounterColor: () => '#ff0000' }],
+      },
+    ];
+
+    let currentScores = { 'Player 1': 0 };
+    const game = fakeGame({
+      getPlayers: () => ({
+        getAllPlayers: () => players,
+      }),
+      getScores: () => ({ ...currentScores }),
+      updateScores: (scores) => {
+        currentScores = { ...scores };
+      },
+      getCurrentPhase: () => 'Movement',
+      endPhase: () => false,
+      getBoard: () => ({
+        sparseBoard: () => ({}),
+        getSelectedHex: () => null,
+        isOwnHexSelected: () => false,
+        hasCombat: () => false,
+      }),
+    });
+
+    axios.post.mockResolvedValue({
+      data: {
+        scores: {
+          'Player 1': 4,
+        },
+      },
+    });
+
+    const menu = new Menu(game);
+    expect(document.querySelector('.victory-score').textContent).toBe('0');
+
+    menu.doEndPhase();
+    await flushPromises();
+
+    expect(document.querySelector('.victory-score').textContent).toBe('4');
   });
 });


### PR DESCRIPTION
### Motivation
- Victory point displays in the menu were not being refreshed after the server awarded objective points at the end of movement or turn, so the UI could show stale scores.

### Description
- Added `updateScores` to the frontend `Game` model to accept and normalize score payloads (`battle-hexes-web/src/model/game.js`).
- Hooked server responses from `end-movement` and `end-turn` in the menu phase completion flow to call `game.updateScores` and refresh the menu via `updateMenu()` (`battle-hexes-web/src/menu.js`).
- Added a unit test that stubs an `end-movement` response and verifies the victory points are updated in the DOM (`battle-hexes-web/tests/menu/menu.test.js`).

### Testing
- Ran `npm run test-and-build` which executed the test suite and build; all test suites passed and the webpack build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ebadf3948327991275f5a842dea1)