### PR TITLE
Add deterministic forest terrain overlay drawer with pine glyphs

### DIFF
--- a/battle-hexes-web/src/terraindraw/forest-drawer.js
+++ b/battle-hexes-web/src/terraindraw/forest-drawer.js
@@ -1,0 +1,66 @@
+const PINE_FILL_COLORS = ['#4F5B44', '#606C52'];
+const PINE_OUTLINE_COLOR = '#2F3528';
+
+export class ForestDrawer {
+  #p;
+  #hexDrawer;
+
+  constructor(p, hexDrawer) {
+    this.#p = p;
+    this.#hexDrawer = hexDrawer;
+  }
+
+  draw(aHex) {
+    const row = aHex.getRow?.() ?? aHex.row ?? 0;
+    const column = aHex.getColumn?.() ?? aHex.column ?? 0;
+    this.#p.randomSeed(this.#seedFromCoords(row, column));
+
+    const center = this.#hexDrawer.hexCenter(aHex);
+    const radius = this.#hexDrawer.getHexRadius();
+    const innerRadius = radius * 0.68;
+    const treeCount = Math.max(8, Math.floor(radius * 0.16 + this.#p.random(11) + 8));
+    const strokeWeight = Math.max(0.4, radius * 0.016);
+
+    this.#p.stroke(PINE_OUTLINE_COLOR);
+    this.#p.strokeWeight(strokeWeight);
+
+    for (let i = 0; i < treeCount; i += 1) {
+      const angle = this.#p.random(this.#p.TWO_PI);
+      const distance = Math.sqrt(this.#p.random()) * innerRadius;
+      const x = center.x + this.#p.cos(angle) * distance;
+      const y = center.y + this.#p.sin(angle) * distance;
+      const treeHeight = this.#p.random(radius * 0.15, radius * 0.24);
+      const treeWidth = treeHeight * this.#p.random(0.55, 0.72);
+      const rotation = this.#p.random(-0.1745, 0.1745);
+      const fillColor = PINE_FILL_COLORS[Math.floor(this.#p.random(PINE_FILL_COLORS.length))];
+      const layerCount = this.#p.random() < 0.5 ? 1 : 2;
+
+      this.#drawPineGlyph(x, y, treeWidth, treeHeight, rotation, fillColor, layerCount);
+    }
+
+    this.#p.randomSeed();
+  }
+
+  #drawPineGlyph(x, y, width, height, rotation, fillColor, layerCount) {
+    this.#p.push();
+    this.#p.translate(x, y);
+    this.#p.rotate(rotation);
+    this.#p.fill(fillColor);
+
+    if (layerCount === 2) {
+      this.#p.triangle(-width * 0.42, -height * 0.3, width * 0.42, -height * 0.3, 0, -height);
+      this.#p.triangle(-width * 0.5, height * 0.06, width * 0.5, height * 0.06, 0, -height * 0.55);
+    } else {
+      this.#p.triangle(-width * 0.52, height * 0.05, width * 0.52, height * 0.05, 0, -height);
+    }
+
+    this.#p.line(0, height * 0.04, 0, height * 0.28);
+    this.#p.pop();
+  }
+
+  #seedFromCoords(row, column) {
+    const rowPart = (row * 73856093) >>> 0;
+    const colPart = (column * 19349663) >>> 0;
+    return (rowPart ^ colPart) >>> 0;
+  }
+}

--- a/battle-hexes-web/src/terraindraw/terrain-drawer-resolver.js
+++ b/battle-hexes-web/src/terraindraw/terrain-drawer-resolver.js
@@ -1,5 +1,6 @@
 import { RoughDrawer } from "./rough-drawer.js";
 import { VillageDrawer } from "./village-drawer.js";
+import { ForestDrawer } from "./forest-drawer.js";
 
 export class TerrainDrawerResolver {
   #terrainMap;
@@ -7,7 +8,8 @@ export class TerrainDrawerResolver {
   constructor(p, hexDrawer) {
     this.#terrainMap = new Map([
       ["village", new VillageDrawer(p, hexDrawer)],
-      ["rough", new RoughDrawer(p, hexDrawer)]
+      ["rough", new RoughDrawer(p, hexDrawer)],
+      ["forest", new ForestDrawer(p, hexDrawer)]
     ]);
   }
 

--- a/battle-hexes-web/tests/drawer/forest-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/forest-drawer.test.js
@@ -1,0 +1,77 @@
+import { ForestDrawer } from '../../src/terraindraw/forest-drawer.js';
+
+const createMockP5 = () => ({
+  TWO_PI: Math.PI * 2,
+  cos: Math.cos,
+  sin: Math.sin,
+  random: jest.fn((min, max) => {
+    if (typeof min === 'undefined') {
+      return 0.5;
+    }
+
+    if (typeof max === 'undefined') {
+      return min * 0.5;
+    }
+
+    return min + (max - min) * 0.5;
+  }),
+  randomSeed: jest.fn(),
+  stroke: jest.fn(),
+  strokeWeight: jest.fn(),
+  fill: jest.fn(),
+  push: jest.fn(),
+  pop: jest.fn(),
+  translate: jest.fn(),
+  rotate: jest.fn(),
+  triangle: jest.fn(),
+  line: jest.fn(),
+});
+
+describe('ForestDrawer', () => {
+  test('draw renders deterministic pine glyphs inside the hex', () => {
+    const p5 = createMockP5();
+    const hexDrawer = {
+      hexCenter: jest.fn(() => ({ x: 100, y: 100 })),
+      getHexRadius: jest.fn(() => 40),
+    };
+    const forestDrawer = new ForestDrawer(p5, hexDrawer);
+    const hex = {
+      getRow: jest.fn(() => 3),
+      getColumn: jest.fn(() => 5),
+    };
+
+    forestDrawer.draw(hex);
+
+    expect(p5.randomSeed).toHaveBeenCalledTimes(2);
+    expect(p5.randomSeed.mock.calls[0][0]).toBe(149986828);
+    expect(p5.randomSeed.mock.calls[1][0]).toBeUndefined();
+    expect(p5.stroke).toHaveBeenCalledWith('#2F3528');
+    expect(p5.strokeWeight).toHaveBeenCalledWith(0.64);
+
+    expect(p5.fill).toHaveBeenCalled();
+    const fills = p5.fill.mock.calls.map((call) => call[0]);
+    expect(fills.every((color) => color === '#4F5B44' || color === '#606C52')).toBe(true);
+
+    expect(p5.push).toHaveBeenCalledTimes(19);
+    expect(p5.pop).toHaveBeenCalledTimes(19);
+    expect(p5.triangle).toHaveBeenCalledTimes(38);
+    expect(p5.line).toHaveBeenCalledTimes(19);
+
+    expect(p5.rotate).toHaveBeenCalledWith(0);
+  });
+
+  test('draw supports direct row/column properties and applies minimum stroke weight', () => {
+    const p5 = createMockP5();
+    const hexDrawer = {
+      hexCenter: jest.fn(() => ({ x: 0, y: 0 })),
+      getHexRadius: jest.fn(() => 5),
+    };
+    const forestDrawer = new ForestDrawer(p5, hexDrawer);
+
+    forestDrawer.draw({ row: 1, column: 2 });
+
+    expect(p5.push).toHaveBeenCalledTimes(14);
+    expect(p5.line).toHaveBeenCalledTimes(14);
+    expect(p5.strokeWeight).toHaveBeenCalledWith(0.4);
+  });
+});

--- a/battle-hexes-web/tests/drawer/terrain-drawer-resolver.test.js
+++ b/battle-hexes-web/tests/drawer/terrain-drawer-resolver.test.js
@@ -25,10 +25,22 @@ describe('TerrainDrawerResolver', () => {
     expect(typeof drawer.draw).toBe('function');
   });
 
-  test('returns null when no terrain drawer is registered', () => {
+  test('resolves forest terrain to a drawer instance', () => {
     const resolver = new TerrainDrawerResolver({}, {});
     const hex = {
       getTerrain: jest.fn(() => ({ name: 'forest' })),
+    };
+
+    const drawer = resolver.resolve(hex);
+
+    expect(drawer).not.toBeNull();
+    expect(typeof drawer.draw).toBe('function');
+  });
+
+  test('returns null when no terrain drawer is registered', () => {
+    const resolver = new TerrainDrawerResolver({}, {});
+    const hex = {
+      getTerrain: jest.fn(() => ({ name: 'marsh' })),
     };
 
     expect(resolver.resolve(hex)).toBeNull();


### PR DESCRIPTION
### Motivation
- Provide a forest terrain overlay for web hexes that visually matches existing terrain overlay style and can be resolved by the terrain resolver. 
- Trees must be deterministic per-hex so redraws do not change appearance, and should be small, organic “tiny pines” that scale with hex radius. 

### Description
- Add `ForestDrawer` (`battle-hexes-web/src/terraindraw/forest-drawer.js`) that seeds p5 randomness from `(row,column)`, samples positions within an inner radius, and draws ~8–18 pine glyphs (1–2 stacked triangles + small trunk line) with slight per-tree rotation. 
- Use the fill palette `#4F5B44` / `#606C52` and outline `#2F3528` with stroke weight scaled to radius and a minimum cap, and keep glyph placement constrained to the hex interior. 
- Register the drawer in `TerrainDrawerResolver` so terrain name `forest` resolves to the new `ForestDrawer`. 
- Add unit tests (`battle-hexes-web/tests/drawer/forest-drawer.test.js`) asserting deterministic seeding, expected draw calls and palette usage, and update resolver tests to cover `forest` resolution. 

### Testing
- Ran the full frontend validation with `npm run test-and-build` in `battle-hexes-web`, which ran lint, Jest unit tests, and a webpack build, and completed successfully. 
- All unit tests passed (`jest`), and the webpack build produced a distributable `dist` bundle. 
- Served the built site with `python -m http.server` and captured a Playwright screenshot of `battle.html` to visually validate the overlay.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a443be99a8832799d0eaaf60187469)