### PR TITLE
Add stacking-limit move feedback and suppress illegal hover arrows

### DIFF
--- a/battle-hexes-web/src/drawer/move-arrow-drawer.js
+++ b/battle-hexes-web/src/drawer/move-arrow-drawer.js
@@ -11,7 +11,11 @@ export class MoveArrowDrawer {
     if (!aHex.isEmpty() && aHex.getUnits()[0].hasMovePath()) {
       const movePath = aHex.getUnits()[0].getMovePath();
       this.#drawMoveArrow(movePath[0], movePath[1]);
-    } else if (aHex.getMoveHoverFromHex() && aHex.getMoveHoverFromHex().hasMovableUnit()) {
+    } else if (
+      aHex.getMoveHoverIllegalReason() !== 'STACKING_LIMIT_EXCEEDED'
+      && aHex.getMoveHoverFromHex()
+      && aHex.getMoveHoverFromHex().hasMovableUnit()
+    ) {
       console.log('Lets draw a move arrow!');
       this.#drawMoveArrow(aHex.getMoveHoverFromHex(), aHex);
     }

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -101,6 +101,7 @@ export class Menu {
     });
 
     eventBus.on?.('defensiveFireResolved', (events) => this.#showDefensiveFireEvents(events));
+    eventBus.on?.('movementRejected', (payload) => this.#showMovementRejectionStatus(payload));
 
     this.#initPhasesInMenu();
     this.#initPhaseEndButton();
@@ -266,6 +267,18 @@ export class Menu {
         return `<div class="selected-unit-row"><span class="victory-swatch selected-unit-swatch" style="background-color: ${color};"></span><span class="selected-unit-label" title="${tooltipText}">${unit.getName()} <span class="selected-unit-moves">(moves ${movesDisplay})</span></span></div>`;
       })
       .join('');
+  }
+
+  #showMovementRejectionStatus(payload) {
+    if (!this.#reactionStatusDiv) {
+      return;
+    }
+
+    const message = payload?.message;
+    if (typeof message !== 'string' || message.length === 0) {
+      return;
+    }
+    this.#reactionStatusDiv.textContent = message;
   }
 
   #formatSelectedHexTerrain(terrain) {

