### PR TITLE
Blend and soften RoadDrawer two-pass dirt stroke rendering

### DIFF
--- a/battle-hexes-web/src/drawer/road-drawer.js
+++ b/battle-hexes-web/src/drawer/road-drawer.js
@@ -17,14 +17,27 @@ export class RoadDrawer {
     const center = this.#hexDrawer.hexCenter(aHex);
     const radius = this.#hexDrawer.getHexRadius();
     const roadLength = radius * 1.35;
+    const x1 = center.x - roadLength / 2;
+    const x2 = center.x + roadLength / 2;
+    const y = center.y;
+    const ctx = this.#p.drawingContext;
 
-    this.#p.stroke('#8A7650');
+    this.#p.push();
+    this.#p.strokeCap(this.#p.ROUND);
+    this.#p.strokeJoin(this.#p.ROUND);
+
+    ctx.shadowBlur = radius * 0.12;
+    ctx.shadowColor = 'rgba(0,0,0,0.18)';
+    this.#p.stroke(0x8A, 0x76, 0x50, 220);
     this.#p.strokeWeight(radius * 0.33);
-    this.#p.line(center.x - roadLength / 2, center.y, center.x + roadLength / 2, center.y);
+    this.#p.line(x1, y, x2, y);
 
-    this.#p.stroke('#C7B48A');
+    ctx.shadowBlur = 0;
+    ctx.shadowColor = 'rgba(0,0,0,0)';
+    this.#p.stroke(0xC7, 0xB4, 0x8A, 205);
     this.#p.strokeWeight(radius * 0.18);
-    this.#p.line(center.x - roadLength / 2, center.y, center.x + roadLength / 2, center.y);
+    this.#p.line(x1, y, x2, y);
+    this.#p.pop();
   }
 
   #hexHasRoad(aHex) {

--- a/battle-hexes-web/tests/drawer/road-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/road-drawer.test.js
@@ -2,11 +2,24 @@ import { RoadDrawer } from '../../src/drawer/road-drawer.js';
 import { Hex } from '../../src/model/hex.js';
 import { Road, RoadType } from '../../src/model/road.js';
 
-const createMockP5 = () => ({
-  stroke: jest.fn(),
-  strokeWeight: jest.fn(),
-  line: jest.fn(),
-});
+const createMockP5 = () => {
+  const drawingContext = {
+    shadowBlur: 0,
+    shadowColor: '',
+  };
+
+  return {
+    ROUND: 'round',
+    drawingContext,
+    push: jest.fn(),
+    pop: jest.fn(),
+    strokeCap: jest.fn(),
+    strokeJoin: jest.fn(),
+    stroke: jest.fn(),
+    strokeWeight: jest.fn(),
+    line: jest.fn(),
+  };
+};
 
 const createHexDrawer = ({ radius = 50, center = { x: 100, y: 200 } } = {}) => ({
   getHexRadius: jest.fn(() => radius),
@@ -23,13 +36,21 @@ describe('RoadDrawer.draw', () => {
 
     roadDrawer.draw(new Hex(2, 3));
 
-    expect(p5.stroke).toHaveBeenNthCalledWith(1, '#8A7650');
+    expect(p5.push).toHaveBeenCalledTimes(1);
+    expect(p5.strokeCap).toHaveBeenCalledWith(p5.ROUND);
+    expect(p5.strokeJoin).toHaveBeenCalledWith(p5.ROUND);
+
+    expect(p5.stroke).toHaveBeenNthCalledWith(1, 0x8A, 0x76, 0x50, 220);
     expect(p5.strokeWeight).toHaveBeenNthCalledWith(1, expect.any(Number));
     expect(p5.line).toHaveBeenNthCalledWith(1, 66.25, 200, 133.75, 200);
 
-    expect(p5.stroke).toHaveBeenNthCalledWith(2, '#C7B48A');
+    expect(p5.stroke).toHaveBeenNthCalledWith(2, 0xC7, 0xB4, 0x8A, 205);
     expect(p5.strokeWeight).toHaveBeenNthCalledWith(2, expect.any(Number));
     expect(p5.line).toHaveBeenNthCalledWith(2, 66.25, 200, 133.75, 200);
+
+    expect(p5.drawingContext.shadowBlur).toBe(0);
+    expect(p5.drawingContext.shadowColor).toBe('rgba(0,0,0,0)');
+    expect(p5.pop).toHaveBeenCalledTimes(1);
   });
 
   test('does not draw anything when no road crosses the hex', () => {
@@ -44,5 +65,7 @@ describe('RoadDrawer.draw', () => {
     expect(p5.stroke).not.toHaveBeenCalled();
     expect(p5.strokeWeight).not.toHaveBeenCalled();
     expect(p5.line).not.toHaveBeenCalled();
+    expect(p5.push).not.toHaveBeenCalled();
+    expect(p5.pop).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Motivation
- Improve the visual blending of the two-layer dirt road so strokes look more organic and integrate with terrain.
- Soften and round road ends/joins while preserving the existing stroke-weight proportions and simple horizontal-segment behavior.
- Keep drawing behavior unchanged (still only render when `#hexHasRoad(aHex)` is true and still a simple horizontal segment). 

### Description
- Wrap road rendering in `this.#p.push()`/`this.#p.pop()` and set rounded stroke caps/joins with `strokeCap(this.#p.ROUND)` and `strokeJoin(this.#p.ROUND)`.
- Replace hex-string strokes with RGBA calls for both passes: under-stroke uses `stroke(0x8A,0x76,0x50,220)` and top-stroke uses `stroke(0xC7,0xB4,0x8A,205)`, keeping strokeWeight ratios (`0.33` and `0.18` of radius).
- Apply subtle feathering to the under-stroke via the canvas context (`const ctx = this.#p.drawingContext`) using `ctx.shadowBlur = radius * 0.12` and `ctx.shadowColor = 'rgba(0,0,0,0.18)'`, then reset shadow state before the highlight stroke.
- Refactor to compute `x1`, `x2`, and `y` once and reuse them for both `line()` calls to avoid duplicating arguments. 

### Testing
- Updated the drawer unit test `battle-hexes-web/tests/drawer/road-drawer.test.js` to assert the new p5 calls (`push`/`pop`, `strokeCap`, `strokeJoin`, RGBA stroke args, and drawing-context reset).
- Ran `npm run test-and-build` which executed linting, the test suite, and a build; all test suites passed (`20` test suites, `104` tests) and the webpack build completed successfully.
- Visual check: built app and rendered a sample `battle.html` to validate the softened road appearance in the browser build artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699115999ddc832785d9ef4719197979)