### PR TITLE
Hide Selected Hex Units/Terrain headings when no selection and tighten spacing

### DIFF
--- a/battle-hexes-web/src/battle.html
+++ b/battle-hexes-web/src/battle.html
@@ -54,6 +54,10 @@
       display: block;
       margin: 10px;
     }
+
+    .selected-hex-subheading {
+      margin-bottom: 0.4em;
+    }
   </style>
 </head>
 <body>
@@ -68,9 +72,9 @@
     <div id="selectedHexMenu">
       <h3>Selected Hex</h3>
       <div id="selHexCoord"></div>
-      <h4>Units</h4>
+      <h4 id="selHexUnitsHeading" class="selected-hex-subheading">Units</h4>
       <div id="selHexContents"></div>
-      <h4>Terrain</h4>
+      <h4 id="selHexTerrainHeading" class="selected-hex-subheading">Terrain</h4>
       <div id="selHexTerrain"></div>
       <div id="selHexObjectives"></div>
       <div id="unitMovesLeftDiv"></div>

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -7,6 +7,8 @@ export class Menu {
   #selHexContentsDiv;
   #selHexCoordDiv;
   #selHexTerrainDiv;
+  #selHexUnitsHeading;
+  #selHexTerrainHeading;
   #selHexObjectivesDiv;
   #unitMovesLeftDiv;
   #newGameBtn;
@@ -24,6 +26,8 @@ export class Menu {
     this.#selHexContentsDiv = document.getElementById('selHexContents');
     this.#selHexCoordDiv = document.getElementById('selHexCoord');
     this.#selHexTerrainDiv = document.getElementById('selHexTerrain');
+    this.#selHexUnitsHeading = document.getElementById('selHexUnitsHeading');
+    this.#selHexTerrainHeading = document.getElementById('selHexTerrainHeading');
     this.#selHexObjectivesDiv = document.getElementById('selHexObjectives');
     this.#unitMovesLeftDiv = document.getElementById('unitMovesLeftDiv');
     this.#newGameBtn = document.getElementById('newGameBtn');
@@ -113,9 +117,11 @@ export class Menu {
       this.#selHexCoordDiv.innerHTML = '<em>No selection</em>';
       this.#selHexTerrainDiv.innerHTML = '';
       this.#selHexObjectivesDiv.innerHTML = '';
+      this.#toggleSelectedHexHeadings(false);
     } else {
       this.#selHexCoordDiv.innerHTML = `Coords: (${selectedHex.row}, ${selectedHex.column})`;
       this.#selHexContentsDiv.innerHTML = this.#formatSelectedHexUnits(selectedHex);
+      this.#toggleSelectedHexHeadings(true);
     }
 
     if (selectedHex) {
@@ -142,6 +148,16 @@ export class Menu {
       this.#showGameOver();
     } else {
       this.#hideGameOver();
+    }
+  }
+
+  #toggleSelectedHexHeadings(isVisible) {
+    const displayValue = isVisible ? '' : 'none';
+    if (this.#selHexUnitsHeading) {
+      this.#selHexUnitsHeading.style.display = displayValue;
+    }
+    if (this.#selHexTerrainHeading) {
+      this.#selHexTerrainHeading.style.display = displayValue;
     }
   }
 

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -18,7 +18,9 @@ describe('auto new game persistence', () => {
     document.body.innerHTML = `
       <div id="selHexContents"></div>
       <div id="selHexCoord"></div>
+      <h4 id="selHexUnitsHeading"></h4>
       <div id="selHexTerrain"></div>
+      <h4 id="selHexTerrainHeading"></h4>
       <div id="selHexObjectives"></div>
       <div id="unitMovesLeftDiv"></div>
       <button id="newGameBtn"></button>
@@ -177,7 +179,7 @@ describe('auto new game persistence', () => {
     });
   });
 
-  test('shows selected hex coord, units fallback, and terrain move cost', () => {
+  test('shows selected hex coord, units fallback, terrain move cost, and headings', () => {
     buildDom();
     history.replaceState(null, '', '/');
 
@@ -204,6 +206,8 @@ describe('auto new game persistence', () => {
     expect(document.getElementById('selHexCoord').innerHTML).toBe('Coords: (1, 2)');
     expect(document.getElementById('selHexContents').innerHTML).toBe('<em>None</em>');
     expect(document.getElementById('selHexTerrain').innerHTML).toBe('Open (cost=1)');
+    expect(document.getElementById('selHexUnitsHeading').style.display).toBe('');
+    expect(document.getElementById('selHexTerrainHeading').style.display).toBe('');
   });
 
 
@@ -246,6 +250,8 @@ describe('auto new game persistence', () => {
     new Menu(fakeGame());
 
     expect(document.getElementById('selHexCoord').innerHTML).toBe('<em>No selection</em>');
+    expect(document.getElementById('selHexUnitsHeading').style.display).toBe('none');
+    expect(document.getElementById('selHexTerrainHeading').style.display).toBe('none');
   });
 
   test('shows objective details when present on selected hex', () => {


### PR DESCRIPTION
### Motivation

- The Selected Hex panel showed the `Units` and `Terrain` headings even when no hex was selected, creating visual clutter.
- The spacing between those headings and their content was larger than desired and should be reduced for a tighter layout.

### Description

- Add stable IDs (`selHexUnitsHeading`, `selHexTerrainHeading`) and a shared class (`selected-hex-subheading`) to the `Units` and `Terrain` headings in `battle.html`. 
- Add CSS to reduce the bottom margin for the subheading class to `0.4em` so headings sit closer to their content. 
- Update `Menu` to locate the new heading elements and toggle their `style.display` to `none` when no hex is selected and back when a selection exists by introducing `#toggleSelectedHexHeadings`. 
- Update `tests/menu/menu.test.js` to include the heading elements in the test DOM and assert heading visibility for both selected and no-selection states.

### Testing

- Ran `npm run test-and-build`, which executed lint, Jest tests, and build, and it passed (25 test suites, 135 tests all passing). 
- Ran `npm run build` (webpack) and the build completed successfully. 
- Built frontend was served with a mock API and a screenshot was captured for visual verification with the headings hidden when no selection was present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7902af75c832790e3963f85112f43)