### PR TITLE
Tighten selected-hex subheading spacing and add unit faction swatches

### DIFF
--- a/battle-hexes-web/src/battle.html
+++ b/battle-hexes-web/src/battle.html
@@ -56,6 +56,7 @@
     }
 
     .selected-hex-subheading {
+      margin-top: 0.67em;
       margin-bottom: 0.4em;
     }
   </style>

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -168,8 +168,11 @@ export class Menu {
     }
 
     return units
-      .map((unit) => `${unit.getName()} (${unit.getAttack()}-${unit.getDefense()}-${unit.getMovement()})`)
-      .join('<br/>');
+      .map((unit) => {
+        const color = this.#getPlayerSwatchColor(unit.getOwningPlayer?.());
+        return `<div class="selected-unit-row"><span class="victory-swatch selected-unit-swatch" style="background-color: ${color};"></span>${unit.getName()} (${unit.getAttack()}-${unit.getDefense()}-${unit.getMovement()})</div>`;
+      })
+      .join('');
   }
 
   #formatSelectedHexTerrain(terrain) {

--- a/battle-hexes-web/src/styles/menu.css
+++ b/battle-hexes-web/src/styles/menu.css
@@ -68,6 +68,21 @@
   font-weight: 600;
 }
 
+#menu .selected-unit-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#menu .selected-unit-row + .selected-unit-row {
+  margin-top: 4px;
+}
+
+#menu .selected-unit-swatch {
+  width: 12px;
+  height: 12px;
+}
+
 #phasesList span {
   font-style: italic;
 }

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -223,6 +223,9 @@ describe('auto new game persistence', () => {
         getAttack: () => 3,
         getDefense: () => 2,
         getMovement: () => 5,
+        getOwningPlayer: () => ({
+          getFactions: () => [{ getCounterColor: () => '#ff0000' }],
+        }),
       }],
       getTerrain: () => ({
         name: 'open',
@@ -240,7 +243,9 @@ describe('auto new game persistence', () => {
 
     menu.updateMenu();
 
-    expect(document.getElementById('selHexContents').innerHTML).toBe('Airborne Inf. A (3-2-5)');
+    const unitRow = document.querySelector('#selHexContents .selected-unit-row');
+    expect(unitRow.textContent).toBe('Airborne Inf. A (3-2-5)');
+    expect(unitRow.querySelector('.selected-unit-swatch').style.backgroundColor).toBe('rgb(255, 0, 0)');
   });
 
   test('shows no selection message when no hex is selected', () => {


### PR DESCRIPTION
### Motivation
- Reduce the visual gap above the `Units` and `Terrain` subheadings in the selected-hex panel so the selected-hex content reads more compactly. 
- Surface each unit's faction color inline with unit entries to match the existing victory-points swatch affordance and make ownership easier to scan. 

### Description
- Adjusted the selected-hex heading spacing by adding `margin-top: 0.67em` to `.selected-hex-subheading` in `src/battle.html` to tighten the vertical gap. 
- Changed unit rendering in `src/menu.js` (`#formatSelectedHexUnits`) to emit a markup block per unit that prepends a swatch using the existing `#getPlayerSwatchColor` logic. 
- Added CSS rules in `src/styles/menu.css` to style `.selected-unit-row` and `.selected-unit-swatch` for alignment and sizing consistency with the victory points swatches. 
- Updated `tests/menu/menu.test.js` to exercise the new unit rendering and assert the swatch element and its resolved color are present. 

### Testing
- Ran lint via `npm run test-and-build` (which runs `eslint`) and the lint step completed successfully. 
- Ran unit tests via `jest` as part of `npm run test-and-build` and all test suites passed (`25` test suites, `135` tests). 
- The build step in `npm run test-and-build` completed and webpack produced the application bundles successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a79387f7e48327a25acfa766e7aecf)