### PR TITLE
Add legal-movement check (`canUnitLegallyEnterHex`) and tests to block illegal moves

### DIFF
--- a/battle-hexes-web/src/model/board.js
+++ b/battle-hexes-web/src/model/board.js
@@ -131,8 +131,7 @@ export class Board {
       oldSelection.setSelected(false);
     } else if (!oldSelection.isEmpty() && oldSelection.isAdjacent(hexToSelect)
         && oldSelection.getUnits()[0].isMovable()
-        && oldSelection.getUnits()[0].canEnterHex(hexToSelect)
-        && !this.isOppositionHex(hexToSelect)) {
+        && this.canUnitLegallyEnterHex(oldSelection.getUnits()[0], hexToSelect)) {
       const units = oldSelection.getUnits();
       console.log(`Moving unit ${units[0]}.`);
       const path = [oldSelection, hexToSelect];
@@ -214,6 +213,28 @@ export class Board {
     return this.#selectedHex !== undefined;
   }
 
+  // A legal entry requires sufficient movement, no enemy occupants, and staying within the optional friendly stacking cap.
+  canUnitLegallyEnterHex(unit, destinationHex) {
+    if (!unit.canEnterHex(destinationHex)) {
+      return false;
+    }
+
+    const destinationUnits = destinationHex.getUnits();
+    if (destinationUnits.length > 0 && destinationUnits[0].getOwningPlayer() !== unit.getOwningPlayer()) {
+      return false;
+    }
+
+    if (this.stackingLimit === null) {
+      return true;
+    }
+
+    const friendlyUnitsInDestination = destinationUnits.filter(
+      (destinationUnit) => destinationUnit.getOwningPlayer() === unit.getOwningPlayer(),
+    ).length;
+
+    return friendlyUnitsInDestination + 1 <= this.stackingLimit;
+  }
+
   updateHoverHex(hoverHex) {
     const oldHover = this.#hoverHex;
     this.#hoverHex = hoverHex;
@@ -225,9 +246,8 @@ export class Board {
     if (this.#hoverHex && this.hasSelection() && !this.#selectedHex.isEmpty()
         && !this.#selectedHex.hasUnitMoves() 
         && this.#hoverHex.isAdjacent(this.#selectedHex)
-        && this.#selectedHex.getUnits()[0].canEnterHex(this.#hoverHex)
         && this.isOwnHexSelected()
-        && !this.isOppositionHex(hoverHex)) {
+        && this.canUnitLegallyEnterHex(this.#selectedHex.getUnits()[0], this.#hoverHex)) {
       console.log(`We have a move hover hex! ${this.#hoverHex}`);
       this.#hoverHex.setMoveHoverFromHex(this.selectedHex);
     }

--- a/battle-hexes-web/tests/model/board.test.js
+++ b/battle-hexes-web/tests/model/board.test.js
@@ -170,6 +170,54 @@ describe('animator integration', () => {
     expect(board.selectedHex).toBe(start);
   });
 
+
+  test('selectHex does not animate movement into enemy-occupied destination', () => {
+    const player = { isHuman: () => true };
+    const opposingPlayer = { isHuman: () => true };
+    const factions = [new Faction('f1', 'f1', '#f00'), new Faction('f2', 'f2', '#00f')];
+    factions[0].setOwningPlayer(player);
+    factions[1].setOwningPlayer(opposingPlayer);
+    const board = new Board(1, 2);
+    board.players = { getCurrentPlayer: () => player };
+
+    const movingUnit = new Unit('u1', 'Unit', factions[0], null, 1, 1, 2);
+    const blockingEnemy = new Unit('u2', 'Enemy', factions[1], null, 1, 1, 2);
+    board.addUnit(movingUnit, 0, 0);
+    board.addUnit(blockingEnemy, 0, 1);
+
+    const start = board.getHex(0, 0);
+    const end = board.getHex(0, 1);
+
+    const animatorInstance = board.animator;
+    board.selectHex(start);
+    board.selectHex(end);
+
+    expect(animatorInstance.animate).not.toHaveBeenCalled();
+  });
+
+  test('selectHex blocks movement when friendly stacking limit is reached', () => {
+    const player = { isHuman: () => true };
+    const factions = [new Faction('f1', 'f1', '#f00')];
+    factions[0].setOwningPlayer(player);
+    const board = new Board(1, 2);
+    board.players = { getCurrentPlayer: () => player };
+    board.stackingLimit = 1;
+
+    const movingUnit = new Unit('u1', 'Unit', factions[0], null, 1, 1, 2);
+    const friendlyUnit = new Unit('u2', 'Friend', factions[0], null, 1, 1, 2);
+    board.addUnit(movingUnit, 0, 0);
+    board.addUnit(friendlyUnit, 0, 1);
+
+    const start = board.getHex(0, 0);
+    const end = board.getHex(0, 1);
+
+    const animatorInstance = board.animator;
+    board.selectHex(start);
+    board.selectHex(end);
+
+    expect(animatorInstance.animate).not.toHaveBeenCalled();
+  });
+
   test('selectHex does not animate movement when destination terrain cost is unaffordable', () => {
     const player = { isHuman: () => true };
     const factions = [new Faction('f1', 'f1', '#f00')];


### PR DESCRIPTION
### Motivation
- Centralize movement legality logic so both click-selection and hover behavior consult the same rules before attempting animation.
- Prevent animating a move into a hex occupied by an opposing unit and enforce an optional friendly stacking limit.

### Description
- Add `canUnitLegallyEnterHex(unit, destinationHex)` which returns false if `unit.canEnterHex(destinationHex)` is false, if the destination has an enemy occupant, or if adding the unit would exceed `stackingLimit`, and true otherwise.
- Update `selectHex` to call `canUnitLegallyEnterHex` instead of duplicating `canEnterHex` and `isOppositionHex` checks before resolving movement.
- Update `updateHoverHex` to call `canUnitLegallyEnterHex` for hover move previews.
- Add two unit tests in `tests/model/board.test.js` to ensure no animation is started when the destination is enemy-occupied and when a friendly stacking limit is reached.

### Testing
- Ran the test suite with `jest` for `tests/model/board.test.js`, including the new animator-integration tests and the two new movement-blocking tests, and all tests passed.
- Verified that `animator.animate` is not called in the new tests when movement is illegal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd3bf213f08327aff1134670d4b52f)