--- a/battle-hexes-web/src/model/board-updater.js
+++ b/battle-hexes-web/src/model/board-updater.js
@@ -4,6 +4,12 @@ export class BoardUpdater {
   constructor() {
   }
 
+  clearMoveHoverIllegalReasons(board) {
+    for (const hex of board.getAllHexes()) {
+      hex.setMoveHoverIllegalReason(undefined);
+    }
+  }
+
   updateBoard(board, units = [], { defensiveFireEvents = [] } = {}) {
     const unitsById = new Map((units ?? []).map((unit) => [unit.id, unit]));
 

--- a/battle-hexes-web/src/model/board.js
+++ b/battle-hexes-web/src/model/board.js
@@ -191,6 +191,7 @@ export class Board {
         && !this.#selectedHex.hasUnitMoves() 
         && this.#hoverHex.isAdjacent(this.#selectedHex)
         && this.#selectedHex.getUnits()[0].canEnterHex(this.#hoverHex)
+        && this.#hoverHex.getMoveHoverIllegalReason() !== 'STACKING_LIMIT_EXCEEDED'
         && this.isOwnHexSelected()
         && !this.isOppositionHex(hoverHex)) {
       console.log(`We have a move hover hex! ${this.#hoverHex}`);

--- a/battle-hexes-web/src/model/hex.js
+++ b/battle-hexes-web/src/model/hex.js
@@ -3,6 +3,7 @@ export class Hex {
   #adjacentHexCoords;
   #selected;
   #moveHoverFromHex;
+  #moveHoverIllegalReason;
   #terrain;
   #objectives;
 
@@ -12,6 +13,7 @@ export class Hex {
     this.#units = [];
     this.#selected = false;
     this.#moveHoverFromHex = undefined;
+    this.#moveHoverIllegalReason = undefined;
     this.#terrain = undefined;
     this.#objectives = [];
 
@@ -98,6 +100,14 @@ export class Hex {
 
   getMoveHoverFromHex() {
     return this.#moveHoverFromHex;
+  }
+
+  setMoveHoverIllegalReason(reasonCode) {
+    this.#moveHoverIllegalReason = reasonCode;
+  }
+
+  getMoveHoverIllegalReason() {
+    return this.#moveHoverIllegalReason;
   }
 
   setTerrain(terrain) {

--- a/battle-hexes-web/src/model/movement-response-handler.js
+++ b/battle-hexes-web/src/model/movement-response-handler.js
@@ -1,12 +1,57 @@
 import { eventBus } from '../event-bus.js';
 import { BoardUpdater } from './board-updater.js';
 
+const REASON_TO_MESSAGE = {
+  STACKING_LIMIT_EXCEEDED: 'Destination hex is full due to the scenario stacking limit.',
+};
+
+function getPlanReasonCode(plan) {
+  if (!plan || typeof plan !== 'object') {
+    return null;
+  }
+  return plan.reason_code ?? plan.reason ?? plan.invalid_reason ?? plan.failure_reason ?? null;
+}
+
+function getPlanDestinationHex(plan, board) {
+  const path = Array.isArray(plan?.path) ? plan.path : [];
+  if (path.length === 0) {
+    return null;
+  }
+  const destination = path[path.length - 1];
+  if (!destination) {
+    return null;
+  }
+  return board.getHex?.(destination.row, destination.column) ?? null;
+}
+
 export function applyMovementResponse(board, response) {
+  const boardUpdater = new BoardUpdater();
   const units = response?.game?.board?.units ?? response?.sparse_board?.units ?? [];
-  new BoardUpdater().updateBoard(board, units);
+  boardUpdater.clearMoveHoverIllegalReasons(board);
+  boardUpdater.updateBoard(board, units);
 
   const defensiveFireEvents = response?.defensive_fire_events ?? [];
   if (defensiveFireEvents.length > 0) {
     eventBus.emit('defensiveFireResolved', defensiveFireEvents);
+  }
+
+  const rejectedPlans = (response?.plans ?? [])
+    .map((plan) => {
+      const reasonCode = getPlanReasonCode(plan);
+      return { plan, reasonCode };
+    })
+    .filter(({ reasonCode }) => reasonCode !== null);
+
+  for (const { plan, reasonCode } of rejectedPlans) {
+    const destinationHex = getPlanDestinationHex(plan, board);
+    destinationHex?.setMoveHoverIllegalReason(reasonCode);
+
+    if (REASON_TO_MESSAGE[reasonCode]) {
+      eventBus.emit('movementRejected', {
+        reasonCode,
+        message: REASON_TO_MESSAGE[reasonCode],
+        plan,
+      });
+    }
   }
 }

--- a/battle-hexes-web/src/model/movement-response-handler.js
+++ b/battle-hexes-web/src/model/movement-response-handler.js
@@ -12,6 +12,21 @@ function getPlanReasonCode(plan) {
   return plan.reason_code ?? plan.reason ?? plan.invalid_reason ?? plan.failure_reason ?? null;
 }
 
+function getRejectedPlans(response) {
+  if (!response || typeof response !== 'object') {
+    return [];
+  }
+
+  const preferredRejectedPlans = Array.isArray(response.rejected_plans)
+    ? response.rejected_plans
+    : [];
+  if (preferredRejectedPlans.length > 0) {
+    return preferredRejectedPlans;
+  }
+
+  return Array.isArray(response.plans) ? response.plans : [];
+}
+
 function getPlanDestinationHex(plan, board) {
   const path = Array.isArray(plan?.path) ? plan.path : [];
   if (path.length === 0) {
@@ -35,7 +50,7 @@ export function applyMovementResponse(board, response) {
     eventBus.emit('defensiveFireResolved', defensiveFireEvents);
   }
 
-  const rejectedPlans = (response?.plans ?? [])
+  const rejectedPlans = getRejectedPlans(response)
     .map((plan) => {
       const reasonCode = getPlanReasonCode(plan);
       return { plan, reasonCode };

--- a/battle-hexes-web/tests/drawer/move-arrow-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/move-arrow-drawer.test.js
@@ -1,0 +1,43 @@
+import { MoveArrowDrawer } from '../../src/drawer/move-arrow-drawer.js';
+
+function createP5Mock() {
+  return {
+    PI: Math.PI,
+    CLOSE: 'close',
+    stroke: jest.fn(),
+    strokeWeight: jest.fn(),
+    fill: jest.fn(),
+    atan2: Math.atan2,
+    push: jest.fn(),
+    pop: jest.fn(),
+    translate: jest.fn(),
+    rotate: jest.fn(),
+    beginShape: jest.fn(),
+    vertex: jest.fn(),
+    endShape: jest.fn(),
+  };
+}
+
+describe('MoveArrowDrawer', () => {
+  test('does not draw hover arrow for stacking-illegal destination', () => {
+    const p = createP5Mock();
+    const hexDrawer = {
+      getHexRadius: () => 10,
+      hexCenter: () => ({ x: 5, y: 5 }),
+    };
+    const moveArrowDrawer = new MoveArrowDrawer(p, hexDrawer);
+
+    const fromHex = {
+      hasMovableUnit: () => true,
+    };
+    const targetHex = {
+      isEmpty: () => true,
+      getMoveHoverIllegalReason: () => 'STACKING_LIMIT_EXCEEDED',
+      getMoveHoverFromHex: () => fromHex,
+    };
+
+    moveArrowDrawer.draw(targetHex);
+
+    expect(p.beginShape).not.toHaveBeenCalled();
+  });
+});

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -158,6 +158,26 @@ describe('auto new game persistence', () => {
     );
   });
 
+  test('shows stacking-limit movement rejection message in reaction status', async () => {
+    buildDom();
+
+    new Menu(fakeGame(), { service: mockService });
+    await flushPromises();
+
+    const movementRejectedListener = eventBus.on.mock.calls.find(
+      ([eventName]) => eventName === 'movementRejected'
+    )?.[1];
+
+    movementRejectedListener({
+      reasonCode: 'STACKING_LIMIT_EXCEEDED',
+      message: 'Destination hex is full due to the scenario stacking limit.',
+    });
+
+    expect(document.getElementById('reactionStatus').textContent).toBe(
+      'Destination hex is full due to the scenario stacking limit.'
+    );
+  });
+
   test('falls back to scenario id and hides optional sections when details are missing', async () => {
     buildDom();
 

--- a/battle-hexes-web/tests/model/board.test.js
+++ b/battle-hexes-web/tests/model/board.test.js
@@ -200,3 +200,25 @@ describe('board dimensions', () => {
     expect(board.getColumns()).toBe(18);
   });
 });
+
+describe('stacking limit hover rejection behavior', () => {
+  test('setHoverHex does not set move hover origin for stacking-illegal destination', () => {
+    const player = { isHuman: () => true };
+    const faction = new Faction('f1', 'f1', '#f00');
+    faction.setOwningPlayer(player);
+    const board = new Board(1, 2);
+    board.setPlayers({ getCurrentPlayer: () => player });
+
+    const unit = new Unit('u1', 'Unit', faction, null, 1, 1, 2);
+    board.addUnit(unit, 0, 0);
+
+    const start = board.getHex(0, 0);
+    const blockedDestination = board.getHex(0, 1);
+    blockedDestination.setMoveHoverIllegalReason('STACKING_LIMIT_EXCEEDED');
+
+    board.selectHex(start);
+    board.setHoverHex(blockedDestination);
+
+    expect(blockedDestination.getMoveHoverFromHex()).toBeUndefined();
+  });
+});

--- a/battle-hexes-web/tests/model/movement-response-handler.test.js
+++ b/battle-hexes-web/tests/model/movement-response-handler.test.js
@@ -62,7 +62,7 @@ describe('applyMovementResponse', () => {
     expect(eventBus.emit).not.toHaveBeenCalled();
   });
 
-  test('maps STACKING_LIMIT_EXCEEDED reason code to user-facing message and tags destination hex', () => {
+  test('maps STACKING_LIMIT_EXCEEDED reason code from rejected_plans and tags destination hex', () => {
     const stackingHex = { setMoveHoverIllegalReason: jest.fn() };
     const board = {
       id: 'board-1',
@@ -72,6 +72,38 @@ describe('applyMovementResponse', () => {
       sparse_board: {
         units: [{ id: 'unit-2', row: 3, column: 4 }],
       },
+      rejected_plans: [{
+        unit_id: 'unit-2',
+        path: [{ row: 3, column: 3 }, { row: 3, column: 4 }],
+        reason_code: 'STACKING_LIMIT_EXCEEDED',
+      }],
+      plans: [{
+        unit_id: 'unit-2',
+        path: [{ row: 3, column: 3 }, { row: 3, column: 4 }],
+      }],
+    };
+
+    applyMovementResponse(board, response);
+
+    expect(board.getHex).toHaveBeenCalledWith(3, 4);
+    expect(stackingHex.setMoveHoverIllegalReason).toHaveBeenCalledWith('STACKING_LIMIT_EXCEEDED');
+    expect(eventBus.emit).toHaveBeenCalledWith('movementRejected', expect.objectContaining({
+      reasonCode: 'STACKING_LIMIT_EXCEEDED',
+      message: 'Destination hex is full due to the scenario stacking limit.',
+    }));
+  });
+
+  test('falls back to plans when rejected_plans is empty', () => {
+    const stackingHex = { setMoveHoverIllegalReason: jest.fn() };
+    const board = {
+      id: 'board-1',
+      getHex: jest.fn().mockReturnValue(stackingHex),
+    };
+    const response = {
+      sparse_board: {
+        units: [{ id: 'unit-2', row: 3, column: 4 }],
+      },
+      rejected_plans: [],
       plans: [{
         unit_id: 'unit-2',
         path: [{ row: 3, column: 3 }, { row: 3, column: 4 }],
@@ -85,7 +117,6 @@ describe('applyMovementResponse', () => {
     expect(stackingHex.setMoveHoverIllegalReason).toHaveBeenCalledWith('STACKING_LIMIT_EXCEEDED');
     expect(eventBus.emit).toHaveBeenCalledWith('movementRejected', expect.objectContaining({
       reasonCode: 'STACKING_LIMIT_EXCEEDED',
-      message: 'Destination hex is full due to the scenario stacking limit.',
     }));
   });
 });

--- a/battle-hexes-web/tests/model/movement-response-handler.test.js
+++ b/battle-hexes-web/tests/model/movement-response-handler.test.js
@@ -4,6 +4,7 @@ import { eventBus } from '../../src/event-bus.js';
 
 jest.mock('../../src/model/board-updater.js', () => ({
   BoardUpdater: jest.fn().mockImplementation(() => ({
+    clearMoveHoverIllegalReasons: jest.fn(),
     updateBoard: jest.fn(),
   })),
 }));
@@ -36,6 +37,7 @@ describe('applyMovementResponse', () => {
     applyMovementResponse(board, response);
 
     const updater = BoardUpdater.mock.results[0].value;
+    expect(updater.clearMoveHoverIllegalReasons).toHaveBeenCalledWith(board);
     expect(updater.updateBoard).toHaveBeenCalledWith(board, response.game.board.units);
     expect(eventBus.emit).toHaveBeenCalledWith(
       'defensiveFireResolved',
@@ -55,7 +57,35 @@ describe('applyMovementResponse', () => {
     applyMovementResponse(board, response);
 
     const updater = BoardUpdater.mock.results[0].value;
+    expect(updater.clearMoveHoverIllegalReasons).toHaveBeenCalledWith(board);
     expect(updater.updateBoard).toHaveBeenCalledWith(board, response.sparse_board.units);
     expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  test('maps STACKING_LIMIT_EXCEEDED reason code to user-facing message and tags destination hex', () => {
+    const stackingHex = { setMoveHoverIllegalReason: jest.fn() };
+    const board = {
+      id: 'board-1',
+      getHex: jest.fn().mockReturnValue(stackingHex),
+    };
+    const response = {
+      sparse_board: {
+        units: [{ id: 'unit-2', row: 3, column: 4 }],
+      },
+      plans: [{
+        unit_id: 'unit-2',
+        path: [{ row: 3, column: 3 }, { row: 3, column: 4 }],
+        reason_code: 'STACKING_LIMIT_EXCEEDED',
+      }],
+    };
+
+    applyMovementResponse(board, response);
+
+    expect(board.getHex).toHaveBeenCalledWith(3, 4);
+    expect(stackingHex.setMoveHoverIllegalReason).toHaveBeenCalledWith('STACKING_LIMIT_EXCEEDED');
+    expect(eventBus.emit).toHaveBeenCalledWith('movementRejected', expect.objectContaining({
+      reasonCode: 'STACKING_LIMIT_EXCEEDED',
+      message: 'Destination hex is full due to the scenario stacking limit.',
+    }));
   });
 });

--- a/battle-hexes-web/tests/player/cpu-player.test.js
+++ b/battle-hexes-web/tests/player/cpu-player.test.js
@@ -15,6 +15,7 @@ import { eventBus } from '../../src/event-bus.js';
 const mockUpdateBoard = jest.fn();
 jest.mock('../../src/model/board-updater.js', () => ({
   BoardUpdater: jest.fn().mockImplementation(() => ({
+    clearMoveHoverIllegalReasons: jest.fn(),
     updateBoard: mockUpdateBoard,
   })),
 }));

--- a/battle_hexes_api/src/battle_hexes_api/schemas/scenario.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/scenario.py
@@ -26,6 +26,7 @@ class ScenarioModel(BaseModel):
     name: str
     description: str | None = None
     victory: ScenarioVictoryModel | None = None
+    stacking_limit: int | None = None
 
     @classmethod
     def from_core(cls, scenario: Scenario) -> "ScenarioModel":

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -161,12 +161,14 @@ class TestFastAPI(unittest.TestCase):
                     "name": "Test Scenario",
                     "description": None,
                     "victory": None,
+                    "stacking_limit": None,
                 },
                 {
                     "id": "test-2",
                     "name": "Another Scenario",
                     "description": None,
                     "victory": None,
+                    "stacking_limit": None,
                 },
             ],
         )

--- a/battle_hexes_api/tests/test_schemas.py
+++ b/battle_hexes_api/tests/test_schemas.py
@@ -34,6 +34,7 @@ class TestScenarioModel(unittest.TestCase):
         self.assertEqual(model.name, "Scenario 1")
         self.assertEqual(model.description, "Briefing text")
         self.assertIsNone(model.victory)
+        self.assertIsNone(model.stacking_limit)
 
         converted = model.to_core()
         self.assertEqual(converted, core_scenario)
@@ -43,6 +44,7 @@ class TestScenarioModel(unittest.TestCase):
             id="s2",
             name="Scenario 2",
             description="Hold crossroads.",
+            stacking_limit=2,
             victory=ScenarioVictory(
                 method="objective_control",
                 scoring_side="Allies",
@@ -54,6 +56,7 @@ class TestScenarioModel(unittest.TestCase):
 
         self.assertEqual(model.victory.method, "objective_control")
         self.assertEqual(model.victory.scoring_side, "Allies")
+        self.assertEqual(model.stacking_limit, 2)
         self.assertEqual(
             model.victory.description,
             "Allies win by holding the objective.",
@@ -63,6 +66,7 @@ class TestScenarioModel(unittest.TestCase):
         self.assertEqual(converted.id, "s2")
         self.assertEqual(converted.name, "Scenario 2")
         self.assertEqual(converted.description, "Hold crossroads.")
+        self.assertEqual(converted.stacking_limit, 2)
         self.assertEqual(converted.victory.method, "objective_control")
         self.assertEqual(converted.victory.scoring_side, "Allies")
         self.assertEqual(


### PR DESCRIPTION
### Motivation

- Surface stacking-limit movement rejections to players and prevent misleading move-hover arrows when a destination is illegal due to a scenario `stacking_limit`.
- Keep client UI and API schema aligned with the `specs/stacking-limit.md` error semantics so rejected movement plans include a specific code the frontend can display.

### Description

- Map rejected movement plans with `STACKING_LIMIT_EXCEEDED` to a user-facing message and emit a `movementRejected` event from `applyMovementResponse` in `movement-response-handler.js`.
- Add per-hex move-hover illegality state (`setMoveHoverIllegalReason` / `getMoveHoverIllegalReason`) in `Hex` and clear stale markers via `BoardUpdater.clearMoveHoverIllegalReasons` before applying authoritative board updates.
- Prevent hover selection and hide the move-hover arrow when the destination hex is tagged as stacking-illegal by updating `Board.setHoverHex` and `MoveArrowDrawer.draw`.
- Wire the `Menu` to listen for `movementRejected` and show the mapped message in the reaction status area, and add/update unit tests that assert tagging, message mapping, arrow suppression, and hover selection behavior.
- Expose `stacking_limit` on the API `ScenarioModel` and update API tests to assert the new field is present and round-trips as expected.

### Testing

- Ran the web test/build workflow with `npm run test-and-build` in `battle-hexes-web`, which completed successfully with all tests and the production build passing.
- Ran API checks with `./battle_hexes_api/checks.sh`, which executed unit tests (42 passed) and linting (installed `flake8` in the environment) and passed.
- Added/updated unit tests in the web project for `movement-response-handler`, `board` hover behavior, `move-arrow-drawer`, `menu` messaging, and CPU-player compatibility; all web tests passed in the run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2235f6708327a344d1c281afd438)