### PR TITLE
Use echelon-based symbols on unit counters

### DIFF
--- a/battle-hexes-web/src/drawer/unit-drawer.js
+++ b/battle-hexes-web/src/drawer/unit-drawer.js
@@ -1,4 +1,20 @@
 export class UnitDrawer {
+  static ECHELON_SYMBOLS = {
+    fireteam: 'Ø',
+    squad: '●',
+    section: '●●',
+    platoon: '●●●',
+    company: 'I',
+    battalion: 'II',
+    regiment: 'III',
+    brigade: 'X',
+    division: 'XX',
+    corps: 'XXX',
+    'field army': 'XXXX',
+    'army group': 'XXXXX',
+    theater: 'XXXXXX',
+  };
+
   #p;
   #hexDrawer;
   #counterSide;
@@ -41,7 +57,7 @@ export class UnitDrawer {
 
     this.#drawInfantrySymbol(x, y, this.#counterSide / 2, this.#counterSideThird);
     this.#drawUnitStats(aUnit, x, y);
-    this.#drawUnitSize(x, y);
+    this.#drawUnitSize(aUnit, x, y);
   }
 
   #halfColor(hexColor) {
@@ -89,11 +105,21 @@ export class UnitDrawer {
     this.#p.text(`${aUnit.getAttack()}-${aUnit.getDefense()}-${aUnit.getMovement()}`, x, y + this.#counterSideThird);
   }
   
-  #drawUnitSize(x, y) {
+  #drawUnitSize(aUnit, x, y) {
+    const unitEchelon = aUnit.getEchelon?.();
+    if (!unitEchelon) {
+      return;
+    }
+
+    const echelonSymbol = UnitDrawer.ECHELON_SYMBOLS[unitEchelon.trim().toLowerCase()];
+    if (!echelonSymbol) {
+      return;
+    }
+
     this.#p.fill(255);
     this.#p.noStroke();
     this.#p.textSize(9);
     this.#p.textAlign(this.#p.CENTER, this.#p.CENTER);
-    this.#p.text('XX', x, y - this.#counterSideThird + this.#counterSideThird * 0.2);
+    this.#p.text(echelonSymbol, x, y - this.#counterSideThird + this.#counterSideThird * 0.2);
   }  
 }

--- a/battle-hexes-web/tests/drawer/unit-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/unit-drawer.test.js
@@ -67,3 +67,48 @@ describe('UnitDrawer.draw', () => {
     expect(unitDrawer.drawnCounters[2].y).toBeCloseTo(100 - expectedOffset * 2);
   });
 });
+
+describe('UnitDrawer.drawCounter echelon symbols', () => {
+  const createP5Mock = () => ({
+    CENTER: 'CENTER',
+    stroke: jest.fn(),
+    strokeWeight: jest.fn(),
+    fill: jest.fn(),
+    rectMode: jest.fn(),
+    rect: jest.fn(),
+    line: jest.fn(),
+    noStroke: jest.fn(),
+    textSize: jest.fn(),
+    textAlign: jest.fn(),
+    text: jest.fn(),
+  });
+
+  const createUnit = (echelon) => ({
+    getFaction: () => ({
+      getCounterColor: () => '#808080',
+    }),
+    getAttack: () => 4,
+    getDefense: () => 3,
+    getMovement: () => 2,
+    getEchelon: () => echelon,
+  });
+
+  test('draws echelon symbol for known echelons', () => {
+    const p5 = createP5Mock();
+    const unitDrawer = new UnitDrawer(p5, createHexDrawer());
+
+    unitDrawer.drawCounter(createUnit('division'), 100, 100);
+
+    expect(p5.text).toHaveBeenCalledWith('XX', 100, expect.any(Number));
+  });
+
+  test('omits echelon text when echelon is undefined', () => {
+    const p5 = createP5Mock();
+    const unitDrawer = new UnitDrawer(p5, createHexDrawer());
+
+    unitDrawer.drawCounter(createUnit(undefined), 100, 100);
+
+    expect(p5.text).toHaveBeenCalledTimes(1);
+    expect(p5.text).toHaveBeenCalledWith('4-3-2', 100, expect.any(Number));
+  });
+});


### PR DESCRIPTION
### Motivation
- Unit counters previously displayed a hardcoded `XX` echelon marker which did not reflect a unit's actual echelon.
- The UI should show the correct echelon symbol when a unit has an echelon and omit any marker when none is defined.

### Description
- Added a static `ECHELON_SYMBOLS` map to `UnitDrawer` that maps echelons (e.g. `fireteam`, `squad`, `platoon`, `division`, `theater`) to the requested symbols.
- Updated `drawCounter` to pass the unit into the size/echelon rendering routine and changed `#drawUnitSize` to accept the unit and use `getEchelon()` to look up the symbol (normalized with `trim().toLowerCase()`), drawing it only when recognized.
- Added tests in `battle-hexes-web/tests/drawer/unit-drawer.test.js` to verify that a known echelon renders the expected symbol and that no echelon results in no echelon text being drawn.

### Testing
- Ran `npm run test-and-build` in `battle-hexes-web`, and all checks passed (lint, Jest suites, and production build); Jest output reported all test suites and tests passed.
- The new/updated unit drawer tests passed as part of the above test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a79d7dfd0883278c05409e6cb0890b)