### PR TITLE
Fix failing menu unit-details Jest expectation

### DIFF
--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -241,7 +241,9 @@ describe('auto new game persistence', () => {
 
     menu.updateMenu();
 
-    expect(document.getElementById('selHexContents').innerHTML).toBe('Airborne Inf. A (platoon, 3-2-5)');
+    const unitRow = document.querySelector('#selHexContents .selected-unit-row');
+    expect(unitRow.textContent).toBe('Airborne Inf. A (platoon, 3-2-5)');
+    expect(unitRow.querySelector('.selected-unit-swatch').style.backgroundColor).toBe('rgb(176, 176, 176)');
   });
 
   test('omits echelon in selected hex unit details when not present', () => {


### PR DESCRIPTION
### Motivation
- The menu unit-details test compared raw `innerHTML` but the UI wraps details in a `.selected-unit-row` with a `.selected-unit-swatch`, causing the assertion to fail.

### Description
- Update `battle-hexes-web/tests/menu/menu.test.js` to select `#selHexContents .selected-unit-row` and assert `textContent` equals the expected label and that the `.selected-unit-swatch` has the expected default color.

### Testing
- Ran `./server-side-checks.sh`, `npm test -- --runInBand` and `npm run test-and-build` in `battle-hexes-web`, and all test suites and the build passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a79c72955483279eb0dea066602a4e)