### PR TITLE
Add scenario stacking limit to API and frontend; refactor Board to use property accessors

### DIFF
--- a/battle-hexes-web/src/battle-draw.js
+++ b/battle-hexes-web/src/battle-draw.js
@@ -32,17 +32,25 @@ new p5((p) => {
   const canvasMargin = 20;
   
   let game = new GameCreator().createGame(gameData);
+  const logLoadedScenario = (gameDataPayload, gameInstance) => {
+    const scenarioName = gameDataPayload.scenarioName;
+    const scenarioId = gameDataPayload.scenarioId;
+    console.log(
+      `Scenario loaded: name=${scenarioName}, id=${scenarioId}, stackingLimit=${gameInstance.getBoard().stackingLimit}`,
+    );
+  };
+  logLoadedScenario(gameData, game);
   let menu;
 
   const configureMovementHandling = () => {
-    game.getBoard().setMovementHandler(async () => {
+    game.getBoard().movementHandler = async () => {
       const movementResponse = await battleHexesService.resolveHumanMove(
         game.getId(),
         game.getBoard().sparseBoard(),
       );
 
       applyMovementResponse(game.getBoard(), movementResponse);
-    });
+    };
   };
   configureMovementHandling();
 
@@ -57,6 +65,7 @@ new p5((p) => {
     updateUrlWithGameId(newGameData.id);
     rememberLoadedGameData(newGameData);
     game = new GameCreator().createGame(newGameData);
+    logLoadedScenario(newGameData, game);
     configureMovementHandling();
     menu.setGame(game);
     p.resizeCanvas(getCanvasWidth(), getCanvasHeight());
@@ -79,7 +88,7 @@ new p5((p) => {
   const hexDrawWithCoords = new HexDrawer(p, hexRadius);
   hexDrawWithCoords.setShowHexCoords(menu.getShowHexCoordsPreference());
   const hexDraw = new HexDrawer(p, hexRadius);
-  const roadDraw = new RoadDrawer(p, hexDraw, () => game.getBoard().getRoads());
+  const roadDraw = new RoadDrawer(p, hexDraw, () => game.getBoard().roads);
   const terrainOverlayDraw = new TerrainOverlayDrawer(p, hexDraw);
   
   const unitDraw = new UnitDrawer(p, hexDraw);
@@ -162,19 +171,19 @@ new p5((p) => {
   p.mouseMoved = function() {
     let mouseHexPos = pixelToHex(p.mouseX, p.mouseY);
     let hoverHex = game.getBoard().getHex(mouseHexPos.row, mouseHexPos.col);
-    let oldHover = game.getBoard().setHoverHex(hoverHex);
+    let oldHover = game.getBoard().updateHoverHex(hoverHex);
 
     if (oldHover === hoverHex) {
       return;
     }
 
-    drawHexNeighborhood([oldHover, hoverHex, game.getBoard().getSelectedHex()]);
+    drawHexNeighborhood([oldHover, hoverHex, game.getBoard().selectedHex]);
   }
 
   function getCanvasDimensionsForBoard() {
     return getCanvasDimensions({
-      rows: game.getBoard().getRows(),
-      columns: game.getBoard().getColumns(),
+      columns: game.getBoard().columns,
+      rows: game.getBoard().rows,
       hexRadius,
       windowWidth: p.windowWidth,
       menuWidth,

--- a/battle-hexes-web/src/model/board.js
+++ b/battle-hexes-web/src/model/board.js
@@ -12,6 +12,7 @@ export class Board {
   #animator;
   #rows;
   #columns;
+  #stackingLimit = null;
   #movementHandler;
   #movementInProgress = false;
 
@@ -30,8 +31,12 @@ export class Board {
     }
   }
 
-  setPlayers(players) {
+  set players(players) {
     this.#players = players;
+  }
+
+  setPlayers(players) {
+    this.players = players;
   }
 
   addUnit(unit, row, column) {
@@ -52,24 +57,54 @@ export class Board {
     unit.setContainingHex(null);
   }
 
-  getUnits() {
+  get units() {
     return this.#units;
   }
 
-  getAnimator() {
+  getUnits() {
+    return this.units;
+  }
+
+  get animator() {
     return this.#animator;
   }
 
-  getRows() {
+  getAnimator() {
+    return this.animator;
+  }
+
+  get rows() {
     return this.#rows;
   }
 
-  setMovementHandler(handler) {
+  getRows() {
+    return this.rows;
+  }
+
+  set movementHandler(handler) {
     this.#movementHandler = handler;
   }
 
-  getColumns() {
+  setMovementHandler(handler) {
+    this.movementHandler = handler;
+  }
+
+  get columns() {
     return this.#columns;
+  }
+
+  getColumns() {
+    return this.columns;
+  }
+
+  get stackingLimit() {
+    return this.#stackingLimit;
+  }
+
+  set stackingLimit(stackingLimit) {
+    this.#stackingLimit = Number.isInteger(stackingLimit) && stackingLimit > 0
+      ? stackingLimit
+      : null;
   }
 
   getHex(row, column) {
@@ -104,7 +139,7 @@ export class Board {
       this.#resolveMovement(units[0], path);
       oldSelection.setSelected(false);
       hexToSelect.setSelected(true);
-      this.setHoverHex(undefined);
+      this.updateHoverHex(undefined);
     } else {
       oldSelection.setSelected(false);
     }
@@ -148,7 +183,7 @@ export class Board {
       startingHex?.setSelected(true);
     }
 
-    this.setHoverHex(undefined);
+    this.updateHoverHex(undefined);
     eventBus.emit('redraw');
   }
 
@@ -179,7 +214,7 @@ export class Board {
     return this.#selectedHex !== undefined;
   }
 
-  setHoverHex(hoverHex) {
+  updateHoverHex(hoverHex) {
     const oldHover = this.#hoverHex;
     this.#hoverHex = hoverHex;
 
@@ -194,7 +229,7 @@ export class Board {
         && this.isOwnHexSelected()
         && !this.isOppositionHex(hoverHex)) {
       console.log(`We have a move hover hex! ${this.#hoverHex}`);
-      this.#hoverHex.setMoveHoverFromHex(this.getSelectedHex());
+      this.#hoverHex.setMoveHoverFromHex(this.selectedHex);
     }
 
     if (oldHover) {
@@ -202,6 +237,10 @@ export class Board {
     }
 
     return oldHover;
+  }
+
+  setHoverHex(hoverHex) {
+    return this.updateHoverHex(hoverHex);
   }
 
   getHexAndAdjacent(aHex) {
@@ -246,8 +285,12 @@ export class Board {
     return allTheHexes;
   }
 
-  getSelectedHex() {
+  get selectedHex() {
     return this.#selectedHex;
+  }
+
+  getSelectedHex() {
+    return this.selectedHex;
   }
 
   resetMovesRemaining(player = null) {
@@ -293,18 +336,18 @@ export class Board {
 
   getOccupiedHexes() {
     const occupiedHexes = new Set();
-    for (let unit of this.getUnits()) {
+    for (let unit of this.units) {
       occupiedHexes.add(unit.getContainingHex());
     }
     return occupiedHexes;
   }
 
   refreshCombat() {
-    for (let unit of this.getUnits()) {
+    for (let unit of this.units) {
       unit.resetCombat();
     }
 
-    for (let unit of this.getUnits()) {
+    for (let unit of this.units) {
       const hex = unit.getContainingHex();
       if (hex) {
         unit.updateCombatOpponents(this.getAdjacentHexes(hex));
@@ -317,13 +360,17 @@ export class Board {
     console.log("There are " + this.#roads.length + " roads.");
   }
 
-  getRoads() {
+  get roads() {
     return [...this.#roads];
+  }
+
+  getRoads() {
+    return this.roads;
   }
 
   sparseBoard() {
     const sparseUnits = [];
-    for (let unit of this.getUnits()) {
+    for (let unit of this.units) {
       let unitHex = unit.getContainingHex();
       sparseUnits.push({
         id: unit.getId(),

--- a/battle-hexes-web/src/model/game-creator.js
+++ b/battle-hexes-web/src/model/game-creator.js
@@ -11,6 +11,7 @@ import { Road, RoadType } from './road';
 export class GameCreator {
   createGame(gameData) {
     const board = new Board(gameData.board.rows, gameData.board.columns);
+    board.stackingLimit = this.#extractStackingLimit(gameData);
     const scenarioId = this.#extractScenarioId(gameData);
     const playerTypeIds = this.#extractPlayerTypeIds(gameData);
     const turnLimit = this.#extractTurnLimit(gameData);
@@ -73,6 +74,13 @@ export class GameCreator {
     }
 
     return 1;
+  }
+
+  #extractStackingLimit(gameData) {
+    const stackingLimit = gameData?.stackingLimit;
+    return Number.isInteger(stackingLimit) && stackingLimit > 0
+      ? stackingLimit
+      : null;
   }
 
   #extractPlayerTypeIds(gameData) {

--- a/battle-hexes-web/src/model/game.js
+++ b/battle-hexes-web/src/model/game.js
@@ -27,7 +27,7 @@ export class Game {
     this.#players = players;
 
     this.#board = board;
-    this.#board.setPlayers(players);
+    this.#board.players = players;
 
     this.#combatResolver = new CombatResolver(id, board, { service: battleHexesService });
     this.#scenarioId = typeof scenarioId === 'string' && scenarioId.trim().length > 0

--- a/battle-hexes-web/src/player/cpu-player.js
+++ b/battle-hexes-web/src/player/cpu-player.js
@@ -26,7 +26,7 @@ export class CpuPlayer extends Player {
 
         const animator = new MovementAnimator(game.getBoard());
         for (const plan of responseData.plans) {
-          const unit = [...game.getBoard().getUnits()].find(
+          const unit = [...game.getBoard().units].find(
             u => u.getId() === plan.unit_id
           );
           if (unit) {

--- a/battle-hexes-web/tests/model/board-updater.test.js
+++ b/battle-hexes-web/tests/model/board-updater.test.js
@@ -95,7 +95,7 @@ describe('updateBoard', () => {
     const player2 = { isHuman: () => false };
     factions[0].setOwningPlayer(player1);
     factions[1].setOwningPlayer(player2);
-    board.setPlayers({ getCurrentPlayer: () => player1 });
+    board.players = { getCurrentPlayer: () => player1 };
 
     board.addUnit(redUnit, 2, 2);
     board.addUnit(blueUnit, 4, 4);

--- a/battle-hexes-web/tests/model/board.test.js
+++ b/battle-hexes-web/tests/model/board.test.js
@@ -92,9 +92,9 @@ describe('sparseBoard', () => {
 });
 
 describe('animator integration', () => {
-  test('getAnimator returns animator instance from constructor', () => {
+  test('animator getter returns animator instance from constructor', () => {
     const board = new Board(1, 1);
-    expect(typeof board.getAnimator().animate).toBe('function');
+    expect(typeof board.animator.animate).toBe('function');
   });
 
   test('selectHex uses animator to animate movement', () => {
@@ -102,14 +102,14 @@ describe('animator integration', () => {
     const factions = [new Faction('f1', 'f1', '#f00')];
     factions[0].setOwningPlayer(player);
     const board = new Board(1, 2);
-    board.setPlayers({ getCurrentPlayer: () => player });
+    board.players = { getCurrentPlayer: () => player };
     const unit = new Unit('u1', 'Unit', factions[0], null, 1, 1, 1);
     board.addUnit(unit, 0, 0);
 
     const start = board.getHex(0, 0);
     const end = board.getHex(0, 1);
 
-    const animatorInstance = board.getAnimator();
+    const animatorInstance = board.animator;
     board.selectHex(start);
     board.selectHex(end);
 
@@ -121,11 +121,11 @@ describe('animator integration', () => {
     const factions = [new Faction('f1', 'f1', '#f00')];
     factions[0].setOwningPlayer(player);
     const board = new Board(1, 2);
-    board.setPlayers({ getCurrentPlayer: () => player });
+    board.players = { getCurrentPlayer: () => player };
     const unit = new Unit('u1', 'Unit', factions[0], null, 1, 1, 1);
     board.addUnit(unit, 0, 0);
     const movementHandler = jest.fn().mockResolvedValue();
-    board.setMovementHandler(movementHandler);
+    board.movementHandler = movementHandler;
 
     const start = board.getHex(0, 0);
     const end = board.getHex(0, 1);
@@ -148,11 +148,11 @@ describe('animator integration', () => {
     const factions = [new Faction('f1', 'f1', '#f00')];
     factions[0].setOwningPlayer(player);
     const board = new Board(1, 2);
-    board.setPlayers({ getCurrentPlayer: () => player });
+    board.players = { getCurrentPlayer: () => player };
     const unit = new Unit('u1', 'Unit', factions[0], null, 1, 1, 2);
     board.addUnit(unit, 0, 0);
     const movementHandler = jest.fn().mockRejectedValue(new Error('network'));
-    board.setMovementHandler(movementHandler);
+    board.movementHandler = movementHandler;
 
     const start = board.getHex(0, 0);
     const end = board.getHex(0, 1);
@@ -167,7 +167,7 @@ describe('animator integration', () => {
     expect(start.getUnits()).toContain(unit);
     expect(end.getUnits()).not.toContain(unit);
     expect(unit.getMovesRemaining()).toBe(2);
-    expect(board.getSelectedHex()).toBe(start);
+    expect(board.selectedHex).toBe(start);
   });
 
   test('selectHex does not animate movement when destination terrain cost is unaffordable', () => {
@@ -175,7 +175,7 @@ describe('animator integration', () => {
     const factions = [new Faction('f1', 'f1', '#f00')];
     factions[0].setOwningPlayer(player);
     const board = new Board(1, 2);
-    board.setPlayers({ getCurrentPlayer: () => player });
+    board.players = { getCurrentPlayer: () => player };
     const unit = new Unit('u1', 'Unit', factions[0], null, 1, 1, 1);
     board.addUnit(unit, 0, 0);
 
@@ -183,7 +183,7 @@ describe('animator integration', () => {
     const end = board.getHex(0, 1);
     end.setTerrain({ moveCost: 2 });
 
-    const animatorInstance = board.getAnimator();
+    const animatorInstance = board.animator;
     board.selectHex(start);
     board.selectHex(end);
 
@@ -196,7 +196,7 @@ describe('board dimensions', () => {
   test('stores row and column counts from constructor', () => {
     const board = new Board(11, 18);
 
-    expect(board.getRows()).toBe(11);
-    expect(board.getColumns()).toBe(18);
+    expect(board.rows).toBe(11);
+    expect(board.columns).toBe(18);
   });
 });

--- a/battle-hexes-web/tests/model/game-creator.test.js
+++ b/battle-hexes-web/tests/model/game-creator.test.js
@@ -8,6 +8,7 @@ beforeEach(() => {
   const gameData = JSON.parse(
     '{"id":"093e432e-28ba-4dd1-a202-0802ee6ef32b",' +
     '"scenarioId":"elem_test",' +
+    '"stackingLimit":2,' +
     '"playerTypeIds":["human","q-learning"],"turnLimit":9,"turnNumber":2,' +
     '"players":[{"name":"Player 1","type":"Human","factions":[{"id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","name":"Red Faction","color":"#C81010","sounds":{"defensive_fire":{"effect":"red_effect.ogg","no_effect":"red_no_effect.ogg"}}}]},' +
     '{"name":"Player 2","type":"Computer","factions":[{"id":"38400000-8cf0-41bd-b23e-10b96e4ef00d","name":"Blue Faction","color":"#4682B4"}]}],' +
@@ -70,7 +71,7 @@ describe("createGame", () => {
   });
 
   test("board has two units", () => {
-    expect(game.getBoard().getUnits().size).toBe(2)
+    expect(game.getBoard().units.size).toBe(2)
   });
 
   test("board has units in correct hexes", () => {
@@ -104,6 +105,7 @@ describe("createGame", () => {
     expect(game.getPlayerTypeIds()).toEqual(['human', 'q-learning']);
     expect(game.getTurnLimit()).toBe(9);
     expect(game.getTurnNumber()).toBe(2);
+    expect(game.getBoard().stackingLimit).toBe(2);
   });
 
   test('defaults turn metadata when omitted from payload', () => {
@@ -181,7 +183,7 @@ describe("createGame", () => {
   });
 
   test('board loads roads from board payload', () => {
-    const roads = game.getBoard().getRoads();
+    const roads = game.getBoard().roads;
 
     expect(roads).toHaveLength(1);
     expect(roads[0].type).toBe('secondary');
@@ -207,7 +209,7 @@ describe("createGame", () => {
     };
 
     const legacyRoadGame = gameCreator.createGame(gameData);
-    const roads = legacyRoadGame.getBoard().getRoads();
+    const roads = legacyRoadGame.getBoard().roads;
 
     expect(roads).toHaveLength(1);
     expect(roads[0].path).toEqual([[0, 0], [0, 1]]);

--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -78,6 +78,9 @@ def _serialize_game(game) -> dict:
 
     if scenario_id is not None:
         model["scenarioId"] = scenario_id
+    if scenario is not None:
+        model["scenarioName"] = scenario.name
+        model["stackingLimit"] = scenario.stacking_limit
 
     model["turnLimit"] = model.pop("turn_limit", None)
     model["turnNumber"] = model.pop("turn_number", 1)

--- a/battle_hexes_api/src/battle_hexes_api/schemas/scenario.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/scenario.py
@@ -26,6 +26,7 @@ class ScenarioModel(BaseModel):
     name: str
     description: str | None = None
     victory: ScenarioVictoryModel | None = None
+    stacking_limit: int | None = None
 
     @classmethod
     def from_core(cls, scenario: Scenario) -> "ScenarioModel":

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -54,6 +54,7 @@ class TestFastAPI(unittest.TestCase):
         self.assertEqual(post_response.status_code, 200)
         self.assertEqual(post_body.get('playerTypeIds'), ['human', 'random'])
         self.assertEqual(post_body.get('scenarioId'), 'elim_1')
+        self.assertEqual(post_body.get('stackingLimit'), 2)
         terrain = post_body.get("board", {}).get("terrain", {})
         self.assertEqual(terrain.get("default"), "open")
         self.assertIn("open", terrain.get("types", {}))
@@ -94,6 +95,7 @@ class TestFastAPI(unittest.TestCase):
         self.assertEqual(new_game_id, get_body.get('id'))
         self.assertEqual(get_body.get('playerTypeIds'), ['human', 'random'])
         self.assertEqual(get_body.get('scenarioId'), 'elim_1')
+        self.assertEqual(get_body.get('stackingLimit'), 2)
         self.assertEqual(
             get_body.get("board", {})
             .get("terrain", {})
@@ -161,12 +163,14 @@ class TestFastAPI(unittest.TestCase):
                     "name": "Test Scenario",
                     "description": None,
                     "victory": None,
+                    "stacking_limit": None,
                 },
                 {
                     "id": "test-2",
                     "name": "Another Scenario",
                     "description": None,
                     "victory": None,
+                    "stacking_limit": None,
                 },
             ],
         )


### PR DESCRIPTION
### Motivation
- Surface scenario metadata (`scenarioName` and `stackingLimit`) in the API payload so the frontend can enforce/display stacking rules.
- Modernize and simplify the JavaScript `Board` API by introducing getters/setters and property-style access to reduce boilerplate and make code clearer.
- Maintain backwards-compatible wrappers where convenient and add a debug log when scenarios are loaded.

### Description
- Backend: include `scenarioName` and `stackingLimit` in serialized game model by updating `_serialize_game` and extend the Pydantic `ScenarioModel` with `stacking_limit`.
- Frontend: set `board.stackingLimit` in `GameCreator` from payload and add a `logLoadedScenario` call in `battle-draw.js` to log `scenarioName`, `scenarioId`, and `stackingLimit` when games are loaded.
- Board refactor: introduce property getters/setters (`rows`, `columns`, `units`, `animator`, `selectedHex`, `roads`, `movementHandler`, `stackingLimit`) and internal `updateHoverHex` while keeping `setHoverHex` as a delegating compatibility method; update internal references to use the new properties.
- Update various callers to use properties instead of old getters/setters and adapt movement/hover handling: e.g. `board.getRows()` -> `board.rows`, `board.getUnits()` -> `board.units`, `board.setMovementHandler()` -> `board.movementHandler = ...`, and `board.getSelectedHex()` -> `board.selectedHex`.
- Tests: update API unit tests and frontend unit tests to assert the new `stackingLimit`/property-based APIs and the renamed accessors.

### Testing
- Ran API unit tests in `battle_hexes_api/tests/test_main.py`, which were updated to assert `stackingLimit` and passed.
- Ran frontend Jest tests under `battle-hexes-web/tests/model/` after updating expectations for property accessors and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f006bee3e88327bb25bd5c192b18de)