### PR TITLE
Add SoundPlayer for defensive fire audio and integrate with Menu

### DIFF
--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -1,6 +1,7 @@
 import { battleHexesService } from './service/service-factory.js';
 import { eventBus } from './event-bus.js';
 import { BoardUpdater } from './model/board-updater.js';
+import { SoundPlayer } from './sound/sound-player.js';
 
 export class Menu {
   #game;
@@ -21,15 +22,17 @@ export class Menu {
   #scenarioVictoryHeading;
   #scenarioVictoryDescription;
   #activeScenarioId;
+  #activeScenario;
   #scenarioDetailsRequestId = 0;
   #autoReloadScheduled = false;
   #onNewGameRequested;
   #reactionMessagesDiv;
   #service;
+  #soundPlayer;
   static #SHOW_HEX_COORDS_STORAGE_KEY = 'battleHexes.showHexCoords';
   static #DEFAULT_SWATCH_COLOR = '#B0B0B0';
 
-  constructor(game, { onNewGameRequested, service = battleHexesService } = {}) {
+  constructor(game, { onNewGameRequested, service = battleHexesService, soundPlayer = new SoundPlayer() } = {}) {
     this.#game = game;
     this.#selHexContentsDiv = document.getElementById('selHexContents');
     this.#selHexCoordDiv = document.getElementById('selHexCoord');
@@ -49,6 +52,7 @@ export class Menu {
     this.#scenarioVictoryDescription = document.getElementById('scenarioVictoryDescription');
     this.#reactionMessagesDiv = document.getElementById('reactionMessages');
     this.#activeScenarioId = this.#game.getScenarioId?.() ?? null;
+    this.#activeScenario = null;
     this.#onNewGameRequested = onNewGameRequested;
     this.#service = service
       ?? battleHexesService
@@ -57,6 +61,7 @@ export class Menu {
         endMovement: async () => ({}),
         endTurn: async () => ({}),
       };
+    this.#soundPlayer = soundPlayer;
 
     // Initialize checkbox state from URL param
     const params = new URLSearchParams(window.location.search);
@@ -108,6 +113,8 @@ export class Menu {
   }
 
   #renderScenarioOverview(scenario = null) {
+    this.#activeScenario = scenario;
+
     if (!this.#scenarioOverviewHeading || !this.#scenarioVictoryHeading) {
       return;
     }
@@ -491,6 +498,11 @@ export class Menu {
       .map((event) => `<div class="reaction-message reaction-message--${event.outcome ?? 'info'}">${event.message ?? 'Defensive fire resolved.'}</div>`)
       .join('');
     this.#reactionMessagesDiv.style.display = 'block';
+    this.#soundPlayer.playDefensiveFireEvents({
+      events,
+      game: this.#game,
+      scenario: this.#activeScenario,
+    });
   }
 
   #setCurrentTurn() {

--- a/battle-hexes-web/src/sound/sound-player.js
+++ b/battle-hexes-web/src/sound/sound-player.js
@@ -17,9 +17,14 @@ export class SoundPlayer {
       return null;
     }
 
+    this.#logger.info("===== SCENARIO =====");
+    this.#logger.info(JSON.stringify(scenario));
+
     const factions = Array.isArray(scenario.factions) ? scenario.factions : [];
+    this.#logger.info("Found " + factions.length + " factions.");
     const faction = factions.find((entry) => entry.id === factionId);
     if (!faction) {
+      this.#logger.warn("Did not find faction with factionId=" + factionId);
       return null;
     }
 
@@ -40,6 +45,7 @@ export class SoundPlayer {
   }
 
   playDefensiveFireEvents({ events, game, scenario }) {
+    this.#logger.info("Playing defensive fire sound fx for " + events.length + " events.");
     if (!Array.isArray(events) || events.length === 0) {
       return;
     }
@@ -52,7 +58,16 @@ export class SoundPlayer {
         factionId,
         soundPath: ['defensive_fire', outcomeKey],
       });
+      this.#logger.info(
+        "firing_unit_id=" + event?.firing_unit_id +
+        ", factionId=" + factionId + ", outcomeKey=" + outcomeKey +
+        ", soundPath=" + soundPath
+      );
       if (!soundPath) {
+        this.#logger.warn(
+          "No defensive fire sound found for factionId=" + factionId +
+          " and outcomeKey=" + outcomeKey
+        );
         continue;
       }
 

--- a/battle-hexes-web/src/sound/sound-player.js
+++ b/battle-hexes-web/src/sound/sound-player.js
@@ -1,0 +1,79 @@
+const NO_EFFECT_OUTCOME = 'no_effect';
+
+export class SoundPlayer {
+  #audioFactory;
+  #logger;
+
+  constructor({
+    audioFactory = (soundPath) => new Audio(soundPath),
+    logger = console,
+  } = {}) {
+    this.#audioFactory = audioFactory;
+    this.#logger = logger;
+  }
+
+  getFactionSoundPath({ scenario, factionId, soundPath }) {
+    if (!scenario || !factionId || !Array.isArray(soundPath) || soundPath.length === 0) {
+      return null;
+    }
+
+    const factions = Array.isArray(scenario.factions) ? scenario.factions : [];
+    const faction = factions.find((entry) => entry.id === factionId);
+    if (!faction) {
+      return null;
+    }
+
+    let soundFilename = faction.sounds;
+    for (const segment of soundPath) {
+      soundFilename = soundFilename?.[segment];
+    }
+    if (typeof soundFilename !== 'string' || soundFilename.trim().length === 0) {
+      return null;
+    }
+
+    return `/sounds/${soundFilename}`;
+  }
+
+  playSound(soundPath) {
+    const audio = this.#audioFactory(soundPath);
+    return audio.play();
+  }
+
+  playDefensiveFireEvents({ events, game, scenario }) {
+    if (!Array.isArray(events) || events.length === 0) {
+      return;
+    }
+
+    for (const event of events) {
+      const factionId = this.#resolveFiringFactionId(game, event?.firing_unit_id);
+      const outcomeKey = event?.outcome === NO_EFFECT_OUTCOME ? 'no_effect' : 'effect';
+      const soundPath = this.getFactionSoundPath({
+        scenario,
+        factionId,
+        soundPath: ['defensive_fire', outcomeKey],
+      });
+      if (!soundPath) {
+        continue;
+      }
+
+      this.playSound(soundPath).catch((error) => {
+        this.#logger.warn('Failed to play defensive fire sound', error);
+      });
+    }
+  }
+
+  #resolveFiringFactionId(game, firingUnitId) {
+    if (!game || !firingUnitId) {
+      return null;
+    }
+
+    const units = game.getBoard?.().getUnits?.() ?? [];
+    for (const unit of units) {
+      if (unit.getId?.() === firingUnitId) {
+        return unit.getFaction?.().getId?.() ?? null;
+      }
+    }
+
+    return null;
+  }
+}

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 import { eventBus } from '../../src/event-bus.js';
 import { BoardUpdater } from '../../src/model/board-updater.js';
