### PR TITLE
Add dedicated road drawing layer with two-tone horizontal roads

### DIFF
--- a/battle-hexes-web/src/battle-draw.js
+++ b/battle-hexes-web/src/battle-draw.js
@@ -7,6 +7,8 @@ import { SelectionDrawer } from './drawer/selection-drawer.js';
 import { MoveSelectionDrawer } from './drawer/selection-drawer.js';
 import { CombatSelectionDrawer } from './drawer/selection-drawer.js';
 import { MoveArrowDrawer } from './drawer/move-arrow-drawer.js';
+import { RoadDrawer } from './drawer/road-drawer.js';
+import { TerrainOverlayDrawer } from './drawer/terrain-overlay-drawer.js';
 import { Menu } from './menu.js';
 import './styles/menu.css';
 import { GameCreator } from './model/game-creator.js';
@@ -62,13 +64,24 @@ new p5((p) => {
   const hexDrawWithCoords = new HexDrawer(p, hexRadius);
   hexDrawWithCoords.setShowHexCoords(menu.getShowHexCoordsPreference());
   const hexDraw = new HexDrawer(p, hexRadius);
+  const roadDraw = new RoadDrawer(p, hexDraw, () => game.getBoard().getRoads());
+  const terrainOverlayDraw = new TerrainOverlayDrawer(p, hexDraw);
   
   const unitDraw = new UnitDrawer(p, hexDraw);
   const combatSelectionDraw = new CombatSelectionDrawer(new HexDrawer(p, hexRadius));
   const selectionDraw = new SelectionDrawer(hexDraw);
   const moveSelectionDraw = new MoveSelectionDrawer(hexDraw);
   const moveArrowDraw = new MoveArrowDrawer(p, hexDraw);
-  const drawers = [hexDrawWithCoords, combatSelectionDraw, selectionDraw, moveSelectionDraw, unitDraw, moveArrowDraw];
+  const drawers = [
+    hexDrawWithCoords,
+    roadDraw,
+    terrainOverlayDraw,
+    combatSelectionDraw,
+    selectionDraw,
+    moveSelectionDraw,
+    unitDraw,
+    moveArrowDraw,
+  ];
 
   eventBus.on('hexCoordsVisibilityChanged', (shouldShow) => {
     hexDrawWithCoords.setShowHexCoords(shouldShow);
@@ -97,12 +110,10 @@ new p5((p) => {
     // console.log("I'm starting to draw!");
     p.background(90);
   
-    for (let currentHex of game.getBoard().getAllHexes()) {
-      hexDrawWithCoords.draw(currentHex);
-    }
-  
-    for (let currentHex of game.getBoard().getAllHexes()) {
-      unitDraw.draw(currentHex);
+    for (let drawer of drawers) {
+      for (let currentHex of game.getBoard().getAllHexes()) {
+        drawer.draw(currentHex);
+      }
     }  
   };
 

--- a/battle-hexes-web/src/drawer/hex-drawer.js
+++ b/battle-hexes-web/src/drawer/hex-drawer.js
@@ -1,12 +1,9 @@
-import { TerrainDrawerResolver } from "../terraindraw/terrain-drawer-resolver.js";
-
 export class HexDrawer {
   #p;
   #hexRadius;
   #hexHeight;
   #hexDiameter;
   #showHexCoords;
-  #terrainDrawerResolver;
 
   constructor(p, hexRadius) {
     this.#p = p;
@@ -15,14 +12,12 @@ export class HexDrawer {
     this.#hexDiameter = hexRadius * 2;
     
     this.#showHexCoords = false;
-    this.#terrainDrawerResolver = new TerrainDrawerResolver(p, this);
   }
 
   draw(hexToDraw) {
     const terrain = hexToDraw.getTerrain();
     const fillColor = terrain ? terrain.color : '#fffdd0';
     this.drawHex(hexToDraw, '#202020', 2, fillColor);
-    this.#terrainDrawerResolver.resolve(hexToDraw)?.draw(hexToDraw);
   }
 
   drawHex(hexToDraw, strokeColor, strokeSize, fillColor) {

--- a/battle-hexes-web/src/drawer/road-drawer.js
+++ b/battle-hexes-web/src/drawer/road-drawer.js
@@ -1,0 +1,41 @@
+export class RoadDrawer {
+  #p;
+  #hexDrawer;
+  #getRoads;
+
+  constructor(p, hexDrawer, getRoads) {
+    this.#p = p;
+    this.#hexDrawer = hexDrawer;
+    this.#getRoads = getRoads;
+  }
+
+  draw(aHex) {
+    if (!this.#hexHasRoad(aHex)) {
+      return;
+    }
+
+    const center = this.#hexDrawer.hexCenter(aHex);
+    const radius = this.#hexDrawer.getHexRadius();
+    const roadLength = radius * 1.35;
+
+    this.#p.stroke('#8A7650');
+    this.#p.strokeWeight(radius * 0.22);
+    this.#p.line(center.x - roadLength / 2, center.y, center.x + roadLength / 2, center.y);
+
+    this.#p.stroke('#C7B48A');
+    this.#p.strokeWeight(radius * 0.12);
+    this.#p.line(center.x - roadLength / 2, center.y, center.x + roadLength / 2, center.y);
+  }
+
+  #hexHasRoad(aHex) {
+    for (const road of this.#getRoads()) {
+      for (const [row, column] of road.path) {
+        if (row === aHex.row && column === aHex.column) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+}

--- a/battle-hexes-web/src/drawer/terrain-overlay-drawer.js
+++ b/battle-hexes-web/src/drawer/terrain-overlay-drawer.js
@@ -1,0 +1,13 @@
+import { TerrainDrawerResolver } from '../terraindraw/terrain-drawer-resolver.js';
+
+export class TerrainOverlayDrawer {
+  #terrainDrawerResolver;
+
+  constructor(p, hexDrawer) {
+    this.#terrainDrawerResolver = new TerrainDrawerResolver(p, hexDrawer);
+  }
+
+  draw(aHex) {
+    this.#terrainDrawerResolver.resolve(aHex)?.draw(aHex);
+  }
+}

--- a/battle-hexes-web/tests/drawer/hex-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/hex-drawer.test.js
@@ -2,18 +2,6 @@ import { HexDrawer } from '../../src/drawer/hex-drawer.js';
 import { Hex } from '../../src/model/hex.js';
 import { Terrain } from '../../src/model/terrain.js';
 
-let mockResolve;
-let mockTerrainDrawerResolverConstructor;
-
-jest.mock('../../src/terraindraw/terrain-drawer-resolver.js', () => {
-  mockTerrainDrawerResolverConstructor = jest.fn();
-  mockResolve = jest.fn();
-  mockTerrainDrawerResolverConstructor.mockImplementation(() => ({
-    resolve: mockResolve
-  }));
-  return { TerrainDrawerResolver: mockTerrainDrawerResolverConstructor };
-});
-
 class TestHexDrawer extends HexDrawer {
   constructor(...args) {
     super(...args);
@@ -25,7 +13,7 @@ class TestHexDrawer extends HexDrawer {
       hexToDraw,
       strokeColor,
       strokeSize,
-      fillColor
+      fillColor,
     });
   }
 }
@@ -41,7 +29,7 @@ const createMockP5 = () => ({
   beginShape: jest.fn(),
   vertex: jest.fn(),
   endShape: jest.fn(),
-  CENTER: 'CENTER'
+  CENTER: 'CENTER',
 });
 
 describe('HexDrawer.draw', () => {
@@ -51,8 +39,6 @@ describe('HexDrawer.draw', () => {
   beforeEach(() => {
     p5 = createMockP5();
     hexDrawer = new TestHexDrawer(p5, 30);
-    mockResolve.mockReset();
-    mockTerrainDrawerResolverConstructor.mockClear();
   });
 
   test('uses terrain color when hex has terrain', () => {
@@ -73,31 +59,5 @@ describe('HexDrawer.draw', () => {
 
     expect(hexDrawer.drawnHexes).toHaveLength(1);
     expect(hexDrawer.drawnHexes[0].fillColor).toBe('#fffdd0');
-  });
-
-  test('draws terrain overlay when resolver returns a drawer', () => {
-    const hex = new Hex(1, 2);
-    const terrain = new Terrain('village', '#9b8f7a');
-    hex.setTerrain(terrain);
-
-    const terrainDrawer = { draw: jest.fn() };
-    mockResolve.mockReturnValue(terrainDrawer);
-
-    hexDrawer.draw(hex);
-
-    expect(mockResolve).toHaveBeenCalledWith(hex);
-    expect(terrainDrawer.draw).toHaveBeenCalledWith(hex);
-  });
-
-  test('skips terrain overlay when resolver returns null', () => {
-    const hex = new Hex(3, 4);
-    const terrain = new Terrain('village', '#9b8f7a');
-    hex.setTerrain(terrain);
-
-    mockResolve.mockReturnValue(null);
-
-    hexDrawer.draw(hex);
-
-    expect(mockResolve).toHaveBeenCalledWith(hex);
   });
 });

--- a/battle-hexes-web/tests/drawer/road-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/road-drawer.test.js
@@ -1,0 +1,48 @@
+import { RoadDrawer } from '../../src/drawer/road-drawer.js';
+import { Hex } from '../../src/model/hex.js';
+import { Road, RoadType } from '../../src/model/road.js';
+
+const createMockP5 = () => ({
+  stroke: jest.fn(),
+  strokeWeight: jest.fn(),
+  line: jest.fn(),
+});
+
+const createHexDrawer = ({ radius = 50, center = { x: 100, y: 200 } } = {}) => ({
+  getHexRadius: jest.fn(() => radius),
+  hexCenter: jest.fn(() => center),
+});
+
+describe('RoadDrawer.draw', () => {
+  test('draws a two-tone horizontal road when a road crosses the hex', () => {
+    const p5 = createMockP5();
+    const hexDrawer = createHexDrawer();
+    const roadType = new RoadType('secondary', 1);
+    const roads = [new Road(roadType, [[2, 3], [2, 4]])];
+    const roadDrawer = new RoadDrawer(p5, hexDrawer, () => roads);
+
+    roadDrawer.draw(new Hex(2, 3));
+
+    expect(p5.stroke).toHaveBeenNthCalledWith(1, '#8A7650');
+    expect(p5.strokeWeight).toHaveBeenNthCalledWith(1, 11);
+    expect(p5.line).toHaveBeenNthCalledWith(1, 66.25, 200, 133.75, 200);
+
+    expect(p5.stroke).toHaveBeenNthCalledWith(2, '#C7B48A');
+    expect(p5.strokeWeight).toHaveBeenNthCalledWith(2, 6);
+    expect(p5.line).toHaveBeenNthCalledWith(2, 66.25, 200, 133.75, 200);
+  });
+
+  test('does not draw anything when no road crosses the hex', () => {
+    const p5 = createMockP5();
+    const hexDrawer = createHexDrawer();
+    const roadType = new RoadType('secondary', 1);
+    const roads = [new Road(roadType, [[2, 4], [2, 5]])];
+    const roadDrawer = new RoadDrawer(p5, hexDrawer, () => roads);
+
+    roadDrawer.draw(new Hex(2, 3));
+
+    expect(p5.stroke).not.toHaveBeenCalled();
+    expect(p5.strokeWeight).not.toHaveBeenCalled();
+    expect(p5.line).not.toHaveBeenCalled();
+  });
+});

--- a/battle-hexes-web/tests/drawer/terrain-overlay-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/terrain-overlay-drawer.test.js
@@ -1,0 +1,42 @@
+import { TerrainOverlayDrawer } from '../../src/drawer/terrain-overlay-drawer.js';
+
+let mockResolve;
+let mockTerrainDrawerResolverConstructor;
+
+jest.mock('../../src/terraindraw/terrain-drawer-resolver.js', () => {
+  mockTerrainDrawerResolverConstructor = jest.fn();
+  mockResolve = jest.fn();
+  mockTerrainDrawerResolverConstructor.mockImplementation(() => ({
+    resolve: mockResolve,
+  }));
+  return { TerrainDrawerResolver: mockTerrainDrawerResolverConstructor };
+});
+
+describe('TerrainOverlayDrawer.draw', () => {
+  beforeEach(() => {
+    mockResolve.mockReset();
+    mockTerrainDrawerResolverConstructor.mockClear();
+  });
+
+  test('draws terrain overlay when resolver returns a drawer', () => {
+    const terrainOverlayDrawer = new TerrainOverlayDrawer({}, {});
+    const hex = { id: 'hex-1' };
+    const terrainDrawer = { draw: jest.fn() };
+    mockResolve.mockReturnValue(terrainDrawer);
+
+    terrainOverlayDrawer.draw(hex);
+
+    expect(mockResolve).toHaveBeenCalledWith(hex);
+    expect(terrainDrawer.draw).toHaveBeenCalledWith(hex);
+  });
+
+  test('skips terrain overlay when resolver returns null', () => {
+    const terrainOverlayDrawer = new TerrainOverlayDrawer({}, {});
+    const hex = { id: 'hex-1' };
+    mockResolve.mockReturnValue(null);
+
+    terrainOverlayDrawer.draw(hex);
+
+    expect(mockResolve).toHaveBeenCalledWith(hex);
+  });
+});


### PR DESCRIPTION
### Motivation

- Render roads as a separate, visible layer on top of hex fills so UI elements (villages, unit counters) can stay above roads.
- Start with a simple visual indicator: a horizontal two-tone stroke per hex that participates in any road path, using the requested hard-coded colors. 
- Keep road logic out of `Hex`/`HexDrawer` so hex classes remain focused on base geometry/terrain.

### Description

- Added `RoadDrawer` (`src/drawer/road-drawer.js`) that draws a horizontal two-tone road on hexes included in any road path using the colors `#8A7650` (base) and `#C7B48A` (top) with stroke sizes scaled to hex radius. 
- Introduced `TerrainOverlayDrawer` (`src/drawer/terrain-overlay-drawer.js`) to move terrain overlays (e.g. villages) out of `HexDrawer` and render them as their own layer. 
- Simplified `HexDrawer` (`src/drawer/hex-drawer.js`) to only draw base hex geometry and fill color (terrain overlays removed). 
- Updated the main render pipeline (`src/battle-draw.js`) to use a `drawers` array and render in this order: hexes -> roads -> terrain overlays -> selections -> units -> move arrows. 
- Added unit tests for the new drawers and adjusted the `HexDrawer` tests: `tests/drawer/road-drawer.test.js`, `tests/drawer/terrain-overlay-drawer.test.js`, and updated `tests/drawer/hex-drawer.test.js`.

### Testing

- Ran `npm run test-and-build` in `battle-hexes-web`, which runs lint, Jest tests, and the webpack build, and all checks passed. 
- Jest summary: all test suites passed (20 suites, 104 tests) and webpack compiled successfully. 
- Performed a quick visual validation by serving the built app with a mocked API and capturing a screenshot to confirm roads render as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69910a50a8a48327b2fbe6a95869c2d0)