### PR TITLE
Add armor symbol support to UnitTypeSymbolDrawer

### DIFF
--- a/battle-hexes-web/src/drawer/unit-type-symbol-drawer.js
+++ b/battle-hexes-web/src/drawer/unit-type-symbol-drawer.js
@@ -7,8 +7,15 @@ export class UnitTypeSymbolDrawer {
 
   draw(aUnit, x, y, width, height) {
     const unitType = aUnit.getType?.();
-    if (unitType && unitType.trim().toLowerCase() === 'infantry') {
+    const normalizedUnitType = unitType?.trim().toLowerCase();
+
+    if (normalizedUnitType === 'infantry') {
       this.#drawInfantrySymbol(x, y, width, height);
+      return;
+    }
+
+    if (normalizedUnitType === 'armor') {
+      this.#drawArmorSymbol(x, y, width, height);
       return;
     }
 
@@ -27,6 +34,16 @@ export class UnitTypeSymbolDrawer {
     this.#p.strokeWeight(2);
     this.#p.line(x - halfWidth, y - halfHeight, x + halfWidth, y + halfHeight);
     this.#p.line(x + halfWidth, y - halfHeight, x - halfWidth, y + halfHeight);
+  }
+
+  #drawArmorSymbol(x, y, width, height) {
+    this.#p.stroke(255);
+    this.#p.strokeWeight(2);
+    this.#p.rect(x, y, width, height);
+
+    this.#p.stroke(255);
+    this.#p.strokeWeight(2);
+    this.#p.ellipse(x, y, width, height);
   }
 
   #drawFallbackUnitTypeSymbol(x, y, width, height) {

--- a/battle-hexes-web/src/drawer/unit-type-symbol-drawer.js
+++ b/battle-hexes-web/src/drawer/unit-type-symbol-drawer.js
@@ -41,9 +41,14 @@ export class UnitTypeSymbolDrawer {
     this.#p.strokeWeight(2);
     this.#p.rect(x, y, width, height);
 
+    const trackWidth = width * 0.7;
+    const trackHeight = height * 0.4;
+    const cornerRadius = trackHeight / 2;
+
     this.#p.stroke(255);
     this.#p.strokeWeight(2);
-    this.#p.ellipse(x, y, width, height);
+    this.#p.noFill();
+    this.#p.rect(x, y, trackWidth, trackHeight, cornerRadius);
   }
 
   #drawFallbackUnitTypeSymbol(x, y, width, height) {

--- a/battle-hexes-web/tests/drawer/unit-type-symbol-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/unit-type-symbol-drawer.test.js
@@ -4,6 +4,7 @@ describe('UnitTypeSymbolDrawer', () => {
   const createP5Mock = () => ({
     stroke: jest.fn(),
     strokeWeight: jest.fn(),
+    noFill: jest.fn(),
     rect: jest.fn(),
     line: jest.fn(),
     ellipse: jest.fn(),
@@ -19,15 +20,17 @@ describe('UnitTypeSymbolDrawer', () => {
     expect(p5.ellipse).not.toHaveBeenCalled();
   });
 
-  test('draws armor symbol for armor units regardless of case', () => {
+  test('draws armor symbol as a centered capsule inside the outer box', () => {
     const p5 = createP5Mock();
     const drawer = new UnitTypeSymbolDrawer(p5);
 
     drawer.draw({ getType: () => 'ArMoR' }, 100, 100, 20, 10);
 
-    expect(p5.rect).toHaveBeenCalledWith(100, 100, 20, 10);
-    expect(p5.ellipse).toHaveBeenCalledWith(100, 100, 20, 10);
+    expect(p5.rect).toHaveBeenNthCalledWith(1, 100, 100, 20, 10);
+    expect(p5.rect).toHaveBeenNthCalledWith(2, 100, 100, 14, 4, 2);
+    expect(p5.noFill).toHaveBeenCalled();
     expect(p5.line).not.toHaveBeenCalled();
+    expect(p5.ellipse).not.toHaveBeenCalled();
   });
 
   test('draws fallback symbol for non-infantry units', () => {

--- a/battle-hexes-web/tests/drawer/unit-type-symbol-drawer.test.js
+++ b/battle-hexes-web/tests/drawer/unit-type-symbol-drawer.test.js
@@ -6,6 +6,7 @@ describe('UnitTypeSymbolDrawer', () => {
     strokeWeight: jest.fn(),
     rect: jest.fn(),
     line: jest.fn(),
+    ellipse: jest.fn(),
   });
 
   test('draws infantry symbol for infantry units regardless of case', () => {
@@ -15,6 +16,18 @@ describe('UnitTypeSymbolDrawer', () => {
     drawer.draw({ getType: () => 'InFaNtRy' }, 100, 100, 20, 10);
 
     expect(p5.line).toHaveBeenCalledTimes(2);
+    expect(p5.ellipse).not.toHaveBeenCalled();
+  });
+
+  test('draws armor symbol for armor units regardless of case', () => {
+    const p5 = createP5Mock();
+    const drawer = new UnitTypeSymbolDrawer(p5);
+
+    drawer.draw({ getType: () => 'ArMoR' }, 100, 100, 20, 10);
+
+    expect(p5.rect).toHaveBeenCalledWith(100, 100, 20, 10);
+    expect(p5.ellipse).toHaveBeenCalledWith(100, 100, 20, 10);
+    expect(p5.line).not.toHaveBeenCalled();
   });
 
   test('draws fallback symbol for non-infantry units', () => {
@@ -25,5 +38,6 @@ describe('UnitTypeSymbolDrawer', () => {
 
     expect(p5.rect).toHaveBeenCalledWith(100, 100, 20, 10);
     expect(p5.line).not.toHaveBeenCalled();
+    expect(p5.ellipse).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Motivation
- Add visual support for the `Armor` unit type so armor units render the expected oval symbol inside the unit frame.

### Description
- Normalize `getType()` once and branch on the lower-cased value in `UnitTypeSymbolDrawer.draw` to handle `armor` in addition to `infantry` and the fallback case.
- Add a private `#drawArmorSymbol` that draws the same rectangle frame and an inscribed oval using `rect` and `ellipse` respectively.
- Update unit tests to mock `ellipse` and assert that `Armor` draws the rectangle plus oval while preserving existing `infantry` and fallback behavior.
- Changes made in `battle-hexes-web/src/drawer/unit-type-symbol-drawer.js` and `battle-hexes-web/tests/drawer/unit-type-symbol-drawer.test.js`.

### Testing
- Ran `npm run test-and-build` (in `battle-hexes-web`) and all tests passed with the build completing successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131f8e096483278970e3a62ada9736)