### PR TITLE
Implement zero-movement forced-retreat elimination

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/combat/combat.py
+++ b/battle_hexes_core/src/battle_hexes_core/combat/combat.py
@@ -89,14 +89,7 @@ class Combat:
                 self.board.remove_units(attackers)
             case CombatResult.ATTACKER_RETREAT_2:
                 origin = defenders[0].get_coords()
-                removed = []
-                for attacker in attackers:
-                    attacker.record_forced_retreat(
-                        self.game.get_current_player()
-                    )
-                    success = attacker.forced_move(self.board, origin, 2)
-                    if not success:
-                        removed.append(attacker)
+                removed = self._resolve_forced_retreat(attackers, origin, 2)
                 if removed:
                     self.board.remove_units(removed)
                     combat_result.add_no_retreat_units(removed)
@@ -108,14 +101,7 @@ class Combat:
                 self.board.remove_units(defenders)
             case CombatResult.DEFENDER_RETREAT_2:
                 origin = attackers[0].get_coords()
-                removed = []
-                for defender in defenders:
-                    defender.record_forced_retreat(
-                        self.game.get_current_player()
-                    )
-                    success = defender.forced_move(self.board, origin, 2)
-                    if not success:
-                        removed.append(defender)
+                removed = self._resolve_forced_retreat(defenders, origin, 2)
                 if removed:
                     self.board.remove_units(removed)
                     combat_result.add_no_retreat_units(removed)
@@ -137,6 +123,23 @@ class Combat:
                     'Unhandled combat result:',
                     combat_result.get_combat_result(),
                 )
+
+    def _resolve_forced_retreat(
+            self,
+            units,
+            origin: tuple[int, int] | None,
+            distance: int,
+    ) -> list:
+        removed = []
+        for unit in units:
+            unit.record_forced_retreat(self.game.get_current_player())
+            if unit.get_move() == 0:
+                removed.append(unit)
+                continue
+            success = unit.forced_move(self.board, origin, distance)
+            if not success:
+                removed.append(unit)
+        return removed
 
     def _attackers_to_remove(self, attackers, defense_factor):
         """Return subset of attackers to remove for an exchange."""

--- a/battle_hexes_core/tests/combat/test_combat.py
+++ b/battle_hexes_core/tests/combat/test_combat.py
@@ -280,6 +280,34 @@ class TestCombat(unittest.TestCase):
             combat_result.get_battles()[0].get_no_retreat_units(),
         )
 
