### PR TITLE
Add scenario overview panel to the battle menu

### DIFF
--- a/battle-hexes-web/src/battle.html
+++ b/battle-hexes-web/src/battle.html
@@ -92,6 +92,13 @@
       <button id="newGameBtn" style="display: none;">New Game</button>
     </div>
     <hr class="menu-divider">
+    <div id="scenarioOverviewMenu">
+      <h3 id="scenarioOverviewHeading"></h3>
+      <p id="scenarioOverviewDescription"></p>
+      <h4 id="scenarioVictoryHeading">Victory Conditions</h4>
+      <p id="scenarioVictoryDescription"></p>
+    </div>
+    <hr class="menu-divider">
     <div id="optionsMenu">
       <h3>Options</h3>
       <label class="menu-toggle"><input type="checkbox" id="showHexCoords" checked> Show hex coordinates</label>

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -15,6 +15,12 @@ export class Menu {
   #autoNewGameChk;
   #showHexCoordsChk;
   #victoryPointsList;
+  #scenarioOverviewHeading;
+  #scenarioOverviewDescription;
+  #scenarioVictoryHeading;
+  #scenarioVictoryDescription;
+  #activeScenarioId;
+  #scenarioDetailsRequestId = 0;
   #autoReloadScheduled = false;
   #onNewGameRequested;
   static #SHOW_HEX_COORDS_STORAGE_KEY = 'battleHexes.showHexCoords';
@@ -33,6 +39,11 @@ export class Menu {
     this.#autoNewGameChk = document.getElementById('autoNewGame');
     this.#showHexCoordsChk = document.getElementById('showHexCoords');
     this.#victoryPointsList = document.getElementById('victoryPointsList');
+    this.#scenarioOverviewHeading = document.getElementById('scenarioOverviewHeading');
+    this.#scenarioOverviewDescription = document.getElementById('scenarioOverviewDescription');
+    this.#scenarioVictoryHeading = document.getElementById('scenarioVictoryHeading');
+    this.#scenarioVictoryDescription = document.getElementById('scenarioVictoryDescription');
+    this.#activeScenarioId = this.#game.getScenarioId?.() ?? null;
     this.#onNewGameRequested = onNewGameRequested;
 
     // Initialize checkbox state from URL param
@@ -72,9 +83,59 @@ export class Menu {
 
     this.#initPhasesInMenu();
     this.#initPhaseEndButton();
+    this.#renderScenarioOverview();
+    this.#loadScenarioDetails(this.#activeScenarioId);
     this.#setCurrentTurn();
     this.#updateCombatIndicator();
     this.updateMenu();
+  }
+
+  #renderScenarioOverview(scenario = null) {
+    if (!this.#scenarioOverviewHeading || !this.#scenarioVictoryHeading) {
+      return;
+    }
+
+    const fallbackScenarioId = this.#activeScenarioId ?? this.#game.getScenarioId?.() ?? '';
+    const scenarioHeading = scenario?.name || scenario?.id || fallbackScenarioId;
+    this.#scenarioOverviewHeading.textContent = scenarioHeading || 'Scenario';
+
+    if (this.#scenarioOverviewDescription) {
+      this.#scenarioOverviewDescription.textContent = scenario?.description || '';
+      this.#scenarioOverviewDescription.style.display = this.#scenarioOverviewDescription.textContent ? '' : 'none';
+    }
+
+    if (this.#scenarioVictoryDescription) {
+      const victoryDescription = scenario?.victory?.description || '';
+      this.#scenarioVictoryDescription.textContent = victoryDescription;
+      this.#scenarioVictoryHeading.style.display = victoryDescription ? '' : 'none';
+      this.#scenarioVictoryDescription.style.display = victoryDescription ? '' : 'none';
+    }
+  }
+
+  #loadScenarioDetails(scenarioId) {
+    if (!scenarioId) {
+      this.#renderScenarioOverview();
+      return;
+    }
+
+    const requestId = this.#scenarioDetailsRequestId + 1;
+    this.#scenarioDetailsRequestId = requestId;
+    axios.get(`${API_URL}/scenarios`)
+      .then((response) => {
+        if (requestId !== this.#scenarioDetailsRequestId) {
+          return;
+        }
+        const scenarios = Array.isArray(response?.data) ? response.data : [];
+        const scenario = scenarios.find((value) => value?.id === scenarioId);
+        this.#renderScenarioOverview(scenario);
+      })
+      .catch((error) => {
+        if (requestId !== this.#scenarioDetailsRequestId) {
+          return;
+        }
+        console.warn('Failed to load scenario details for menu', error);
+        this.#renderScenarioOverview();
+      });
   }
 
   getShowHexCoordsPreference() {
@@ -404,6 +465,12 @@ export class Menu {
 
   setGame(game) {
     this.#game = game;
+    const scenarioId = this.#game.getScenarioId?.() ?? null;
+    if (scenarioId !== this.#activeScenarioId) {
+      this.#activeScenarioId = scenarioId;
+      this.#renderScenarioOverview();
+      this.#loadScenarioDetails(this.#activeScenarioId);
+    }
     this.#autoReloadScheduled = false;
     this.#hideGameOver();
     this.updateMenu();

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -32,6 +32,10 @@ describe('auto new game persistence', () => {
       <div id="currentTurnLabel"></div>
       <div id="victoryTurnLabel"></div>
       <div id="victoryPointsList"></div>
+      <h3 id="scenarioOverviewHeading"></h3>
+      <p id="scenarioOverviewDescription"></p>
+      <h4 id="scenarioVictoryHeading"></h4>
+      <p id="scenarioVictoryDescription"></p>
     `;
   }
 
@@ -55,6 +59,7 @@ describe('auto new game persistence', () => {
       getScores: () => ({}),
       isGameOver: () => false,
       getId: () => 'game-id',
+      getScenarioId: () => 'elim_1',
     };
 
     return { ...baseGame, ...overrides };
@@ -64,6 +69,51 @@ describe('auto new game persistence', () => {
     eventBus.emit.mockClear();
     window.localStorage.clear();
     axios.post.mockReset();
+    axios.get.mockReset();
+    axios.get.mockResolvedValue({ data: [] });
+  });
+
+  test('shows scenario heading from name with description and victory conditions', async () => {
+    buildDom();
+
+    axios.get.mockResolvedValue({
+      data: [{
+        id: 'elim_1',
+        name: 'Elimination One',
+        description: 'Secure all objectives before the turn limit.',
+        victory: {
+          description: 'Control every objective at the end of any turn.',
+        },
+      }],
+    });
+
+    new Menu(fakeGame());
+    await flushPromises();
+
+    expect(document.getElementById('scenarioOverviewHeading').textContent).toBe('Elimination One');
+    expect(document.getElementById('scenarioOverviewDescription').textContent).toBe('Secure all objectives before the turn limit.');
+    expect(document.getElementById('scenarioVictoryHeading').style.display).toBe('');
+    expect(document.getElementById('scenarioVictoryDescription').textContent).toBe('Control every objective at the end of any turn.');
+  });
+
+  test('falls back to scenario id and hides optional sections when details are missing', async () => {
+    buildDom();
+
+    axios.get.mockResolvedValue({
+      data: [{
+        id: 'elim_1',
+      }],
+    });
+
+    new Menu(fakeGame());
+    await flushPromises();
+
+    expect(document.getElementById('scenarioOverviewHeading').textContent).toBe('elim_1');
+    expect(document.getElementById('scenarioOverviewDescription').style.display).toBe('none');
+    expect(document.getElementById('scenarioOverviewDescription').textContent).toBe('');
+    expect(document.getElementById('scenarioVictoryHeading').style.display).toBe('none');
+    expect(document.getElementById('scenarioVictoryDescription').style.display).toBe('none');
+    expect(document.getElementById('scenarioVictoryDescription').textContent).toBe('');
   });
 
   test('checkbox reflects url parameter', () => {


### PR DESCRIPTION
### Motivation
- Surface scenario metadata in the in-battle menu so players can see the scenario name, description and victory conditions without returning to the title screen.
- Make the UI robust when scenario fields are missing by falling back to safe defaults and hiding optional text.

### Description
- Inserted a new menu section between Game Stages and Options in `battle-hexes-web/src/battle.html` with elements `#scenarioOverviewHeading`, `#scenarioOverviewDescription`, `#scenarioVictoryHeading`, and `#scenarioVictoryDescription`.
- Extended `Menu` (`battle-hexes-web/src/menu.js`) to fetch scenario list from the API (`GET ${API_URL}/scenarios`), render the scenario heading using `name` (fallback to `id` then a safe label), render the `description`, and render a "Victory Conditions" subsection using `victory.description`, hiding optional blocks when values are absent.
- Made the scenario overview reactive to game changes by refreshing details in `setGame()` when the active `scenarioId` changes, and added request-id handling to ignore stale async responses.
- Added/updated unit tests in `battle-hexes-web/tests/menu/menu.test.js` to cover full metadata rendering and fallback behavior.

### Testing
- Ran the web package validation with `npm run test-and-build` in `battle-hexes-web`, which ran linting, Jest unit tests and the webpack build successfully.
- Test results: `Test Suites: 25 passed, 25 total` and `Tests: 147 passed, 147 total`, and the `webpack` build completed without errors.
- Performed a smoke render of the built `battle.html` in a headless browser and captured a screenshot to verify the new menu section visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad997136f483278ca25f706d2621ab)