### PR TITLE
Display per-unit moves and tooltip in Selected Hex UI

### DIFF
--- a/battle-hexes-web/src/battle.html
+++ b/battle-hexes-web/src/battle.html
@@ -78,7 +78,6 @@
       <h4 id="selHexTerrainHeading" class="selected-hex-subheading">Terrain</h4>
       <div id="selHexTerrain"></div>
       <div id="selHexObjectives"></div>
-      <div id="unitMovesLeftDiv"></div>
     </div>
     <hr class="menu-divider">
     <div id="gameStagesMenu">

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -10,7 +10,6 @@ export class Menu {
   #selHexUnitsHeading;
   #selHexTerrainHeading;
   #selHexObjectivesDiv;
-  #unitMovesLeftDiv;
   #newGameBtn;
   #gameOverLabel;
   #autoNewGameChk;
@@ -29,7 +28,6 @@ export class Menu {
     this.#selHexUnitsHeading = document.getElementById('selHexUnitsHeading');
     this.#selHexTerrainHeading = document.getElementById('selHexTerrainHeading');
     this.#selHexObjectivesDiv = document.getElementById('selHexObjectives');
-    this.#unitMovesLeftDiv = document.getElementById('unitMovesLeftDiv');
     this.#newGameBtn = document.getElementById('newGameBtn');
     this.#gameOverLabel = document.getElementById('gameOverLabel');
     this.#autoNewGameChk = document.getElementById('autoNewGame');
@@ -130,14 +128,6 @@ export class Menu {
       this.#selHexObjectivesDiv.innerHTML = this.#formatObjectives(selectedHex);
     }
 
-    if (this.#game.getBoard().isOwnHexSelected()) {
-      // friendly hex selected
-      this.#unitMovesLeftDiv.innerHTML = `Moves Left: ${selectedHex.getUnits()[0].getMovesRemaining()}`;
-    } else {
-      // opposing hex selected
-      this.#unitMovesLeftDiv.innerHTML = '';
-    }
-
     this.#updateCombatIndicator();
     this.#setCurrentTurn();
     this.#updateVictoryPoints();
@@ -171,13 +161,15 @@ export class Menu {
       .map((unit) => {
         const echelon = unit.getEchelon?.();
         const unitStrength = `${unit.getAttack()}-${unit.getDefense()}-${unit.getMovement()}`;
+        const movesRemaining = unit.getMovesRemaining?.();
+        const movesDisplay = Number.isFinite(movesRemaining) ? movesRemaining : 0;
         const color = this.#getPlayerSwatchColor(unit.getOwningPlayer?.());
-        const unitData = echelon
-          ? `${unit.getName()} (${echelon}, ${unitStrength})`
-          : `${unit.getName()} (${unitStrength})`;
-        return `<div class="selected-unit-row"><span class="victory-swatch selected-unit-swatch" style="background-color: ${color};"></span>${unitData}</div>`;
+        const tooltipText = echelon
+          ? `${echelon}, ${unitStrength}`
+          : unitStrength;
+        return `<div class="selected-unit-row"><span class="victory-swatch selected-unit-swatch" style="background-color: ${color};"></span><span class="selected-unit-label" title="${tooltipText}">${unit.getName()} <span class="selected-unit-moves">(moves ${movesDisplay})</span></span></div>`;
       })
-      .join('<br/>');
+      .join('');
   }
 
   #formatSelectedHexTerrain(terrain) {

--- a/battle-hexes-web/src/styles/menu.css
+++ b/battle-hexes-web/src/styles/menu.css
@@ -83,6 +83,10 @@
   height: 12px;
 }
 
+#menu .selected-unit-moves {
+  font-size: 0.85em;
+}
+
 #phasesList span {
   font-style: italic;
 }

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -224,6 +224,7 @@ describe('auto new game persistence', () => {
         getDefense: () => 2,
         getMovement: () => 5,
         getEchelon: () => 'platoon',
+        getMovesRemaining: () => 0,
       }],
       getTerrain: () => ({
         name: 'open',
@@ -242,7 +243,8 @@ describe('auto new game persistence', () => {
     menu.updateMenu();
 
     const unitRow = document.querySelector('#selHexContents .selected-unit-row');
-    expect(unitRow.textContent).toBe('Airborne Inf. A (platoon, 3-2-5)');
+    expect(unitRow.textContent).toBe('Airborne Inf. A (moves 0)');
+    expect(unitRow.querySelector('.selected-unit-label').title).toBe('platoon, 3-2-5');
     expect(unitRow.querySelector('.selected-unit-swatch').style.backgroundColor).toBe('rgb(176, 176, 176)');
   });
 
@@ -259,6 +261,7 @@ describe('auto new game persistence', () => {
         getDefense: () => 2,
         getMovement: () => 5,
         getEchelon: () => null,
+        getMovesRemaining: () => 0,
         getOwningPlayer: () => ({
           getFactions: () => [{ getCounterColor: () => '#ff0000' }],
         }),
@@ -280,7 +283,8 @@ describe('auto new game persistence', () => {
     menu.updateMenu();
 
     const unitRow = document.querySelector('#selHexContents .selected-unit-row');
-    expect(unitRow.textContent).toBe('Airborne Inf. A (3-2-5)');
+    expect(unitRow.textContent).toBe('Airborne Inf. A (moves 0)');
+    expect(unitRow.querySelector('.selected-unit-label').title).toBe('3-2-5');
     expect(unitRow.querySelector('.selected-unit-swatch').style.backgroundColor).toBe('rgb(255, 0, 0)');
   });
 


### PR DESCRIPTION
### Motivation
- Improve the Units section to show each unit's remaining moves inline while preserving the faction color swatch.
- Make the moves text visually smaller than the unit name so it reads as a secondary datum.
- Expose echelon and combat stats as a hover tooltip (alt text) rather than inline so the list stays compact.
- Remove the separate "Moves Left" row because move information is now shown per-unit.

### Description
- Reworked unit rendering in `battle-hexes-web/src/menu.js` to output: a faction color swatch, the unit name, and `(moves N)` with a tooltip `title` containing `echelon, attack-defense-movement` (or `attack-defense-movement` when echelon is absent).
- Removed the `unitMovesLeftDiv` usage and the bottom "Moves Left" update logic from `updateMenu()` and removed the corresponding div from `battle.html`.
- Added a CSS rule in `battle-hexes-web/src/styles/menu.css` to reduce the font size of the `(moves N)` text (`.selected-unit-moves { font-size: 0.85em; }`).
- Updated unit-related tests in `battle-hexes-web/tests/menu/menu.test.js` to assert the new `(moves N)` label and `title` tooltip behavior for both echelon and non-echelon units.

### Testing
- Ran `npm install` in `battle-hexes-web` successfully.
- Ran `npm run test-and-build` in `battle-hexes-web` which executed linting, Jest tests and a production build; all automated tests passed and the webpack build completed successfully (Test Suites: 25 passed, Tests: 140 passed, build compiled).
- Captured a small visual verification screenshot artifact of the updated menu (artifact path produced during testing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7a3ef23b48327b03c34da1c3bcd00)