### PR TITLE
Update Selected Hex menu with Units and Terrain subsections

### DIFF
--- a/battle-hexes-web/src/battle.html
+++ b/battle-hexes-web/src/battle.html
@@ -67,8 +67,10 @@
     <hr class="menu-divider">
     <div id="selectedHexMenu">
       <h3>Selected Hex</h3>
-      <div id="selHexContents"></div>
       <div id="selHexCoord"></div>
+      <h4>Units</h4>
+      <div id="selHexContents"></div>
+      <h4>Terrain</h4>
       <div id="selHexTerrain"></div>
       <div id="selHexObjectives"></div>
       <div id="unitMovesLeftDiv"></div>

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -109,21 +109,18 @@ export class Menu {
     const selectedHex = this.#game.getBoard().getSelectedHex();
 
     if (!selectedHex) {
-      this.#selHexContentsDiv.innerHTML = '<em>No selection</em>';
-      this.#selHexCoordDiv.innerHTML = '';
+      this.#selHexContentsDiv.innerHTML = '';
+      this.#selHexCoordDiv.innerHTML = '<em>No selection</em>';
       this.#selHexTerrainDiv.innerHTML = '';
       this.#selHexObjectivesDiv.innerHTML = '';
-    } else if (selectedHex.isEmpty()) {
-      this.#selHexContentsDiv.innerHTML = 'Empty Hex';
-      this.#selHexCoordDiv.innerHTML = `Hex Coord: (${selectedHex.row}, ${selectedHex.column})`;
     } else {
-      this.#selHexContentsDiv.innerHTML = 'Hex contains a unit.';
-      this.#selHexCoordDiv.innerHTML = `Hex Coord: (${selectedHex.row}, ${selectedHex.column})`;
+      this.#selHexCoordDiv.innerHTML = `Coords: (${selectedHex.row}, ${selectedHex.column})`;
+      this.#selHexContentsDiv.innerHTML = this.#formatSelectedHexUnits(selectedHex);
     }
 
     if (selectedHex) {
       const terrain = selectedHex.getTerrain();
-      this.#selHexTerrainDiv.innerHTML = terrain ? `Terrain: ${terrain.name}` : '';
+      this.#selHexTerrainDiv.innerHTML = this.#formatSelectedHexTerrain(terrain);
       this.#selHexObjectivesDiv.innerHTML = this.#formatObjectives(selectedHex);
     }
 
@@ -146,6 +143,31 @@ export class Menu {
     } else {
       this.#hideGameOver();
     }
+  }
+
+  #formatSelectedHexUnits(selectedHex) {
+    const units = selectedHex?.getUnits?.() ?? [];
+    if (units.length === 0) {
+      return '<em>None</em>';
+    }
+
+    return units
+      .map((unit) => `${unit.getName()} (${unit.getAttack()}-${unit.getDefense()}-${unit.getMovement()})`)
+      .join('<br/>');
+  }
+
+  #formatSelectedHexTerrain(terrain) {
+    if (!terrain) {
+      return '';
+    }
+
+    const moveCost = Number.isFinite(terrain.moveCost) && terrain.moveCost > 0
+      ? terrain.moveCost
+      : 1;
+    const terrainName = terrain.name
+      ? `${terrain.name.charAt(0).toUpperCase()}${terrain.name.slice(1)}`
+      : 'Unknown';
+    return `${terrainName} (cost=${moveCost})`;
   }
 
   #formatObjectives(selectedHex) {

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -177,16 +177,17 @@ describe('auto new game persistence', () => {
     });
   });
 
-  test('updates terrain label when a hex is selected', () => {
+  test('shows selected hex coord, units fallback, and terrain move cost', () => {
     buildDom();
     history.replaceState(null, '', '/');
 
     const selectedHex = {
       row: 1,
       column: 2,
-      isEmpty: () => true,
+      getUnits: () => [],
       getTerrain: () => ({
         name: 'open',
+        moveCost: 1,
       }),
     };
 
@@ -200,7 +201,42 @@ describe('auto new game persistence', () => {
 
     menu.updateMenu();
 
-    expect(document.getElementById('selHexTerrain').innerHTML).toBe('Terrain: open');
+    expect(document.getElementById('selHexCoord').innerHTML).toBe('Coords: (1, 2)');
+    expect(document.getElementById('selHexContents').innerHTML).toBe('<em>None</em>');
+    expect(document.getElementById('selHexTerrain').innerHTML).toBe('Open (cost=1)');
+  });
+
+
+  test('shows selected hex unit details when units are present', () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+
+    const selectedHex = {
+      row: 4,
+      column: 9,
+      getUnits: () => [{
+        getName: () => 'Airborne Inf. A',
+        getAttack: () => 3,
+        getDefense: () => 2,
+        getMovement: () => 5,
+      }],
+      getTerrain: () => ({
+        name: 'open',
+        moveCost: 1,
+      }),
+    };
+
+    const menu = new Menu(fakeGame({
+      getBoard: () => ({
+        getSelectedHex: () => selectedHex,
+        isOwnHexSelected: () => false,
+        hasCombat: () => false,
+      }),
+    }));
+
+    menu.updateMenu();
+
+    expect(document.getElementById('selHexContents').innerHTML).toBe('Airborne Inf. A (3-2-5)');
   });
 
   test('shows no selection message when no hex is selected', () => {
@@ -209,7 +245,7 @@ describe('auto new game persistence', () => {
 
     new Menu(fakeGame());
 
-    expect(document.getElementById('selHexContents').innerHTML).toBe('<em>No selection</em>');
+    expect(document.getElementById('selHexCoord').innerHTML).toBe('<em>No selection</em>');
   });
 
   test('shows objective details when present on selected hex', () => {


### PR DESCRIPTION
### Motivation
- Make the Selected Hex panel clearer by separating unit and terrain information and showing terrain movement cost alongside the terrain name.

### Description
- Reorganized the Selected Hex markup in `battle-hexes-web/src/battle.html` to add explicit `Units` and `Terrain` subsection headers and move the content elements accordingly.
- Updated `Menu.updateMenu()` in `battle-hexes-web/src/menu.js` to render `Coords: (row, column)`, to show units via a new `#formatSelectedHexUnits` helper that returns `Name (attack-defense-move)` or `<em>None</em>`, and to show terrain via `#formatSelectedHexTerrain` which displays `TerrainName (cost=n)` using `terrain.moveCost` with a sensible fallback.
- Moved the no-selection message to the coordinate element and preserved existing objective rendering and moves-left behavior.
- Added/updated unit tests in `battle-hexes-web/tests/menu/menu.test.js` to verify the new layout and content cases (no units, units present, terrain cost formatting).

### Testing
- Ran `npm run test-and-build` (runs `eslint`, `jest`, and the webpack build); all test suites passed and the build completed successfully.
- `jest` results: 25 test suites passed, 135 tests passed, and the webpack build emitted the updated `battle.html` and JS assets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78cf022cc8327aa61f1d126033dd9)