+    def test_attacker_retreat_eliminates_zero_movement_unit(self):
+        fixed_attacker = Unit(
+            id=str(uuid.uuid4()),
+            name='Fixed Red Unit',
+            faction=self.red_faction,
+            player=self.red_player,
+            type='Garrison',
+            attack=4,
+            defense=4,
+            move=0,
+        )
+        self.board.add_unit(fixed_attacker, 4, 4)
+        self.board.add_unit(self.blue_unit, 3, 5)
+        self.combat.set_static_die_roll(4)
+
+        combat_result = self.combat.resolve_combat().get_battles()[0]
+
+        self.assertEqual(1, len(self.board.get_units()))
+        self.assertEqual(self.blue_unit, self.board.get_units()[0])
+        self.assertEqual(
+            CombatResult.ATTACKER_ELIMINATED,
+            combat_result.get_combat_result(),
+        )
+        self.assertEqual(
+            (fixed_attacker,),
+            combat_result.get_no_retreat_units(),
+        )
+
     def test_attacker_retreat_blocked_by_enemy_eliminates_unit(self):
         blue_blocker = Unit(
             id=str(uuid.uuid4()),
@@ -353,6 +381,89 @@ class TestCombat(unittest.TestCase):
         self.assertEqual(
             (self.blue_unit,),
             combat_result.get_battles()[0].get_no_retreat_units(),
+        )
+
+    def test_defender_retreat_eliminates_zero_movement_unit(self):
+        fixed_defender = Unit(
+            id=str(uuid.uuid4()),
+            name='Fixed Blue Unit',
+            faction=self.blue_faction,
+            player=self.blue_player,
+            type='Garrison',
+            attack=2,
+            defense=2,
+            move=0,
+        )
+        self.board.add_unit(self.red_unit, 2, 5)
+        self.board.add_unit(fixed_defender, 3, 5)
+        self.combat.set_static_die_roll(3)
+
+        combat_result = self.combat.resolve_combat().get_battles()[0]
+
+        self.assertEqual(1, len(self.board.get_units()))
+        self.assertEqual(self.red_unit, self.board.get_units()[0])
+        self.assertEqual(
+            CombatResult.DEFENDER_ELIMINATED,
+            combat_result.get_combat_result(),
+        )
+        self.assertEqual(
+            (fixed_defender,),
+            combat_result.get_no_retreat_units(),
+        )
+
+    def test_defender_retreat_only_eliminates_zero_movement_units(self):
+        fixed_defender = Unit(
+            id=str(uuid.uuid4()),
+            name='Fixed Blue Unit',
+            faction=self.blue_faction,
+            player=self.blue_player,
+            type='Garrison',
+            attack=2,
+            defense=2,
+            move=0,
+        )
+        mobile_defender = Unit(
+            id=str(uuid.uuid4()),
+            name='Mobile Blue Unit',
+            faction=self.blue_faction,
+            player=self.blue_player,
+            type='Recon',
+            attack=2,
+            defense=2,
+            move=6,
+        )
+        red_support = Unit(
+            id=str(uuid.uuid4()),
+            name='Red Support Unit',
+            faction=self.red_faction,
+            player=self.red_player,
+            type='Infantry',
+            attack=4,
+            defense=4,
+            move=4,
+        )
+        self.board.add_unit(self.red_unit, 2, 5)
+        self.board.add_unit(red_support, 3, 4)
+        self.board.add_unit(fixed_defender, 3, 5)
+        self.board.add_unit(mobile_defender, 2, 6)
+        self.combat.set_static_die_roll(3)
+
+        combat_result = self.combat.resolve_combat().get_battles()[0]
+
+        units = self.board.get_units()
+        self.assertEqual(3, len(units))
+        self.assertCountEqual(
+            units,
+            [self.red_unit, red_support, mobile_defender],
+        )
+        self.assertNotEqual((2, 6), mobile_defender.get_coords())
+        self.assertEqual(
+            CombatResult.DEFENDER_RETREAT_2,
+            combat_result.get_combat_result(),
+        )
+        self.assertEqual(
+            (fixed_defender,),
+            combat_result.get_no_retreat_units(),
         )
 
     def test_combat_uses_defender_terrain_shift(self):


### PR DESCRIPTION
### Motivation

- Enforce the rule that units with movement `0` cannot retreat and must be eliminated when a combat result forces a retreat.
- Centralize retreat-resolution logic to keep attacker/defender retreat handling consistent and avoid duplicated checks.

### Description

- Add a `_resolve_forced_retreat` helper that records forced retreat for each unit, eliminates units with `move == 0`, and otherwise attempts the existing `forced_move` behavior, collecting units that fail to retreat.
- Route both `ATTACKER_RETREAT_2` and `DEFENDER_RETREAT_2` branches through the new helper and preserve the existing off-map and blocked-retreat elimination semantics.
- Add unit tests covering attacker zero-movement elimination, defender zero-movement elimination, and mixed defender stacks where only immobile units are eliminated.
- Adjust test formatting (line wraps) to satisfy linting where necessary.

### Testing

- Ran `pytest battle_hexes_core/tests/combat/test_combat.py` and the modified combat tests passed.
- Ran the full server-side checks via `./server-side-checks.sh`, which runs all package tests and linters, and the suite passed (153 + 17 + 42 tests across packages).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2bc0bc3e88327bcae001dea153926)