### PR TITLE
Refactor board movement/pathfinding into weighted MovementCalculator

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/game/movement.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/movement.py
@@ -1,0 +1,146 @@
+import heapq
+from itertools import count
+from typing import TYPE_CHECKING, List, Set
+
+from battle_hexes_core.game.hex import Hex
+from battle_hexes_core.unit.unit import Unit
+
+if TYPE_CHECKING:
+    from battle_hexes_core.game.board import Board
+
+
+class MovementCalculator:
+    def __init__(self, board: "Board"):
+        self.board = board
+
+    def move_cost(self, unit: Unit, from_hex: Hex, to_hex: Hex) -> int:
+        """Return movement cost for entering ``to_hex`` from ``from_hex``."""
+        del unit, from_hex
+        if to_hex.terrain is None:
+            return 1
+        return to_hex.terrain.move_cost
+
+    def get_reachable_hexes(
+            self, unit: Unit, start: Hex, move_points: int = None
+    ) -> Set[Hex]:
+        """Get all hexes reachable by the unit from the start hex."""
+        if move_points is None:
+            move_points = unit.get_move()
+
+        min_cost_by_coord: dict[tuple[int, int], float] = {
+            (start.row, start.column): 0,
+        }
+        reachable_hexes = {start}
+        queue_counter = count()
+        queue: list[tuple[float, int, Hex]] = [(0, next(queue_counter), start)]
+
+        while queue:
+            current_cost, _, current_hex = heapq.heappop(queue)
+            current_coord = (current_hex.row, current_hex.column)
+            if current_cost > min_cost_by_coord[current_coord]:
+                continue
+
+            if current_cost >= move_points:
+                continue
+
+            if self.board.enemy_adjacent(unit, current_hex):
+                # Movement must stop when entering a hex adjacent to an enemy
+                # unit, so do not expand further from this hex.
+                continue
+
+            for neighbor in self.board.get_neighboring_hexes(current_hex):
+                step_cost = self.move_cost(unit, current_hex, neighbor)
+                new_cost = current_cost + step_cost
+                if new_cost > move_points:
+                    continue
+
+                coord = (neighbor.row, neighbor.column)
+                prior_cost = min_cost_by_coord.get(coord, float("inf"))
+                if new_cost < prior_cost:
+                    min_cost_by_coord[coord] = new_cost
+                    reachable_hexes.add(neighbor)
+                    heapq.heappush(
+                        queue,
+                        (new_cost, next(queue_counter), neighbor),
+                    )
+
+        return reachable_hexes
+
+    def shortest_path(
+            self, unit: Unit, start: Hex, end: Hex
+    ) -> List[Hex]:
+        """Find the shortest path from start to end hex for the unit."""
+        move_points = unit.get_move()
+        reachable_hexes = self.get_reachable_hexes(unit, start, move_points)
+
+        if end not in reachable_hexes:
+            return []
+
+        min_cost_by_coord: dict[tuple[int, int], float] = {
+            (start.row, start.column): 0,
+        }
+        predecessor_by_coord: dict[tuple[int, int], tuple[int, int] | None] = {
+            (start.row, start.column): None,
+        }
+        hex_by_coord: dict[tuple[int, int], Hex] = {
+            (start.row, start.column): start,
+        }
+        queue_counter = count()
+        queue: list[tuple[float, int, Hex]] = [(0, next(queue_counter), start)]
+
+        while queue:
+            current_cost, _, current_hex = heapq.heappop(queue)
+            current_coord = (current_hex.row, current_hex.column)
+            if current_cost > min_cost_by_coord[current_coord]:
+                continue
+
+            if current_hex == end:
+                return self._build_path(
+                    end,
+                    predecessor_by_coord,
+                    hex_by_coord,
+                )
+
+            if self.board.enemy_adjacent(unit, current_hex):
+                # Cannot continue moving once adjacent to an enemy unit
+                continue
+
+            for neighbor in self.board.get_neighboring_hexes(current_hex):
+                if neighbor not in reachable_hexes:
+                    continue
+
+                step_cost = self.move_cost(unit, current_hex, neighbor)
+                new_cost = current_cost + step_cost
+                if new_cost > move_points:
+                    continue
+
+                coord = (neighbor.row, neighbor.column)
+                prior_cost = min_cost_by_coord.get(coord, float("inf"))
+                if new_cost < prior_cost:
+                    min_cost_by_coord[coord] = new_cost
+                    predecessor_by_coord[coord] = current_coord
+                    hex_by_coord[coord] = neighbor
+                    heapq.heappush(
+                        queue,
+                        (new_cost, next(queue_counter), neighbor),
+                    )
+
+        return []
+
+    def _build_path(
+            self,
+            end: Hex,
+            predecessor_by_coord: dict[
+                tuple[int, int],
+                tuple[int, int] | None,
+            ],
+            hex_by_coord: dict[tuple[int, int], Hex],
+    ) -> List[Hex]:
+        coord = (end.row, end.column)
+        path: list[Hex] = []
+        while coord is not None:
+            path.append(hex_by_coord[coord])
+            coord = predecessor_by_coord[coord]
+
+        path.reverse()
+        return path

