### PR TITLE
Highlight current player in Victory Points with Turn pill

### DIFF
--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -170,6 +170,7 @@ export class Menu {
     this.#victoryPointsList.innerHTML = '';
     const players = this.#game.getPlayers()?.getAllPlayers?.() ?? [];
     const scores = this.#game.getScores?.() ?? {};
+    const currentPlayerName = this.#game.getCurrentPlayer?.()?.getName?.();
 
     for (const player of players) {
       const row = document.createElement('div');
@@ -184,6 +185,17 @@ export class Menu {
       name.classList.add('victory-name');
       name.textContent = playerName;
 
+      const isCurrentPlayer = typeof currentPlayerName === 'string'
+        && currentPlayerName === playerName;
+      if (isCurrentPlayer) {
+        row.classList.add('victory-row-current');
+      }
+
+      const turnBadge = document.createElement('span');
+      turnBadge.classList.add('victory-turn-badge');
+      turnBadge.textContent = 'Turn';
+      turnBadge.hidden = !isCurrentPlayer;
+
       const leader = document.createElement('span');
       leader.classList.add('victory-leader');
 
@@ -192,7 +204,7 @@ export class Menu {
       const value = scores[playerName];
       score.textContent = Number.isFinite(value) ? value : 0;
 
-      row.append(swatch, name, leader, score);
+      row.append(swatch, name, turnBadge, leader, score);
       this.#victoryPointsList.appendChild(row);
     }
   }

--- a/battle-hexes-web/src/styles/menu.css
+++ b/battle-hexes-web/src/styles/menu.css
@@ -18,6 +18,12 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  padding: 4px 6px;
+  border-radius: 4px;
+}
+
+#menu .victory-row-current {
+  background-color: #d9e3f1;
 }
 
 #menu .victory-swatch {
@@ -30,6 +36,25 @@
 
 #menu .victory-name {
   white-space: nowrap;
+}
+
+#menu .victory-row-current .victory-name {
+  color: #1f5ea9;
+  font-weight: 700;
+}
+
+#menu .victory-turn-badge {
+  display: inline-flex;
+  align-items: center;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #fff;
+  background-color: #2c6fbe;
+  border: 1px solid #22579a;
+  border-radius: 12px;
+  padding: 1px 8px;
 }
 
 #menu .victory-leader {

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -262,6 +262,11 @@ describe('auto new game persistence', () => {
       getPlayers: () => ({
         getAllPlayers: () => players,
       }),
+      getCurrentPlayer: () => ({
+        getName: () => 'Player 1',
+        isHuman: () => true,
+        play: jest.fn(),
+      }),
       getScores: () => ({
         'Player 1': 3,
         'Player 2': 1,
@@ -274,10 +279,15 @@ describe('auto new game persistence', () => {
     expect(rows[0].querySelector('.victory-name').textContent).toBe('Player 1');
     expect(rows[0].querySelector('.victory-score').textContent).toBe('3');
     expect(rows[0].querySelector('.victory-swatch').style.backgroundColor).toBe('rgb(255, 0, 0)');
+    expect(rows[0].classList.contains('victory-row-current')).toBe(true);
+    expect(rows[0].querySelector('.victory-turn-badge').textContent).toBe('Turn');
+    expect(rows[0].querySelector('.victory-turn-badge').hidden).toBe(false);
 
     expect(rows[1].querySelector('.victory-name').textContent).toBe('Player 2');
     expect(rows[1].querySelector('.victory-score').textContent).toBe('1');
     expect(rows[1].querySelector('.victory-swatch').style.backgroundColor).toBe('rgb(0, 0, 255)');
+    expect(rows[1].classList.contains('victory-row-current')).toBe(false);
+    expect(rows[1].querySelector('.victory-turn-badge').hidden).toBe(true);
   });
 
   test('falls back to neutral swatch and zero score when missing data', () => {
@@ -351,5 +361,52 @@ describe('auto new game persistence', () => {
     await flushPromises();
 
     expect(document.querySelector('.victory-score').textContent).toBe('4');
+  });
+
+  test('moves turn badge and highlight when current player changes', () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+
+    const players = [
+      {
+        getName: () => 'Player 1',
+        getFactions: () => [{ getCounterColor: () => '#ff0000' }],
+      },
+      {
+        getName: () => 'Player 2',
+        getFactions: () => [{ getCounterColor: () => '#0000ff' }],
+      },
+    ];
+
+    let currentPlayerName = 'Player 1';
+    const menu = new Menu(fakeGame({
+      getPlayers: () => ({
+        getAllPlayers: () => players,
+      }),
+      getCurrentPlayer: () => ({
+        getName: () => currentPlayerName,
+        isHuman: () => true,
+        play: jest.fn(),
+      }),
+      getScores: () => ({
+        'Player 1': 3,
+        'Player 2': 1,
+      }),
+    }));
+
+    let rows = document.querySelectorAll('.victory-row');
+    expect(rows[0].classList.contains('victory-row-current')).toBe(true);
+    expect(rows[0].querySelector('.victory-turn-badge').hidden).toBe(false);
+    expect(rows[1].classList.contains('victory-row-current')).toBe(false);
+    expect(rows[1].querySelector('.victory-turn-badge').hidden).toBe(true);
+
+    currentPlayerName = 'Player 2';
+    menu.updateMenu();
+
+    rows = document.querySelectorAll('.victory-row');
+    expect(rows[0].classList.contains('victory-row-current')).toBe(false);
+    expect(rows[0].querySelector('.victory-turn-badge').hidden).toBe(true);
+    expect(rows[1].classList.contains('victory-row-current')).toBe(true);
+    expect(rows[1].querySelector('.victory-turn-badge').hidden).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation

- Improve the Victory Points UI so the active player is visually highlighted and clearly marked during their turn. 
- Ensure the new UI behavior is covered by unit tests so it remains stable and regressions are caught.

### Description

- Detects the current player in `#updateVictoryPoints` and adds a `victory-row-current` class to the active player row. 
- Inserts a `Turn` pill element (`.victory-turn-badge`) for each player row and toggles its visibility for the active player in `battle-hexes-web/src/menu.js`.
- Adds styling for the highlighted row, emphasized name, and pill appearance in `battle-hexes-web/src/styles/menu.css`.
- Adds and updates unit tests in `battle-hexes-web/tests/menu/menu.test.js` to assert the highlight and pill visibility on initial render and when the current player changes.

### Testing

- Ran the full web package verification with `npm run test-and-build`, which runs lint, Jest unit tests, and the webpack build. 
- All automated checks passed: the test-and-build step completed successfully and the test suite passed (`17` test suites, `99` tests passed) and the build compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a7f5ef3148327a5e45060692523a6)