### PR TITLE
Support stacking_limit in scenarios with validation, logging, and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ tests and linter across **all** Python packages. The script adjusts
 
 - Prefer small, focused methods; avoid introducing long methods when a few well-named helpers would make the logic easier to read.
 - Keep cyclomatic complexity reasonable by extracting branching logic into helper functions or dedicated classes when behavior grows beyond a straightforward flow.
+- Prefer testing observable behavior and public contracts over incidental implementation details.
+- Do not add tests that assert exact log message text, private helper calls, or other brittle internals unless the log/output is itself part of documented behavior or an explicit operational requirement.
 
 ## Specification docs
 
@@ -51,4 +53,3 @@ tests and linter across **all** Python packages. The script adjusts
 - Do not leave new spec files in project package directories unless explicitly requested.
 - Do not perform code changes when creating a specification unless explicitly requested.
 - Include an "Open Questions" section at the end of the spec to clarify any ambiguities that need to be resolved for implementation. If there are no such ambiguities then simply list state "No questions." in this section. Do not create questions just to fill out this section. The questions should be useful, essential, and limited. 
-

--- a/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
+++ b/battle_hexes_core/src/battle_hexes_core/scenario/scenario.py
@@ -96,6 +96,7 @@ class Scenario:
     description: str | None = None
     victory: ScenarioVictory | None = None
     turn_limit: int | None = None
+    stacking_limit: int | None = None
     board_size: Tuple[int, int] | None = None
     factions: tuple[ScenarioFaction, ...] = field(default_factory=tuple)
     units: tuple[ScenarioUnit, ...] = field(default_factory=tuple)

--- a/battle_hexes_core/src/battle_hexes_core/scenario/scenario_loader.py
+++ b/battle_hexes_core/src/battle_hexes_core/scenario/scenario_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator
@@ -27,6 +28,8 @@ from .scenario import (
     ScenarioUnit,
     ScenarioVictory,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -149,6 +152,7 @@ class ScenarioData(BaseModel):
     victory: ScenarioVictoryData | None = None
     defensive_fire: DefensiveFireConfigData | None = None
     turn_limit: int | None = None
+    stacking_limit: StrictInt | None = Field(default=None, ge=1)
     board_size: tuple[int, int]
     factions: list[ScenarioFactionData]
     units: list[ScenarioUnitData]
@@ -303,6 +307,7 @@ class ScenarioData(BaseModel):
                 else None
             ),
             turn_limit=self.turn_limit,
+            stacking_limit=self.stacking_limit,
             board_size=self.board_size,
             factions=self._build_factions(),
             units=self._build_units(),
@@ -364,6 +369,13 @@ def load_scenario_data(
             f"Scenario '{scenario_id}' does not match file contents "
             f"(found id '{scenario.id}')"
         )
+
+    LOGGER.info(
+        "Loaded scenario id=%s name=%s stacking_limit=%s",
+        scenario.id,
+        scenario.name,
+        scenario.stacking_limit,
+    )
 
     return scenario
 

--- a/battle_hexes_core/tests/scenario/test_scenario_loader.py
+++ b/battle_hexes_core/tests/scenario/test_scenario_loader.py
@@ -181,6 +181,52 @@ def test_load_scenario_with_turn_limit():
     assert scenario.turn_limit == 8
 
 
+def test_load_scenario_data_defaults_stacking_limit_to_none():
+    scenario = load_scenario_data(
+        "village_1", scenario_dir=_scenario_dir()
+    )
+
+    assert scenario.stacking_limit is None
+
+
+def test_load_scenario_maps_stacking_limit_to_core_type(tmp_path):
+    payload_path = _scenario_dir() / "elim_1.json"
+    payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    payload["stacking_limit"] = 3
+    scenario_path = tmp_path / "elim_1.json"
+    scenario_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    scenario = load_scenario("elim_1", scenario_dir=tmp_path)
+
+    assert scenario.stacking_limit == 3
+
+
+def test_load_scenario_data_accepts_null_stacking_limit(tmp_path):
+    payload_path = _scenario_dir() / "elim_1.json"
+    payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    payload["stacking_limit"] = None
+    scenario_path = tmp_path / "elim_1.json"
+    scenario_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    scenario = load_scenario_data("elim_1", scenario_dir=tmp_path)
+
+    assert scenario.stacking_limit is None
+
+
+@pytest.mark.parametrize("value", [0, -1, 1.5, "3"])
+def test_load_scenario_data_rejects_invalid_stacking_limit(
+    tmp_path, value
+):
+    payload_path = _scenario_dir() / "elim_1.json"
+    payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    payload["stacking_limit"] = value
+    scenario_path = tmp_path / "elim_1.json"
+    scenario_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="is not a valid scenario"):
+        load_scenario_data("elim_1", scenario_dir=tmp_path)
+
+
 def test_load_scenario_maps_unit_defensive_fire_modifier_to_core_type():
     scenario = load_scenario(
         "d_day_crossroads", scenario_dir=_scenario_dir()


### PR DESCRIPTION
### Motivation
- Add support for a per-scenario `stacking_limit` so scenarios can express unit stacking constraints in the core model and scenario payloads.
- Provide validation for the new field to prevent invalid values from being accepted.
- Improve diagnostics when loading scenarios by emitting a brief log message.
- Clarify testing guidance in the project documentation to prefer testing observable behavior.

### Description
- Added `stacking_limit: int | None` to the core `Scenario` dataclass in `scenario.py`.
- Extended `ScenarioData` pydantic model in `scenario_loader.py` with `stacking_limit: StrictInt | None = Field(default=None, ge=1)` and mapped it into the core `Scenario` in `to_core`.
- Introduced a module `LOGGER` and an informational log entry in `load_scenario_data` to report loaded scenario id, name, and stacking limit.
- Added unit tests in `battle_hexes_core/tests/scenario/test_scenario_loader.py` to cover defaulting, mapping, acceptance of null, and rejection of invalid `stacking_limit` values.
- Updated `AGENTS.md` to add guidance: "Prefer testing observable behavior and public contracts..." and to discourage brittle tests that assert exact internals or log text.

### Testing
- Ran scenario loader unit tests with `pytest battle_hexes_core/tests/scenario -q`, and the test suite completed successfully with the new tests passing.
- All modified and existing scenario-related tests passed (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece818bda48327bff1b8dcd5449c12)