### PR TITLE
Recalculate scenario victory on combat and turn boundaries

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -172,6 +172,8 @@ def resolve_combat(
             post_combat_pts
         )
 
+    scorer.recalculate_scenario_victory(game)
+
     game_repo.update_game(game)
     _call_end_game_callbacks(game)
     sparse_board = SparseBoard.from_board(game.get_board())
@@ -221,6 +223,8 @@ def end_turn(game_id: str, sparse_board: SparseBoard = Body(...)):
 
     # sync the server-side board state with the client provided one
     sparse_board.apply_to_board(game.get_board())
+
+    ObjectiveScorer().recalculate_scenario_victory(game)
 
     old_player = game.get_current_player()
     new_player = game.next_player()

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -210,6 +210,9 @@ class TestFastAPI(unittest.TestCase):
             mock_game,
             mock_results,
         )
+        scorer_instance.recalculate_scenario_victory.assert_called_once_with(
+            mock_game
+        )
         mock_logger.info.assert_any_call(
             'Awarded %d pts for objectvies after combat.',
             3,
@@ -306,12 +309,14 @@ class TestFastAPI(unittest.TestCase):
         self.assertEqual(response.json(), {"id": "game-101"})
 
     @patch('battle_hexes_api.main.SparseBoard.apply_to_board')
+    @patch('battle_hexes_api.main.ObjectiveScorer')
     @patch('battle_hexes_api.main.GameModel.from_game')
     @patch('battle_hexes_api.main.game_repo')
     def test_end_turn_updates_game_and_returns_game_model(
         self,
         mock_game_repo,
         mock_from_game,
+        mock_scorer,
         mock_apply_to_board,
     ):
         mock_game = MagicMock()
@@ -338,6 +343,10 @@ class TestFastAPI(unittest.TestCase):
         )
 
         mock_apply_to_board.assert_called_once_with(mock_board)
+        scorer_instance = mock_scorer.return_value
+        scorer_instance.recalculate_scenario_victory.assert_called_once_with(
+            mock_game
+        )
         mock_game.get_current_player.assert_called_once_with()
         mock_game.next_player.assert_called_once_with()
         mock_game_repo.update_game.assert_called_once_with(mock_game)
@@ -348,10 +357,11 @@ class TestFastAPI(unittest.TestCase):
             {"id": "game-789", "current_player": "Bob"}
         )
 
+    @patch('battle_hexes_api.main.ObjectiveScorer')
     @patch('battle_hexes_api.main.GameModel.from_game')
     @patch('battle_hexes_api.main.game_repo')
     def test_end_turn_calls_end_game_callback_when_game_over(
-        self, mock_game_repo, mock_from_game
+        self, mock_game_repo, mock_from_game, mock_scorer
     ):
         mock_player1 = MagicMock()
         mock_player2 = MagicMock()
@@ -368,6 +378,10 @@ class TestFastAPI(unittest.TestCase):
             f"/games/{game_id}/end-turn", json={"units": []}
         )
 
+        scorer_instance = mock_scorer.return_value
+        scorer_instance.recalculate_scenario_victory.assert_called_once_with(
+            mock_game
+        )
         mock_player1.end_game_cb.assert_called_once_with()
         mock_player2.end_game_cb.assert_called_once_with()
         mock_from_game.assert_called_once_with(mock_game)

--- a/battle_hexes_core/src/battle_hexes_core/scoring/objective_scorer.py
+++ b/battle_hexes_core/src/battle_hexes_core/scoring/objective_scorer.py
@@ -11,6 +11,10 @@ logger = logging.getLogger(__name__)
 class ObjectiveScorer:
     """Award points for objectives held at the end of movement."""
 
+    def recalculate_scenario_victory(self, game: Game) -> int | None:
+        """Recalculate scenario-driven victory scoring when configured."""
+        return self._award_scenario_objective_control(game)
+
     def award_hold_objectives(self, game: Game) -> int:
         """Award points for the active scenario scoring method."""
         scenario_points = self._award_scenario_objective_control(game)


### PR DESCRIPTION
### Motivation

- Ensure scenario-driven victory scoring (e.g. `objective_control`) is recalculated at the right moments so the UI shows up-to-date victory points after combat and at the end of each turn.

### Description

- Added `ObjectiveScorer.recalculate_scenario_victory(game)` as an explicit entrypoint that delegates to the existing `_award_scenario_objective_control` logic.
- Invoke `scorer.recalculate_scenario_victory(game)` in the `/games/{game_id}/combat` route immediately after `award_hold_objectives_after_combat(...)` so legacy post-combat awarding remains but scenario recalculation also runs.
- Invoke `ObjectiveScorer().recalculate_scenario_victory(game)` in the `/games/{game_id}/end-turn` route after syncing the board and before advancing/returning so the returned `GameModel` reflects current control.
- Kept existing score payloads intact by still setting `SparseBoard.scores` in the combat route and returning `GameModel.from_game(game)` in the end-turn route, and updated tests to assert the new calls.

### Testing

- Ran `./server-side-checks.sh` from the repository root which runs unit tests and lint across `battle_hexes_core`, `battle_agent_rl`, and `battle_hexes_api`, and all tests passed.
- Confirmed `battle_hexes_core` tests (117), `battle_agent_rl` tests (17), and `battle_hexes_api` tests (32) all passed and flake8 linting passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad938e229c8327aa6ceb171ab3e020)