### PR TITLE
Extract unit type symbol drawing to UnitTypeSymbolDrawer and add tests

### DIFF
--- a/battle-hexes-web/src/drawer/unit-drawer.js
+++ b/battle-hexes-web/src/drawer/unit-drawer.js
@@ -1,3 +1,5 @@
+import { UnitTypeSymbolDrawer } from './unit-type-symbol-drawer.js';
+
 export class UnitDrawer {
   static ECHELON_SYMBOLS = {
     fireteam: 'Ø',
@@ -19,12 +21,14 @@ export class UnitDrawer {
   #hexDrawer;
   #counterSide;
   #counterSideThird;
+  #unitTypeSymbolDrawer;
 
   constructor(p, hexDrawer) {
     this.#p = p;
     this.#hexDrawer = hexDrawer;
     this.#counterSide = hexDrawer.getHexRadius() + hexDrawer.getHexRadius() * 0.3;
     this.#counterSideThird = this.#counterSide / 3;
+    this.#unitTypeSymbolDrawer = new UnitTypeSymbolDrawer(p);
   }
 
   draw(aHex) {
@@ -55,7 +59,7 @@ export class UnitDrawer {
     this.#p.rectMode(this.#p.CENTER);
     this.#p.rect(x, y, this.#counterSide, this.#counterSide, 3);
 
-    this.#drawInfantrySymbol(x, y, this.#counterSide / 2, this.#counterSideThird);
+    this.#unitTypeSymbolDrawer.draw(aUnit, x, y, this.#counterSide / 2, this.#counterSideThird);
     this.#drawUnitStats(aUnit, x, y);
     this.#drawUnitSize(aUnit, x, y);
     if (aUnit.hasDefensiveFire?.()) {
@@ -84,22 +88,7 @@ export class UnitDrawer {
     return halfHexColor;
   }
 
-  #drawInfantrySymbol(x, y, width, height) {
-    this.#p.stroke(255)
-    this.#p.strokeWeight(2);
-    this.#p.rect(x, y, width, height);
-  
-    let halfWidth = width / 2;
-    let halfHeight = height / 2;
-  
-    this.#p.stroke(255);
-    this.#p.strokeWeight(2);
-  
-    // Draw "X" by connecting the corners of the smaller rectangle
-    this.#p.line(x - halfWidth, y - halfHeight, x + halfWidth, y + halfHeight);
-    this.#p.line(x + halfWidth, y - halfHeight, x - halfWidth, y + halfHeight);
-  }
-  
+
   #drawUnitStats(aUnit, x, y) {
     this.#p.fill(255);
     this.#p.noStroke();

--- a/battle-hexes-web/src/drawer/unit-type-symbol-drawer.js
+++ b/battle-hexes-web/src/drawer/unit-type-symbol-drawer.js
@@ -1,0 +1,37 @@
+export class UnitTypeSymbolDrawer {
+  #p;
+
+  constructor(p) {
+    this.#p = p;
+  }
+
+  draw(aUnit, x, y, width, height) {
+    const unitType = aUnit.getType?.();
+    if (unitType && unitType.trim().toLowerCase() === 'infantry') {
+      this.#drawInfantrySymbol(x, y, width, height);
+      return;
+    }
+
+    this.#drawFallbackUnitTypeSymbol(x, y, width, height);
+  }
+
+  #drawInfantrySymbol(x, y, width, height) {
+    this.#p.stroke(255);
+    this.#p.strokeWeight(2);
+    this.#p.rect(x, y, width, height);
+
+    const halfWidth = width / 2;
+    const halfHeight = height / 2;
+
+    this.#p.stroke(255);
+    this.#p.strokeWeight(2);
+    this.#p.line(x - halfWidth, y - halfHeight, x + halfWidth, y + halfHeight);
+    this.#p.line(x + halfWidth, y - halfHeight, x - halfWidth, y + halfHeight);
+  }
+
+  #drawFallbackUnitTypeSymbol(x, y, width, height) {
+    this.#p.stroke(255);
+    this.#p.strokeWeight(2);
+    this.#p.rect(x, y, width, height);
+  }
+}

--- a/battle-hexes-web/tests/drawer/unit-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/unit-drawer.test.js
@@ -83,7 +83,7 @@ describe('UnitDrawer.drawCounter echelon symbols', () => {
     text: jest.fn(),
   });
 
-  const createUnit = (echelon) => ({
+  const createUnit = (echelon, type = 'infantry') => ({
     getFaction: () => ({
       getCounterColor: () => '#808080',
     }),
@@ -91,6 +91,26 @@ describe('UnitDrawer.drawCounter echelon symbols', () => {
     getDefense: () => 3,
     getMovement: () => 2,
     getEchelon: () => echelon,
+    getType: () => type,
+  });
+
+
+  test('draws infantry symbol for infantry units regardless of case', () => {
+    const p5 = createP5Mock();
+    const unitDrawer = new UnitDrawer(p5, createHexDrawer());
+
+    unitDrawer.drawCounter(createUnit('division', 'InFaNtRy'), 100, 100);
+
+    expect(p5.line).toHaveBeenCalledTimes(2);
+  });
+
+  test('draws fallback symbol for non-infantry units', () => {
+    const p5 = createP5Mock();
+    const unitDrawer = new UnitDrawer(p5, createHexDrawer());
+
+    unitDrawer.drawCounter(createUnit('division', 'MG'), 100, 100);
+
+    expect(p5.line).not.toHaveBeenCalled();
   });
 
   test('draws echelon symbol for known echelons', () => {

--- a/battle-hexes-web/tests/drawer/unit-type-symbol-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/unit-type-symbol-drawer.test.js
@@ -1,0 +1,29 @@
+import { UnitTypeSymbolDrawer } from '../../src/drawer/unit-type-symbol-drawer.js';
+
+describe('UnitTypeSymbolDrawer', () => {
+  const createP5Mock = () => ({
+    stroke: jest.fn(),
+    strokeWeight: jest.fn(),
+    rect: jest.fn(),
+    line: jest.fn(),
+  });
+
+  test('draws infantry symbol for infantry units regardless of case', () => {
+    const p5 = createP5Mock();
+    const drawer = new UnitTypeSymbolDrawer(p5);
+
+    drawer.draw({ getType: () => 'InFaNtRy' }, 100, 100, 20, 10);
+
+    expect(p5.line).toHaveBeenCalledTimes(2);
+  });
+
+  test('draws fallback symbol for non-infantry units', () => {
+    const p5 = createP5Mock();
+    const drawer = new UnitTypeSymbolDrawer(p5);
+
+    drawer.draw({ getType: () => 'MG' }, 100, 100, 20, 10);
+
+    expect(p5.rect).toHaveBeenCalledWith(100, 100, 20, 10);
+    expect(p5.line).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Reduce responsibility of `UnitDrawer` by moving unit-type-specific symbol rendering into a dedicated component to make the code easier to extend and test.
- Support case-insensitive unit type detection and provide a sensible fallback for non-infantry unit types.

### Description
- Add `src/drawer/unit-type-symbol-drawer.js` implementing `UnitTypeSymbolDrawer` with `draw`, `#drawInfantrySymbol`, and `#drawFallbackUnitTypeSymbol` behaviors.
- Update `UnitDrawer` to import and instantiate `UnitTypeSymbolDrawer` and replace the removed `#drawInfantrySymbol` with `unitTypeSymbolDrawer.draw(...)` while keeping existing stats, echelon and defensive-fire rendering intact.
- Use safe optional calls like `aUnit.getType?.()` to detect unit type and perform case-insensitive matching for `infantry`.
- Update and add tests: adjust `tests/drawer/unit-drawer.test.js` to provide unit `type` fixtures and assertions, and add `tests/drawer/unit-type-symbol-drawer.test.js` to validate both infantry and fallback rendering.

### Testing
- Ran unit tests in `tests/drawer`, including `unit-drawer.test.js` and the new `unit-type-symbol-drawer.test.js`.
- All tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131a5c90088327a51453c67fb53fab)