### PR TITLE
Expose scenario description and victory metadata in API ScenarioModel

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/schemas/scenario.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/scenario.py
@@ -4,7 +4,17 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict
 
-from battle_hexes_core.scenario.scenario import Scenario
+from battle_hexes_core.scenario.scenario import Scenario, ScenarioVictory
+
+
+class ScenarioVictoryModel(BaseModel):
+    """Pydantic representation of :class:`ScenarioVictory`."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    method: str
+    scoring_side: str
+    description: str | None = None
 
 
 class ScenarioModel(BaseModel):
@@ -14,6 +24,8 @@ class ScenarioModel(BaseModel):
 
     id: str
     name: str
+    description: str | None = None
+    victory: ScenarioVictoryModel | None = None
 
     @classmethod
     def from_core(cls, scenario: Scenario) -> "ScenarioModel":
@@ -24,4 +36,11 @@ class ScenarioModel(BaseModel):
     def to_core(self) -> Scenario:
         """Convert the Pydantic model back into a core :class:`Scenario`."""
 
-        return Scenario(**self.model_dump())
+        return Scenario(
+            **self.model_dump(exclude={"victory"}),
+            victory=(
+                ScenarioVictory(**self.victory.model_dump())
+                if self.victory is not None
+                else None
+            ),
+        )

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -109,8 +109,18 @@ class TestFastAPI(unittest.TestCase):
         self.assertEqual(
             response.json(),
             [
-                {"id": "test-1", "name": "Test Scenario"},
-                {"id": "test-2", "name": "Another Scenario"},
+                {
+                    "id": "test-1",
+                    "name": "Test Scenario",
+                    "description": None,
+                    "victory": None,
+                },
+                {
+                    "id": "test-2",
+                    "name": "Another Scenario",
+                    "description": None,
+                    "victory": None,
+                },
             ],
         )
         mock_registry.list_scenarios.assert_called_once_with()

--- a/battle_hexes_api/tests/test_schemas.py
+++ b/battle_hexes_api/tests/test_schemas.py
@@ -11,21 +11,60 @@ from battle_hexes_core.game.game import Game
 from battle_hexes_core.game.objective import Objective
 from battle_hexes_core.game.player import Player, PlayerType
 from battle_hexes_core.game.terrain import Terrain
-from battle_hexes_core.scenario.scenario import Scenario
+from battle_hexes_core.scenario.scenario import Scenario, ScenarioVictory
 from battle_hexes_core.unit.faction import Faction
 from battle_hexes_core.unit.unit import Unit
 
 
 class TestScenarioModel(unittest.TestCase):
     def test_round_trip(self):
-        core_scenario = Scenario(id="s1", name="Scenario 1")
+        core_scenario = Scenario(
+            id="s1",
+            name="Scenario 1",
+            description="Briefing text",
+            victory=None,
+        )
 
         model = ScenarioModel.from_core(core_scenario)
         self.assertEqual(model.id, "s1")
         self.assertEqual(model.name, "Scenario 1")
+        self.assertEqual(model.description, "Briefing text")
+        self.assertIsNone(model.victory)
 
         converted = model.to_core()
         self.assertEqual(converted, core_scenario)
+
+    def test_round_trip_with_victory(self):
+        core_scenario = Scenario(
+            id="s2",
+            name="Scenario 2",
+            description="Hold crossroads.",
+            victory=ScenarioVictory(
+                method="objective_control",
+                scoring_side="Allies",
+                description="Allies win by holding the objective.",
+            ),
+        )
+
+        model = ScenarioModel.from_core(core_scenario)
+
+        self.assertEqual(model.victory.method, "objective_control")
+        self.assertEqual(model.victory.scoring_side, "Allies")
+        self.assertEqual(
+            model.victory.description,
+            "Allies win by holding the objective.",
+        )
+
+        converted = model.to_core()
+        self.assertEqual(converted.id, "s2")
+        self.assertEqual(converted.name, "Scenario 2")
+        self.assertEqual(converted.description, "Hold crossroads.")
+        self.assertEqual(converted.victory.method, "objective_control")
+        self.assertEqual(converted.victory.scoring_side, "Allies")
+        self.assertEqual(
+            converted.victory.description,
+            "Allies win by holding the objective.",
+        )
 
 
 class TestGameModel(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- The web menu expects `scenario.description` and `scenario.victory.description` from the `GET /scenarios` response but the API schema only exposed `id` and `name`, so the frontend could not display briefing or victory text.

### Description
- Added `ScenarioVictoryModel` and added `description` and `victory` fields to `ScenarioModel` in `battle_hexes_api/src/battle_hexes_api/schemas/scenario.py` so the API returns the metadata the UI requires.
- Updated `ScenarioModel.to_core()` to correctly convert nested `victory` data back into the core `ScenarioVictory` dataclass.
- Updated tests in `battle_hexes_api/tests/test_schemas.py` and `battle_hexes_api/tests/test_main.py` to cover round-trip serialization with and without victory metadata and to expect `description`/`victory` fields from `/scenarios`.

### Testing
- Ran the repository validation script `./server-side-checks.sh` which executes the test suites for the core, RL, and API packages, and all tests passed.
- The API package tests (including the updated `test_schemas.py` and `test_main.py`) passed as part of the above checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada51dd5688327b3b5cadff230f60e)