--- a/battle_hexes_core/src/battle_hexes_core/game/terrain.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/terrain.py
@@ -1,7 +1,8 @@
 class Terrain:
-    def __init__(self, name: str, hex_color: str):
+    def __init__(self, name: str, hex_color: str, move_cost: int = 1):
         self._name = name
         self._hex_color = hex_color
+        self._move_cost = move_cost
 
     @property
     def name(self) -> str:
@@ -10,6 +11,10 @@ class Terrain:
     @property
     def hex_color(self) -> str:
         return self._hex_color
+
+    @property
+    def move_cost(self) -> int:
+        return self._move_cost
 
     def __str__(self):
         return self.name

--- a/battle_hexes_core/src/battle_hexes_core/gamecreator/gamecreator.py
+++ b/battle_hexes_core/src/battle_hexes_core/gamecreator/gamecreator.py
@@ -130,7 +130,7 @@ class GameCreator:
     ) -> dict[str, Terrain]:
         """Build Terrain instances keyed by their scenario terrain name."""
         return {
-            name: Terrain(name, terrain.color)
+            name: Terrain(name, terrain.color, terrain.move_cost)
             for name, terrain in scenario.terrain_types.items()
         }
 

--- a/battle_hexes_core/tests/gamecreator/test_gamecreator.py
+++ b/battle_hexes_core/tests/gamecreator/test_gamecreator.py
@@ -232,8 +232,8 @@ class TestGameCreator(unittest.TestCase):
             board_size=(2, 2),
             terrain_default="open",
             terrain_types={
-                "open": ScenarioTerrainType(color="#C6AA5C"),
-                "village": ScenarioTerrainType(color="#9A8F7A"),
+                "open": ScenarioTerrainType(color="#C6AA5C", move_cost=1),
+                "village": ScenarioTerrainType(color="#9A8F7A", move_cost=2),
             },
             hex_data=(
                 ScenarioHexData(
@@ -255,8 +255,10 @@ class TestGameCreator(unittest.TestCase):
         self.assertIsNotNone(override_hex)
         self.assertEqual(default_hex.terrain.name, "open")
         self.assertEqual(default_hex.terrain.hex_color, "#C6AA5C")
+        self.assertEqual(default_hex.terrain.move_cost, 1)
         self.assertEqual(override_hex.terrain.name, "village")
         self.assertEqual(override_hex.terrain.hex_color, "#9A8F7A")
+        self.assertEqual(override_hex.terrain.move_cost, 2)
 
     def test_add_roads_populates_board_road_data(self):
         scenario = Scenario(


### PR DESCRIPTION
### Motivation
- Introduce terrain-based movement costs and move pathfinding out of `Board` so `Board` stays focused on board state and topology.
- Replace unweighted BFS traversal with a weighted Dijkstra-style algorithm so movement can account for per-hex costs (terrain now) and later road edge costs.

### Description
- Add `MovementCalculator` in `battle_hexes_core/game/movement.py` and move the logic for `get_reachable_hexes(...)` and `shortest_path(...)` from `Board` into corresponding `MovementCalculator` methods using Dijkstra.
- Provide a `move_cost(unit, from_hex, to_hex)` hook (currently uses terrain `move_cost` as the cost to ENTER `to_hex`) and preserve existing movement constraints such as impassable/occupied handling and the "stop expanding if enemy_adjacent" behavior.
- Keep thin delegating wrappers on `Board` for `get_reachable_hexes` and `shortest_path` so existing callers are unaffected, while retaining `get_neighboring_hexes` and `enemy_adjacent` on `Board`.
- Extend `Terrain` with a `move_cost` property and update `GameCreator` to propagate scenario terrain `move_cost` values to board hexes.
- Add/update unit tests in `battle_hexes_core/tests/game/test_board.py` and `battle_hexes_core/tests/gamecreator/test_gamecreator.py` to validate terrain-weighted reachability, weighted path preference, enemy-adjacent stopping, and terrain move cost propagation.

### Testing
- Ran `./battle_hexes_core/checks.sh` and resolved a missing `flake8` by installing it; core tests passed locally.
- Ran `./server-side-checks.sh` from the repository root which runs core, RL, and API test suites and linter, and all automated tests passed (core, RL, and API test suites completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c4e8d5388327ba3f1baf0792f233)