### PR TITLE
Block unaffordable terrain moves in web unit movement

### DIFF
--- a/battle-hexes-web/src/model/unit.js
+++ b/battle-hexes-web/src/model/unit.js
@@ -68,8 +68,17 @@ export class Unit {
   }
 
   move(destinationHex, adjacentHexes) {
+    const terrainMoveCost = destinationHex?.getTerrain()?.moveCost;
+    const moveCost = Number.isFinite(terrainMoveCost) && terrainMoveCost > 0
+      ? terrainMoveCost
+      : 1;
+
     if (this.#movesRemaining <= 0) {
       throw new Error('No movement points remaining!');
+    }
+
+    if (this.#movesRemaining < moveCost) {
+      throw new Error('Not enough movement points remaining!');
     }
 
     this.setContainingHex(destinationHex);
@@ -79,11 +88,6 @@ export class Unit {
       this.#movesRemaining = 0;
       return;
     }
-
-    const terrainMoveCost = destinationHex?.getTerrain()?.moveCost;
-    const moveCost = Number.isFinite(terrainMoveCost) && terrainMoveCost > 0
-      ? terrainMoveCost
-      : 1;
 
     this.#movesRemaining = Math.max(0, this.#movesRemaining - moveCost);
   }

--- a/battle-hexes-web/tests/model/unit.test.js
+++ b/battle-hexes-web/tests/model/unit.test.js
@@ -55,6 +55,19 @@ describe('move', () => {
     expect(unit.getMovesRemaining()).toBe(1);
   });
 
+  test('throws an error when terrain move cost exceeds movement points remaining', () => {
+    const unit = new Unit('8', 'Test Unit', friendlyFaction, null, 4, 4, 1);
+    const destinationHex = new Hex(5, 5);
+    destinationHex.setTerrain({ moveCost: 3 });
+
+    expect(() => {
+      unit.move(destinationHex, [new Hex(4, 5), new Hex(5, 6)]);
+    }).toThrow('Not enough movement points remaining!');
+
+    expect(unit.getContainingHex()).toBeUndefined();
+    expect(unit.getMovesRemaining()).toBe(1);
+  });
+
   test('adds combat opponent when opponent is adjacent', () => {
     const unit = new Unit('5', 'Test Unit', friendlyFaction, null, 4, 4, 4);
     const oppHex = new Hex(5, 6);


### PR DESCRIPTION
### Motivation

- Prevent units from entering terrain they cannot afford because movement deduction previously clamped negative remaining movement to zero, allowing overspend onto expensive terrain.

### Description

- Compute the terrain `moveCost` at the start of `Unit.move` and reject the move if `#movesRemaining` is less than `moveCost`, throwing `Not enough movement points remaining!` (file: `battle-hexes-web/src/model/unit.js`).
- Preserve the existing zero-moves check that throws `No movement points remaining!` and retain the combat-adjacency behavior that sets `#movesRemaining` to zero when opponents are adjacent.
- Add a unit test covering the bug case where a unit with `1` MP attempts to enter a hex with `moveCost: 3`, asserting the move is blocked, the unit's position is unchanged, and movement points remain unchanged (file: `battle-hexes-web/tests/model/unit.test.js`).

### Testing

- Ran the web package full test and build script with `npm run test-and-build` (from `battle-hexes-web`) and the test/build completed successfully.
- Test output: `25` test suites passed, `132` tests passed, and webpack build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a7ef9b588327957b48fed24c07db)