### PR TITLE
Load road metadata into scenario models

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
+++ b/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
@@ -51,6 +51,21 @@ class ScenarioTerrainType:
 
 
 @dataclass(frozen=True)
+class ScenarioRoadType:
+    """Representation of a road type as defined in a scenario."""
+
+    edge_move_cost: float
+
+
+@dataclass(frozen=True)
+class ScenarioRoad:
+    """Representation of a road path as defined in a scenario."""
+
+    type: str
+    path: tuple[tuple[int, int], ...]
+
+
+@dataclass(frozen=True)
 class Scenario:
     """Container for the data required to configure a game scenario."""
 
@@ -62,4 +77,6 @@ class Scenario:
     units: tuple[ScenarioUnit, ...] = field(default_factory=tuple)
     terrain_default: str | None = None
     terrain_types: dict[str, ScenarioTerrainType] = field(default_factory=dict)
+    road_types: dict[str, ScenarioRoadType] = field(default_factory=dict)
+    roads: tuple[ScenarioRoad, ...] = field(default_factory=tuple)
     hex_data: tuple[ScenarioHexData, ...] = field(default_factory=tuple)

--- a/battle_hexes_core/tests/scenario/test_scenario_loader.py
+++ b/battle_hexes_core/tests/scenario/test_scenario_loader.py
@@ -33,6 +33,19 @@ def test_load_scenario_data_from_directory():
     assert scenario.units[0].movement == 6
 
 
+def test_load_scenario_data_reads_roads_and_road_types():
+    scenario = load_scenario_data(
+        "village_1", scenario_dir=_scenario_dir()
+    )
+
+    assert scenario.road_types is not None
+    assert scenario.road_types["secondary"].edge_move_cost == 1
+    assert scenario.roads is not None
+    assert scenario.roads[0].type == "secondary"
+    assert scenario.roads[0].path[0] == (5, 0)
+    assert scenario.roads[0].path[-1] == (5, 5)
+
+
 def test_load_scenario_data_raises_for_mismatched_id(tmp_path):
     payload_path = _scenario_dir() / "elim_1.json"
     payload = json.loads(payload_path.read_text(encoding="utf-8"))
@@ -54,6 +67,23 @@ def test_load_scenario_converts_core_types():
     assert scenario.hex_data[1].units == ("red_unit_1",)
     assert scenario.hex_data[0].objectives[0].type == "hold"
     assert scenario.hex_data[0].objectives[0].points == 3
+
+
+def test_load_scenario_converts_roads_and_road_types():
+    scenario = load_scenario(
+        "village_1", scenario_dir=_scenario_dir()
+    )
+
+    assert scenario.road_types["secondary"].edge_move_cost == 1
+    assert scenario.roads[0].type == "secondary"
+    assert scenario.roads[0].path == (
+        (5, 0),
+        (5, 1),
+        (6, 2),
+        (6, 3),
+        (6, 4),
+        (5, 5),
+    )
 
 
 def test_load_scenario_assigns_objectives_to_hexes():


### PR DESCRIPTION
### Motivation

- Scenarios include road definitions (`road_types` and `roads`) in JSON but the core scenario models and loader did not expose or convert that data into the core `Scenario` object.

### Description

- Added core dataclasses `ScenarioRoadType` (with `edge_move_cost`) and `ScenarioRoad` (with `type` and `path`) and exposed `road_types` and `roads` on `Scenario`.
- Extended `ScenarioData` with Pydantic models `ScenarioRoadTypeData` and `ScenarioRoadEntry` and added `road_types`/`roads` fields to the data model.
- Implemented conversion helpers `_build_road_types` and `_build_roads` and wired them into `to_core()` so road metadata from JSON is converted into core objects.
- Added unit tests `test_load_scenario_data_reads_roads_and_road_types` and `test_load_scenario_converts_roads_and_road_types` to validate raw loading and core conversion using `village_1.json`.

### Testing

- Ran the full project checks with `./server-side-checks.sh` which runs unit tests and linting across packages, and all automated tests passed: `battle_hexes_core` 98 tests passed, `battle_agent_rl` 17 tests passed, and `battle_hexes_api` 31 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e726147f48327928c03506264e080)