+import { SoundPlayer } from '../../src/sound/sound-player.js';
 
 jest.mock('../../src/event-bus.js', () => ({
   eventBus: {
@@ -22,6 +23,12 @@ jest.mock('../../src/service/service-factory.js', () => ({
 jest.mock('../../src/model/board-updater.js', () => ({
   BoardUpdater: jest.fn().mockImplementation(() => ({
     updateBoard: jest.fn(),
+  })),
+}));
+
+jest.mock('../../src/sound/sound-player.js', () => ({
+  SoundPlayer: jest.fn().mockImplementation(() => ({
+    playDefensiveFireEvents: jest.fn(),
   })),
 }));
 
@@ -58,11 +65,19 @@ describe('auto new game persistence', () => {
   }
 
   function fakeGame(overrides = {}) {
+    const defaultFaction = {
+      getId: () => 'axis',
+    };
+    const defaultUnit = {
+      getId: () => 'firing-unit',
+      getFaction: () => defaultFaction,
+    };
     const baseGame = {
       getBoard: () => ({
         getSelectedHex: () => null,
         isOwnHexSelected: () => false,
         hasCombat: () => false,
+        getUnits: () => [defaultUnit],
       }),
       getPhases: () => ['Movement', 'Combat'],
       getCurrentPhase: () => 'Movement',
@@ -87,6 +102,7 @@ describe('auto new game persistence', () => {
     eventBus.emit.mockClear();
     eventBus.on.mockClear();
     BoardUpdater.mockClear();
+    SoundPlayer.mockClear();
     window.localStorage.clear();
     mockService.listScenarios.mockReset();
     mockService.endMovement.mockReset();
@@ -135,6 +151,67 @@ describe('auto new game persistence', () => {
     expect(document.getElementById('reactionStatus').textContent).toBe(
       'Defensive fire forced the target to retreat to (0, 1). Defensive fire had no effect.'
     );
+  });
+
+  test('passes defensive fire events to sound player with game and scenario context', async () => {
+    buildDom();
+    mockService.listScenarios.mockResolvedValue([{
+      id: 'elim_1',
+      factions: [{
+        id: 'axis',
+        sounds: {
+          defensive_fire: {
+            effect: 'axis-effect.ogg',
+          },
+        },
+      }, {
+        id: 'allies',
+        sounds: {
+          defensive_fire: {
+            effect: 'allies-effect.ogg',
+          },
+        },
+      }],
+    }]);
+
+    const game = fakeGame();
+    new Menu(game, { service: mockService });
+    await flushPromises();
+
+    const defensiveFireListeners = eventBus.on.mock.calls
+      .filter(([eventName]) => eventName === 'defensiveFireResolved')
+      .map(([, listener]) => listener);
+
+    const events = [{
+      firing_unit_id: 'firing-unit',
+      outcome: 'retreat',
+      message: 'Defensive fire forced a retreat.',
+    }];
+    defensiveFireListeners.forEach((listener) => listener(events));
+
+    const soundPlayerInstance = SoundPlayer.mock.results[0].value;
+    expect(soundPlayerInstance.playDefensiveFireEvents).toHaveBeenCalledWith({
+      events,
+      game,
+      scenario: {
+        id: 'elim_1',
+        factions: [{
+          id: 'axis',
+          sounds: {
+            defensive_fire: {
+              effect: 'axis-effect.ogg',
+            },
+          },
+        }, {
+          id: 'allies',
+          sounds: {
+            defensive_fire: {
+              effect: 'allies-effect.ogg',
+            },
+          },
+        }],
+      },
+    });
   });
 
   test('falls back to scenario id and hides optional sections when details are missing', async () => {

--- a/battle-hexes-web/tests/sound/sound-player.test.js
+++ b/battle-hexes-web/tests/sound/sound-player.test.js
@@ -1,0 +1,208 @@
+import { SoundPlayer } from '../../src/sound/sound-player.js';
+
+describe('SoundPlayer', () => {
+  const buildGame = (factionId = 'axis') => ({
+    getBoard: () => ({
+      getUnits: () => [{
+        getId: () => 'firing-unit',
+        getFaction: () => ({
+          getId: () => factionId,
+        }),
+      }],
+    }),
+  });
+
+  test('plays effect outcome sound for firing faction', async () => {
+    const play = jest.fn(() => Promise.resolve());
+    const soundPlayer = new SoundPlayer({
+      audioFactory: () => ({ play }),
+    });
+
+    soundPlayer.playDefensiveFireEvents({
+      events: [{
+        firing_unit_id: 'firing-unit',
+        outcome: 'retreat',
+      }],
+      game: buildGame('axis'),
+      scenario: {
+        factions: [{
+          id: 'axis',
+          sounds: {
+            defensive_fire: {
+              effect: 'axis-effect.ogg',
+            },
+          },
+        }],
+      },
+    });
+
+    expect(play).toHaveBeenCalledTimes(1);
+  });
+
+  test('plays no_effect outcome sound for firing faction', async () => {
+    const play = jest.fn(() => Promise.resolve());
+    const soundPlayer = new SoundPlayer({
+      audioFactory: (path) => ({
+        play,
+        path,
+      }),
+    });
+
+    soundPlayer.playDefensiveFireEvents({
+      events: [{
+        firing_unit_id: 'firing-unit',
+        outcome: 'no_effect',
+      }],
+      game: buildGame('axis'),
+      scenario: {
+        factions: [{
+          id: 'axis',
+          sounds: {
+            defensive_fire: {
+              no_effect: 'axis-no-effect.ogg',
+            },
+          },
+        }],
+      },
+    });
+
+    expect(play).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not play when defensive fire sound config is missing, missing key, or empty', () => {
+    const play = jest.fn(() => Promise.resolve());
+    const soundPlayer = new SoundPlayer({
+      audioFactory: () => ({ play }),
+    });
+
+    soundPlayer.playDefensiveFireEvents({
+      events: [{ firing_unit_id: 'firing-unit', outcome: 'retreat' }],
+      game: buildGame('axis'),
+      scenario: {
+        factions: [{ id: 'axis', sounds: {} }],
+      },
+    });
+
+    soundPlayer.playDefensiveFireEvents({
+      events: [{ firing_unit_id: 'firing-unit', outcome: 'retreat' }],
+      game: buildGame('axis'),
+      scenario: {
+        factions: [{
+          id: 'axis',
+          sounds: {
+            defensive_fire: {
+              no_effect: 'axis-no-effect.ogg',
+            },
+          },
+        }],
+      },
+    });
+
+    soundPlayer.playDefensiveFireEvents({
+      events: [{ firing_unit_id: 'firing-unit', outcome: 'retreat' }],
+      game: buildGame('axis'),
+      scenario: {
+        factions: [{
+          id: 'axis',
+          sounds: {
+            defensive_fire: {
+              effect: '',
+            },
+          },
+        }],
+      },
+    });
+
+    expect(play).not.toHaveBeenCalled();
+  });
+
+  test('uses firing faction-specific sound mapping', () => {
+    const requestedPaths = [];
+    const soundPlayer = new SoundPlayer({
+      audioFactory: (soundPath) => {
+        requestedPaths.push(soundPath);
+        return { play: () => Promise.resolve() };
+      },
+    });
+
+    soundPlayer.playDefensiveFireEvents({
+      events: [{
+        firing_unit_id: 'firing-unit',
+        outcome: 'retreat',
+      }],
+      game: buildGame('allies'),
+      scenario: {
+        factions: [{
+          id: 'axis',
+          sounds: {
+            defensive_fire: {
+              effect: 'axis-effect.ogg',
+            },
+          },
+        }, {
+          id: 'allies',
+          sounds: {
+            defensive_fire: {
+              effect: 'allies-effect.ogg',
+            },
+          },
+        }],
+      },
+    });
+
+    expect(requestedPaths).toEqual(['/sounds/allies-effect.ogg']);
+  });
+
+  test('logs warning and continues processing when playback fails', async () => {
+    const logger = { warn: jest.fn() };
+    const soundPlayer = new SoundPlayer({
+      audioFactory: () => ({
+        play: jest.fn(() => Promise.reject(new Error('decode failed'))),
+      }),
+      logger,
+    });
+
+    soundPlayer.playDefensiveFireEvents({
+      events: [
+        { firing_unit_id: 'firing-unit', outcome: 'retreat' },
+        { firing_unit_id: 'firing-unit', outcome: 'retreat' },
+      ],
+      game: buildGame('axis'),
+      scenario: {
+        factions: [{
+          id: 'axis',
+          sounds: {
+            defensive_fire: {
+              effect: 'axis-effect.ogg',
+            },
+          },
+        }],
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('resolves generic faction sound path from nested keys', () => {
+    const soundPlayer = new SoundPlayer();
+    const path = soundPlayer.getFactionSoundPath({
+      scenario: {
+        factions: [{
+          id: 'axis',
+          sounds: {
+            ui: {
+              click: 'button-click.ogg',
+            },
+          },
+        }],
+      },
+      factionId: 'axis',
+      soundPath: ['ui', 'click'],
+    });
+
+    expect(path).toBe('/sounds/button-click.ogg');
+  });
+});

--- a/battle-hexes-web/tests/sound/sound-player.test.js
+++ b/battle-hexes-web/tests/sound/sound-player.test.js
@@ -41,7 +41,7 @@ describe('SoundPlayer', () => {
 
   test('plays no_effect outcome sound for firing faction', async () => {
     const play = jest.fn(() => Promise.resolve());
-    const soundPlayer = new SoundPlayer({
+    const logger = { warn: jest.fn() };const soundPlayer = new SoundPlayer({
       audioFactory: (path) => ({
         play,
         path,
@@ -154,7 +154,10 @@ describe('SoundPlayer', () => {
   });
 
   test('logs warning and continues processing when playback fails', async () => {
-    const logger = { warn: jest.fn() };
+    const logger = { 
+      warn: jest.fn(),
+      info: jest.fn(),
+    };
     const soundPlayer = new SoundPlayer({
       audioFactory: () => ({
         play: jest.fn(() => Promise.reject(new Error('decode failed'))),

--- a/battle_hexes_core/src/battle_hexes_core/scenarios/elim_1.json
+++ b/battle_hexes_core/src/battle_hexes_core/scenarios/elim_1.json
@@ -9,13 +9,25 @@
       "id": "red faction",
       "name": "Red Faction",
       "color": "#C81010",
-      "player": "Player 1"
+      "player": "Player 1",
+      "sounds": {
+        "defensive_fire": {
+          "effect": "m1_single_rifle_shot.ogg",
+          "no_effect": "m1_single_rifle_shot.ogg"
+        }
+      }
     },
     {
       "id": "blue faction",
       "name": "Blue Faction",
       "color": "#4682B4",
-      "player": "Player 2"
+      "player": "Player 2",
+      "sounds": {
+        "defensive_fire": {
+          "effect": "m1_single_rifle_shot.ogg",
+          "no_effect": "m1_single_rifle_shot.ogg"
+        }
+      }
     }
   ],
   "units": [
@@ -54,7 +66,7 @@
   },
   "hex_data": [
     { "coords": [5, 5], "terrain": "village" },
-    { "coords": [2, 2], "units": ["red_unit_1"] },
+    { "coords": [5, 6], "units": ["red_unit_1"] },
     { "coords": [8, 9], "units": ["blue_unit_1"] },
     { "coords": [9, 5], "units": ["blue_unit_2"] }
   ],


### PR DESCRIPTION
### Motivation
- Provide per-faction defensive-fire sound playback so the UI can play appropriate audio when movement-phase reactions occur.
- Surface scenario context to the sound subsystem so faction-specific mappings can be resolved for playback.

### Description
- Introduce `SoundPlayer` (`src/sound/sound-player.js`) implementing `getFactionSoundPath`, `playSound`, and `playDefensiveFireEvents` with an injectable `audioFactory` and `logger` and a private `#resolveFiringFactionId` helper.
- Integrate `SoundPlayer` into `Menu` by importing it, adding a `soundPlayer` constructor parameter defaulting to `new SoundPlayer()`, storing `#soundPlayer`, tracking `#activeScenario` in `#renderScenarioOverview`, and invoking `#soundPlayer.playDefensiveFireEvents({ events, game: this.#game, scenario: this.#activeScenario })` from `#showDefensiveFireEvents`.
- Update `menu` tests to mock `SoundPlayer` and to include a test that verifies `Menu` passes defensive fire events along with `game` and `scenario` context to the `SoundPlayer` instance.
- Add comprehensive unit tests for `SoundPlayer` in `tests/sound/sound-player.test.js` covering outcome selection, faction mapping, missing configs, playback failures, and resolved paths.

### Testing
- Ran the test suite with `jest` covering updated `tests/menu/menu.test.js` and new `tests/sound/sound-player.test.js`; all unit tests passed.
- New `SoundPlayer` unit tests exercised playback success, failure handling, path resolution, and no-op conditions and succeeded under the mocked `audioFactory` implementations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c932993a0c83278df39673ffbe986e)