### PR TITLE
Propagate terrain movement costs from scenario data to web movement deduction

### DIFF
--- a/battle-hexes-web/src/model/game-creator.js
+++ b/battle-hexes-web/src/model/game-creator.js
@@ -98,14 +98,17 @@ export class GameCreator {
       for (const [key, value] of Object.entries(terrainData.types)) {
         const name = value?.name ?? key;
         const color = value?.color ?? '#F0F0F0';
-        terrainTypes.set(key, new Terrain(name, color));
+        const moveCost = Number.isFinite(value?.move_cost) && value.move_cost > 0
+          ? value.move_cost
+          : 1;
+        terrainTypes.set(key, new Terrain(name, color, moveCost));
       }
     }
 
     const defaultTerrainId = typeof terrainData?.default === 'string' ? terrainData.default : null;
     const defaultTerrain =
       (defaultTerrainId ? terrainTypes.get(defaultTerrainId) : null)
-      ?? (defaultTerrainId ? new Terrain(defaultTerrainId, '#F0F0F0') : new Terrain('default', '#F0F0F0'));
+      ?? (defaultTerrainId ? new Terrain(defaultTerrainId, '#F0F0F0', 1) : new Terrain('default', '#F0F0F0', 1));
 
     for (const hex of board.getAllHexes()) {
       hex.setTerrain(defaultTerrain);

--- a/battle-hexes-web/src/model/terrain.js
+++ b/battle-hexes-web/src/model/terrain.js
@@ -1,10 +1,12 @@
 export class Terrain {
   #name;
   #color;
+  #moveCost;
 
-  constructor(name, color) {
+  constructor(name, color, moveCost = 1) {
     this.#name = name;
     this.#color = color;
+    this.#moveCost = Number.isFinite(moveCost) && moveCost > 0 ? moveCost : 1;
   }
 
   get name() {
@@ -13,5 +15,9 @@ export class Terrain {
 
   get color() {
     return this.#color;
+  }
+
+  get moveCost() {
+    return this.#moveCost;
   }
 }

--- a/battle-hexes-web/src/model/unit.js
+++ b/battle-hexes-web/src/model/unit.js
@@ -76,10 +76,16 @@ export class Unit {
     this.updateCombatOpponents(adjacentHexes);
 
     if (this.#combatOpponents.length > 0) {
-      this.#movesRemaining = 0; 
-    } else if (this.#movesRemaining > 0) {
-      this.#movesRemaining--;
+      this.#movesRemaining = 0;
+      return;
     }
+
+    const terrainMoveCost = destinationHex?.getTerrain()?.moveCost;
+    const moveCost = Number.isFinite(terrainMoveCost) && terrainMoveCost > 0
+      ? terrainMoveCost
+      : 1;
+
+    this.#movesRemaining = Math.max(0, this.#movesRemaining - moveCost);
   }
 
   updateCombatOpponents(adjacentHexes) {

--- a/battle-hexes-web/tests/model/game-creator.test.js
+++ b/battle-hexes-web/tests/model/game-creator.test.js
@@ -14,7 +14,7 @@ beforeEach(() => {
     '"board":{"rows":10,"columns":10,"units":[' +
     '{"id":"a22c90d0-db87-41d0-8c3a-00c04fd708be","name":"Red Unit","faction_id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","type":"Infantry","attack":2,"defense":2,"move":6,"row":6,"column":4},' +
     '{"id":"c9a440d2-2b0a-4730-b4c6-da394b642c61","name":"Blue Unit","faction_id":"38400000-8cf0-41bd-b23e-10b96e4ef00d","type":"Infantry","attack":4,"defense":4,"move":4,"row":3,"column":5}],' +
-    '"terrain":{"default":"open","types":{"open":{"name":"open","color":"#C6AA5C"},"village":{"name":"village","color":"#9A8F7A"}},"hexes":[{"row":6,"column":4,"terrain":"village"}]},' +
+    '"terrain":{"default":"open","types":{"open":{"name":"open","color":"#C6AA5C"},"village":{"name":"village","color":"#9A8F7A","move_cost":2}},"hexes":[{"row":6,"column":4,"terrain":"village"}]},' +
     '"road_types":{"secondary":1.0},' +
     '"road_paths":[{"type":"secondary","path":[{"row":5,"column":0},{"row":5,"column":1},{"row":6,"column":2}]}]},' +
     '"objectives":[{"row":6,"column":4,"points":3,"type":"hold"}]}'
@@ -122,6 +122,7 @@ describe("createGame", () => {
 
     expect(defaultHex.getTerrain().name).toBe('open');
     expect(defaultHex.getTerrain().color).toBe('#C6AA5C');
+    expect(defaultHex.getTerrain().moveCost).toBe(1);
   });
 
   test('board assigns terrain overrides to specified hexes', () => {
@@ -129,6 +130,7 @@ describe("createGame", () => {
 
     expect(terrainHex.getTerrain().name).toBe('village');
     expect(terrainHex.getTerrain().color).toBe('#9A8F7A');
+    expect(terrainHex.getTerrain().moveCost).toBe(2);
   });
 
   test('board assigns objectives to specified hexes', () => {

--- a/battle-hexes-web/tests/model/unit.test.js
+++ b/battle-hexes-web/tests/model/unit.test.js
@@ -44,6 +44,17 @@ describe('move', () => {
     expect(unit.getMovesRemaining()).toBe(3);
   });
 
+
+  test('deducts terrain move cost when not adjacent to opponent', () => {
+    const unit = new Unit('7', 'Test Unit', friendlyFaction, null, 4, 4, 4);
+    const destinationHex = new Hex(5, 5);
+    destinationHex.setTerrain({ moveCost: 3 });
+
+    unit.move(destinationHex, [new Hex(4, 5), new Hex(5, 6)]);
+
+    expect(unit.getMovesRemaining()).toBe(1);
+  });
+
   test('adds combat opponent when opponent is adjacent', () => {
     const unit = new Unit('5', 'Test Unit', friendlyFaction, null, 4, 4, 4);
     const oppHex = new Hex(5, 6);

--- a/battle_hexes_api/src/battle_hexes_api/schemas/terrain.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/terrain.py
@@ -15,6 +15,7 @@ class TerrainTypeModel(BaseModel):
 
     name: str
     color: str
+    move_cost: int = 1
 
     @classmethod
     def from_scenario_type(
@@ -22,7 +23,11 @@ class TerrainTypeModel(BaseModel):
     ) -> "TerrainTypeModel":
         """Create a terrain type model from scenario data."""
 
-        return cls(name=name, color=terrain_type.color)
+        return cls(
+            name=name,
+            color=terrain_type.color,
+            move_cost=terrain_type.move_cost,
+        )
 
 
 class TerrainHexModel(BaseModel):

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -42,6 +42,10 @@ class TestFastAPI(unittest.TestCase):
             "#C6AA5C",
         )
         self.assertEqual(
+            terrain.get("types", {}).get("open", {}).get("move_cost"),
+            1,
+        )
+        self.assertEqual(
             terrain.get("hexes"),
             [{"row": 5, "column": 5, "terrain": "village"}],
         )

--- a/battle_hexes_api/tests/test_schemas_board.py
+++ b/battle_hexes_api/tests/test_schemas_board.py
@@ -125,7 +125,7 @@ class TestBoardModel(unittest.TestCase):
             terrain_default="open",
             terrain_types={
                 "open": ScenarioTerrainType(color="#C6AA5C"),
-                "village": ScenarioTerrainType(color="#9A8F7A"),
+                "village": ScenarioTerrainType(color="#9A8F7A", move_cost=2),
             },
         )
         self.board.get_hex(0, 0).set_terrain(Terrain("open", "#C6AA5C"))
@@ -135,9 +135,11 @@ class TestBoardModel(unittest.TestCase):
 
         self.assertEqual(board_model.terrain.default, "open")
         self.assertEqual(board_model.terrain.types["open"].color, "#C6AA5C")
+        self.assertEqual(board_model.terrain.types["open"].move_cost, 1)
         self.assertEqual(
             board_model.terrain.types["village"].color, "#9A8F7A"
         )
+        self.assertEqual(board_model.terrain.types["village"].move_cost, 2)
         self.assertEqual(len(board_model.terrain.hexes), 1)
         self.assertEqual(board_model.terrain.hexes[0].row, 1)
         self.assertEqual(board_model.terrain.hexes[0].column, 1)

--- a/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
+++ b/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
@@ -48,6 +48,7 @@ class ScenarioTerrainType:
     """Representation of a terrain type as defined in a scenario."""
 
     color: str
+    move_cost: int = 1
 
 
 @dataclass(frozen=True)

--- a/battle_hexes_core/src/battle_hexes_core/scenario/scenario_loader.py
+++ b/battle_hexes_core/src/battle_hexes_core/scenario/scenario_loader.py
@@ -68,6 +68,7 @@ class ScenarioTerrainTypeData(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     color: str
+    move_cost: int = 1
 
 
 class ScenarioHexDataEntry(BaseModel):
@@ -211,7 +212,10 @@ class ScenarioData(BaseModel):
 
         return (
             {
-                key: ScenarioTerrainType(color=terrain_type.color)
+                key: ScenarioTerrainType(
+                    color=terrain_type.color,
+                    move_cost=terrain_type.move_cost,
+                )
                 for key, terrain_type in self.terrain_types.items()
             }
             if self.terrain_types

--- a/battle_hexes_core/tests/scenario/test_scenario_loader.py
+++ b/battle_hexes_core/tests/scenario/test_scenario_loader.py
@@ -63,6 +63,7 @@ def test_load_scenario_converts_core_types():
 
     assert scenario.terrain_default == "open"
     assert scenario.terrain_types["open"].color == "#C6AA5C"
+    assert scenario.terrain_types["open"].move_cost == 1
     assert scenario.hex_data[0].coords == (5, 5)
     assert scenario.hex_data[1].units == ("red_unit_1",)
     assert scenario.hex_data[0].objectives[0].type == "hold"


### PR DESCRIPTION
### Motivation
- Ensure terrain movement costs defined in scenario JSON (e.g. `move_cost` in `terrain_types`) are included in the API payload and available to the frontend so movement-point deduction can account for terrain. 

### Description
- Added `move_cost: int = 1` to core scenario terrain models and updated scenario loading so explicit `move_cost` values are preserved when converting JSON to core types.
- Extended the API terrain schema so terrain type serialization includes `move_cost` in payloads consumed by the frontend.
- Updated the frontend `Terrain` model to hold a `moveCost` property and changed the game-creation pipeline to read `move_cost` (defaulting to `1`) when building terrain types.
- Adjusted frontend unit movement logic to deduct movement points by the destination hex terrain's `moveCost` (while preserving existing behavior that stops movement when adjacent to an enemy) and added/updated tests to validate default and explicit move costs end-to-end.

### Testing
- Ran the repository Python checks with `./server-side-checks.sh`, which executed core, agent, and API test suites; all Python tests passed.
- Ran the frontend test-and-build with `npm run test-and-build` in `battle-hexes-web`; all Jest tests passed and the build completed successfully.
- No automated tests failed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49e4bf3e483279b8964d77fec29e9)