### PR TITLE
Enforce stacking limits for movement and retreat in core

### DIFF
--- a/battle_hexes_core/src/battle_hexes_core/game/board.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/board.py
@@ -31,6 +31,7 @@ class Board:
     def __init__(self, rows: int, columns: int):
         self.rows = rows
         self.columns = columns
+        self.stacking_limit: int | None = None
         self.units: dict[str, Unit] = {}
         self.road_types: dict[str, float] = {}
         self.road_paths: tuple[
@@ -85,6 +86,10 @@ class Board:
         """Return True if the coordinates are on the board."""
         return 0 <= row < self.rows and 0 <= column < self.columns
 
+    def set_stacking_limit(self, stacking_limit: int | None) -> None:
+        """Set optional scenario-level friendly stacking limit."""
+        self.stacking_limit = stacking_limit
+
     def add_unit(self, unit: Unit, row: int, column: int) -> None:
         if not (0 <= row < self.rows) or not (0 <= column < self.columns):
             raise ValueError("Unit is out of bounds")
@@ -116,6 +121,48 @@ class Board:
             if unit.get_coords() == (row, column):
                 return unit
         return None
+
+    def get_units_at(
+        self,
+        row: int,
+        column: int,
+        exclude_unit: Unit | None = None,
+    ) -> List[Unit]:
+        """Return all units occupying ``(row, column)``."""
+        return [
+            unit
+            for unit in self.units.values()
+            if unit is not exclude_unit
+            and unit.get_coords() == (row, column)
+        ]
+
+    def can_unit_enter_hex(
+        self,
+        unit: Unit,
+        row: int,
+        column: int,
+    ) -> bool:
+        """Return whether ``unit`` may legally enter ``(row, column)``."""
+        if not self.is_in_bounds(row, column):
+            return False
+
+        occupying_units = self.get_units_at(
+            row,
+            column,
+            exclude_unit=unit,
+        )
+        if any(not occupant.is_friendly(unit) for occupant in occupying_units):
+            return False
+
+        if self.stacking_limit is None:
+            return True
+
+        friendly_count = sum(
+            1
+            for occupant in occupying_units
+            if occupant.is_friendly(unit)
+        )
+        return friendly_count + 1 <= self.stacking_limit
 
     def get_unit_by_id(self, unit_id: str) -> Unit:
         if not isinstance(unit_id, str):

--- a/battle_hexes_core/src/battle_hexes_core/game/game.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/game.py
@@ -87,6 +87,13 @@ class Game:
             if unit.get_coords() != (from_hex.row, from_hex.column):
                 break
 
+            if not self.board.can_unit_enter_hex(
+                unit,
+                to_hex.row,
+                to_hex.column,
+            ):
+                break
+
             was_adjacent = self.board.enemy_adjacent(unit, from_hex)
             move_cost = movement.move_cost(unit, from_hex, to_hex)
             movement_points_remaining = max(

--- a/battle_hexes_core/src/battle_hexes_core/game/movement.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/movement.py
@@ -49,6 +49,13 @@ class MovementCalculator:
                 continue
 
             for neighbor in self.board.get_neighboring_hexes(current_hex):
+                if not self.board.can_unit_enter_hex(
+                    unit,
+                    neighbor.row,
+                    neighbor.column,
+                ):
+                    continue
+
                 step_cost = self.move_cost(unit, current_hex, neighbor)
                 new_cost = current_cost + step_cost
                 if new_cost > move_points:
@@ -107,6 +114,13 @@ class MovementCalculator:
 
             for neighbor in self.board.get_neighboring_hexes(current_hex):
                 if neighbor not in reachable_hexes:
+                    continue
+
+                if not self.board.can_unit_enter_hex(
+                    unit,
+                    neighbor.row,
+                    neighbor.column,
+                ):
                     continue
 
                 step_cost = self.move_cost(unit, current_hex, neighbor)

--- a/battle_hexes_core/src/battle_hexes_core/gamecreator/gamecreator.py
+++ b/battle_hexes_core/src/battle_hexes_core/gamecreator/gamecreator.py
@@ -59,6 +59,7 @@ class GameCreator:
         )
 
         board = Board(*scenario_obj.board_size)
+        board.set_stacking_limit(scenario_obj.stacking_limit)
 
         players_list = list(players)
         for player in players_list:

--- a/battle_hexes_core/src/battle_hexes_core/unit/unit.py
+++ b/battle_hexes_core/src/battle_hexes_core/unit/unit.py
@@ -226,8 +226,7 @@ class Unit:
                 self.row, self.column = original_position
                 return False
 
-            occupant = board.get_unit_at(next_row, next_col)
-            if occupant and not occupant.is_friendly(self):
+            if not board.can_unit_enter_hex(self, next_row, next_col):
                 self.row, self.column = original_position
                 return False
 

--- a/battle_hexes_core/tests/game/test_board.py
+++ b/battle_hexes_core/tests/game/test_board.py
@@ -318,6 +318,93 @@ class TestBoard(unittest.TestCase):
         path = self.board.shortest_path(self.red_unit, start_hex, end_hex)
         self.assertEqual(path, [])
 
+    def test_reachable_hexes_allow_unlimited_friendly_stacking_by_default(
+        self,
+    ):
+        self.board.add_unit(self.red_unit, 0, 0)
+        friendly = Unit(
+            id=str(uuid.uuid4()),
+            name="Friendly",
+            faction=self.red_faction,
+            player=self.red_player,
+            type="Infantry",
+            attack=1,
+            defense=1,
+            move=3,
+        )
+        self.board.add_unit(friendly, 0, 1)
+
+        start_hex = self.board.get_hex(0, 0)
+        reachable = self.board.get_reachable_hexes(
+            self.red_unit,
+            start_hex,
+            move_points=1,
+        )
+
+        self.assertIn(self.board.get_hex(0, 1), reachable)
+
+    def test_reachable_hexes_limit_one_blocks_friendly_occupied_hex(self):
+        self.board.set_stacking_limit(1)
+        self.board.add_unit(self.red_unit, 0, 0)
+        friendly = Unit(
+            id=str(uuid.uuid4()),
+            name="Friendly",
+            faction=self.red_faction,
+            player=self.red_player,
+            type="Infantry",
+            attack=1,
+            defense=1,
+            move=3,
+        )
+        self.board.add_unit(friendly, 0, 1)
+
+        start_hex = self.board.get_hex(0, 0)
+        reachable = self.board.get_reachable_hexes(
+            self.red_unit,
+            start_hex,
+            move_points=1,
+        )
+
+        self.assertNotIn(self.board.get_hex(0, 1), reachable)
+
+    def test_can_unit_enter_hex_limit_two_allows_two_but_blocks_three(self):
+        self.board.set_stacking_limit(2)
+        self.board.add_unit(self.red_unit, 0, 0)
+        friendly_one = Unit(
+            id=str(uuid.uuid4()),
+            name="Friendly 1",
+            faction=self.red_faction,
+            player=self.red_player,
+            type="Infantry",
+            attack=1,
+            defense=1,
+            move=3,
+        )
+        friendly_two = Unit(
+            id=str(uuid.uuid4()),
+            name="Friendly 2",
+            faction=self.red_faction,
+            player=self.red_player,
+            type="Infantry",
+            attack=1,
+            defense=1,
+            move=3,
+        )
+        self.board.add_unit(friendly_one, 0, 1)
+
+        self.assertTrue(self.board.can_unit_enter_hex(self.red_unit, 0, 1))
+
+        self.board.add_unit(friendly_two, 0, 1)
+
+        self.assertFalse(self.board.can_unit_enter_hex(self.red_unit, 0, 1))
+
+    def test_can_unit_enter_hex_enemy_occupancy_still_illegal(self):
+        self.board.set_stacking_limit(3)
+        self.board.add_unit(self.red_unit, 0, 0)
+        self.board.add_unit(self.blue_unit, 0, 1)
+
+        self.assertFalse(self.board.can_unit_enter_hex(self.red_unit, 0, 1))
+
     def test_get_reachable_hexes_respects_terrain_move_cost(self):
         self.board.add_unit(self.red_unit, 2, 2)
         start_hex = self.board.get_hex(2, 2)

--- a/battle_hexes_core/tests/game/test_game.py
+++ b/battle_hexes_core/tests/game/test_game.py
@@ -325,6 +325,63 @@ class TestGame(unittest.TestCase):
         self.assertEqual(mover.get_coords(), (0, 2))
         self.assertEqual(mover.current_turn_movement_points_remaining, 1)
 
+    def test_apply_movement_plans_respects_stacking_contention_order(self):
+        board, player1, _player2, faction1, _faction2, game = (
+            self._make_two_player_game()
+        )
+        board.set_stacking_limit(2)
+
+        occupant = Unit(
+            id="occupant",
+            name="Occupant",
+            faction=faction1,
+            player=player1,
+            type="Infantry",
+            attack=1,
+            defense=1,
+            move=3,
+        )
+        mover_one = Unit(
+            id="mover-one",
+            name="Mover One",
+            faction=faction1,
+            player=player1,
+            type="Infantry",
+            attack=1,
+            defense=1,
+            move=3,
+        )
+        mover_two = Unit(
+            id="mover-two",
+            name="Mover Two",
+            faction=faction1,
+            player=player1,
+            type="Infantry",
+            attack=1,
+            defense=1,
+            move=3,
+        )
+
+        board.add_unit(occupant, 0, 1)
+        board.add_unit(mover_one, 0, 0)
+        board.add_unit(mover_two, 1, 0)
+
+        plans = [
+            UnitMovementPlan(
+                mover_one,
+                [board.get_hex(0, 0), board.get_hex(0, 1)],
+            ),
+            UnitMovementPlan(
+                mover_two,
+                [board.get_hex(1, 0), board.get_hex(0, 1)],
+            ),
+        ]
+
+        game.apply_movement_plans(plans)
+
+        self.assertEqual(mover_one.get_coords(), (0, 1))
+        self.assertEqual(mover_two.get_coords(), (1, 0))
+
     @patch(
         RANDOM_PATCH_TARGET,
         return_value=0.0,

--- a/battle_hexes_core/tests/unit/test_unit.py
+++ b/battle_hexes_core/tests/unit/test_unit.py
@@ -112,6 +112,74 @@ class TestUnit(unittest.TestCase):
         self.assertFalse(result)
         self.assertEqual((2, 2), self.unit1.get_coords())
 
+    def test_forced_move_blocked_when_destination_exceeds_stacking_limit(self):
+        board = Board(6, 6)
+        board.set_stacking_limit(1)
+        board.add_unit(self.unit1, 2, 2)
+
+        enemy = Unit(
+            id=str(uuid.uuid4()),
+            name="Enemy",
+            player=self.player2,
+            faction=self.faction2,
+            type="Infantry",
+            attack=5,
+            defense=5,
+            move=3,
+        )
+        friendly_blocker = Unit(
+            id=str(uuid.uuid4()),
+            name="Friendly Blocker",
+            player=self.player1,
+            faction=self.faction1,
+            type="Infantry",
+            attack=5,
+            defense=5,
+            move=3,
+        )
+        board.add_unit(enemy, 2, 3)
+        board.add_unit(friendly_blocker, 1, 1)
+
+        result = self.unit1.forced_move(board, enemy.get_coords(), 1)
+
+        self.assertFalse(result)
+        self.assertEqual((2, 2), self.unit1.get_coords())
+
+    def test_forced_move_blocked_when_intermediate_step_exceeds_stacking_limit(
+        self,
+    ):
+        board = Board(6, 6)
+        board.set_stacking_limit(1)
+        board.add_unit(self.unit1, 2, 2)
+
+        enemy = Unit(
+            id=str(uuid.uuid4()),
+            name="Enemy",
+            player=self.player2,
+            faction=self.faction2,
+            type="Infantry",
+            attack=5,
+            defense=5,
+            move=3,
+        )
+        intermediate_blocker = Unit(
+            id=str(uuid.uuid4()),
+            name="Intermediate Blocker",
+            player=self.player1,
+            faction=self.faction1,
+            type="Infantry",
+            attack=5,
+            defense=5,
+            move=3,
+        )
+        board.add_unit(enemy, 2, 3)
+        board.add_unit(intermediate_blocker, 1, 1)
+
+        result = self.unit1.forced_move(board, enemy.get_coords(), 2)
+
+        self.assertFalse(result)
+        self.assertEqual((2, 2), self.unit1.get_coords())
+
     def test_turn_end_needs_more_than_one_move_remaining(self):
         self.unit1.record_friendly_turn_end(1, self.player2)
 


### PR DESCRIPTION
### Motivation
- Centralize hex-entry legality so movement and retreat consistently enforce enemy co-occupancy and optional scenario stacking limits.
- Preserve backward compatibility: scenarios that omit `stacking_limit` should keep unlimited friendly stacking.
- Prevent movement plans and forced retreats from bypassing stacking caps during resolution.

### Description
- Added board-level state `stacking_limit` and a centralized helper `Board.can_unit_enter_hex` to check enemy presence and friendly stacking caps. (file: `game/board.py`)
- Wired the scenario `stacking_limit` into new games via `GameCreator` so the board enforces configured limits. (file: `gamecreator/gamecreator.py`)
- Applied the helper to movement reachability and shortest-path search so pathfinding excludes stacking-illegal hexes. (file: `game/movement.py`)
- Re-checked entry legality during movement-plan execution and used the same helper for forced retreats so intermediate and destination hexes cannot violate stacking limits. (files: `game/game.py`, `unit/unit.py`)
- Added unit tests covering unlimited default stacking, limit=1 and limit=2 behaviors, enemy occupancy, sequential contention ordering, and retreat destination/crossing constraints. (tests updated under `tests/game` and `tests/unit`)

### Testing
- Ran targeted tests: `pytest -q battle_hexes_core/tests/game/test_board.py battle_hexes_core/tests/game/test_game.py battle_hexes_core/tests/unit/test_unit.py`, which passed (63 passed).
- Executed full package checks: `./battle_hexes_core/checks.sh`, which ran the full test-suite and linter and completed successfully (167 tests passed and flake8 checks passing after installing dependencies).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1df75d048327b51dce4bd6a20ede)