### PR TITLE
Only render Turn badge for active player in web menu

### DIFF
--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -191,10 +191,13 @@ export class Menu {
         row.classList.add('victory-row-current');
       }
 
-      const turnBadge = document.createElement('span');
-      turnBadge.classList.add('victory-turn-badge');
-      turnBadge.textContent = 'Turn';
-      turnBadge.hidden = !isCurrentPlayer;
+      const turnBadge = isCurrentPlayer
+        ? document.createElement('span')
+        : null;
+      if (turnBadge) {
+        turnBadge.classList.add('victory-turn-badge');
+        turnBadge.textContent = 'Turn';
+      }
 
       const leader = document.createElement('span');
       leader.classList.add('victory-leader');
@@ -204,7 +207,7 @@ export class Menu {
       const value = scores[playerName];
       score.textContent = Number.isFinite(value) ? value : 0;
 
-      row.append(swatch, name, turnBadge, leader, score);
+      row.append(swatch, name, ...(turnBadge ? [turnBadge] : []), leader, score);
       this.#victoryPointsList.appendChild(row);
     }
   }

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -287,7 +287,7 @@ describe('auto new game persistence', () => {
     expect(rows[1].querySelector('.victory-score').textContent).toBe('1');
     expect(rows[1].querySelector('.victory-swatch').style.backgroundColor).toBe('rgb(0, 0, 255)');
     expect(rows[1].classList.contains('victory-row-current')).toBe(false);
-    expect(rows[1].querySelector('.victory-turn-badge').hidden).toBe(true);
+    expect(rows[1].querySelector('.victory-turn-badge')).toBeNull();
   });
 
   test('falls back to neutral swatch and zero score when missing data', () => {
@@ -398,14 +398,14 @@ describe('auto new game persistence', () => {
     expect(rows[0].classList.contains('victory-row-current')).toBe(true);
     expect(rows[0].querySelector('.victory-turn-badge').hidden).toBe(false);
     expect(rows[1].classList.contains('victory-row-current')).toBe(false);
-    expect(rows[1].querySelector('.victory-turn-badge').hidden).toBe(true);
+    expect(rows[1].querySelector('.victory-turn-badge')).toBeNull();
 
     currentPlayerName = 'Player 2';
     menu.updateMenu();
 
     rows = document.querySelectorAll('.victory-row');
     expect(rows[0].classList.contains('victory-row-current')).toBe(false);
-    expect(rows[0].querySelector('.victory-turn-badge').hidden).toBe(true);
+    expect(rows[0].querySelector('.victory-turn-badge')).toBeNull();
     expect(rows[1].classList.contains('victory-row-current')).toBe(true);
     expect(rows[1].querySelector('.victory-turn-badge').hidden).toBe(false);
   });


### PR DESCRIPTION
### Motivation
- Prevent the turn pill from being shown for off-turn players in the victory points list so only the active player row displays the `Turn` badge.

### Description
- Create the `.victory-turn-badge` element only when `isCurrentPlayer` is true and append it conditionally to the row, and update the menu unit tests to assert off-turn rows do not contain a turn badge element.

### Testing
- Ran `npm run test-and-build` in `battle-hexes-web`; all unit tests passed and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8edd7f9083278ae0f85e860f590a)