### PR TITLE
Add terrain-aware movement checks (Unit.canEnterHex) and update board interactions

### DIFF
--- a/battle-hexes-web/src/model/board.js
+++ b/battle-hexes-web/src/model/board.js
@@ -87,7 +87,9 @@ export class Board {
     } else if (this.isOppositionHex(oldSelection)) {
       oldSelection.setSelected(false);
     } else if (!oldSelection.isEmpty() && oldSelection.isAdjacent(hexToSelect)
-        && oldSelection.getUnits()[0].isMovable() && !this.isOppositionHex(hexToSelect)) {
+        && oldSelection.getUnits()[0].isMovable()
+        && oldSelection.getUnits()[0].canEnterHex(hexToSelect)
+        && !this.isOppositionHex(hexToSelect)) {
       const units = oldSelection.getUnits();
       console.log(`Moving unit ${units[0]}.`);
       const path = [oldSelection, hexToSelect];
@@ -106,6 +108,10 @@ export class Board {
   }
 
   moveUnit(unit, oldHex, newHex) {
+    if (!unit.canEnterHex(newHex)) {
+      throw new Error('Unit does not have enough movement points to enter destination hex.');
+    }
+
     unit.move(newHex, this.getAdjacentHexes(newHex));
     oldHex.removeUnit(unit);
     newHex.addUnit(unit);
@@ -139,6 +145,7 @@ export class Board {
     if (this.#hoverHex && this.hasSelection() && !this.#selectedHex.isEmpty()
         && !this.#selectedHex.hasUnitMoves() 
         && this.#hoverHex.isAdjacent(this.#selectedHex)
+        && this.#selectedHex.getUnits()[0].canEnterHex(this.#hoverHex)
         && this.isOwnHexSelected()
         && !this.isOppositionHex(hoverHex)) {
       console.log(`We have a move hover hex! ${this.#hoverHex}`);

--- a/battle-hexes-web/src/model/unit.js
+++ b/battle-hexes-web/src/model/unit.js
@@ -105,6 +105,15 @@ export class Unit {
     return this.#movesRemaining;
   }
 
+  canEnterHex(destinationHex) {
+    const terrainMoveCost = destinationHex?.getTerrain()?.moveCost;
+    const moveCost = Number.isFinite(terrainMoveCost) && terrainMoveCost > 0
+      ? terrainMoveCost
+      : 1;
+
+    return this.getMovesRemaining() >= moveCost;
+  }
+
   resetMovesRemaining() {
     this.#movesRemaining = this.getMovement();
   }

--- a/battle-hexes-web/tests/model/board.test.js
+++ b/battle-hexes-web/tests/model/board.test.js
@@ -115,6 +115,27 @@ describe('animator integration', () => {
 
     expect(animatorInstance.animate).toHaveBeenCalledWith(unit, [start, end], true);
   });
+
+
+  test('selectHex does not animate movement when destination terrain cost is unaffordable', () => {
+    const player = { isHuman: () => true };
+    const factions = [new Faction('f1', 'f1', '#f00')];
+    factions[0].setOwningPlayer(player);
+    const board = new Board(1, 2);
+    board.setPlayers({ getCurrentPlayer: () => player });
+    const unit = new Unit('u1', 'Unit', factions[0], null, 1, 1, 1);
+    board.addUnit(unit, 0, 0);
+
+    const start = board.getHex(0, 0);
+    const end = board.getHex(0, 1);
+    end.setTerrain({ moveCost: 2 });
+
+    const animatorInstance = board.getAnimator();
+    board.selectHex(start);
+    board.selectHex(end);
+
+    expect(animatorInstance.animate).not.toHaveBeenCalled();
+  });
 });
 
 

--- a/battle-hexes-web/tests/model/unit.test.js
+++ b/battle-hexes-web/tests/model/unit.test.js
@@ -78,3 +78,22 @@ describe('resetCombat', () => {
     expect(unit.getCombatOpponents()).toHaveLength(0);
   });
 });
+
+
+describe('canEnterHex', () => {
+  test('returns true when terrain cost is affordable', () => {
+    const unit = new Unit('8', 'Test Unit', friendlyFaction, null, 4, 4, 3);
+    const destinationHex = new Hex(2, 2);
+    destinationHex.setTerrain({ moveCost: 3 });
+
+    expect(unit.canEnterHex(destinationHex)).toBe(true);
+  });
+
+  test('returns false when terrain cost exceeds remaining moves', () => {
+    const unit = new Unit('9', 'Test Unit', friendlyFaction, null, 4, 4, 2);
+    const destinationHex = new Hex(2, 3);
+    destinationHex.setTerrain({ moveCost: 3 });
+
+    expect(unit.canEnterHex(destinationHex)).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a reusable, destination-aware movement check so the UI and internal callers can determine whether a unit can afford entering a specific hex based on terrain cost.
- Keep `isMovable()` as the coarse human/has-points guard while introducing a precise affordability check for move actions and previews.
- Prevent the UI from animating or previewing moves that the unit cannot actually perform with remaining movement points.

### Description
- Added `Unit.canEnterHex(destinationHex)` which reads `destinationHex?.getTerrain()?.moveCost` (fallback `1`) and returns whether `getMovesRemaining()` is sufficient to pay that cost (file `src/model/unit.js`).
- Updated `Board.selectHex(hexToSelect)` to require `canEnterHex()` for adjacent click-to-move animation in addition to the existing `isMovable()` check (file `src/model/board.js`).
- Updated `Board.setHoverHex(hoverHex)` to only set `moveHoverFromHex` when the selected unit can afford entering the hovered hex (file `src/model/board.js`).
- Hardened `Board.moveUnit(unit, oldHex, newHex)` to throw an error if `unit.canEnterHex(newHex)` is false to keep internal callers consistent (file `src/model/board.js`).
- Added unit tests for `canEnterHex()` and a board integration test to assert that movement animation is not triggered when the destination terrain cost is unaffordable (files under `tests/model`).

### Testing
- Ran unit tests with `npm test -- --runInBand`, and all test suites passed successfully.
- Ran the full project validation with `npm run test-and-build` (includes `eslint`, `jest`, and `webpack` build), and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c16fc6b4832781e8a10c303a8e8e)