### PR TITLE
Docs: Add naming/casing cleanup spec and clarify end-to-end property guidance

### DIFF
--- a/documentation/end-to-end-change-instructions.md
+++ b/documentation/end-to-end-change-instructions.md
@@ -39,7 +39,15 @@ Before editing code, decide:
 - Whether the property is required or optional.
 - The default for existing scenario files.
 - Validation rules (integer vs float, non-empty string, minimum value, allowed enum values, nullable values, etc.).
-- Whether the value is only display metadata or must affect gameplay rules.
+- Whether the value is only display metadata, setup-time data, or must affect gameplay rules.
+
+Use this distinction to decide how far the property must travel:
+
+| Property purpose | Runtime/domain object update? | Typical API source |
+| --- | --- | --- |
+| Display-only scenario metadata | Usually no; keep it on scenario definitions unless runtime code also needs it. | Scenario object attached to the game response, scenario list metadata, or frontend mock data. |
+| Setup-time input that changes initial board/game creation | Maybe; apply it during game creation, but only persist it on runtime objects if later rules or responses need it. | Scenario object during game creation and any resulting runtime state. |
+| Gameplay rule/state property used after creation | Yes; add it to the relevant runtime object or rule service as well as scenario definitions. | Runtime game, board, unit, terrain, objective, movement, or combat objects, sometimes supplemented by scenario metadata. |
 
 ### 2. Add the property to scenario JSON files
 
@@ -133,7 +141,7 @@ Common API schema targets:
 | Terrain values | `battle_hexes_api/src/battle_hexes_api/schemas/terrain.py` |
 | Unit values | `battle_hexes_api/src/battle_hexes_api/schemas/unit.py` |
 | Objective values | `battle_hexes_api/src/battle_hexes_api/schemas/objective.py` |
-| Movement/combat response values | `battle_hexes_api/src/battle_hexes_api/schemas/movement.py` or `combat.py` |
+| Movement/combat response values | `battle_hexes_api/src/battle_hexes_api/schemas/movement.py`, `combat.py`, or `sparseboard.py` |
 | Create-game request inputs | `battle_hexes_api/src/battle_hexes_api/schemas/create_game.py` |
 
 Implementation notes:
@@ -141,7 +149,8 @@ Implementation notes:
 - Add Pydantic fields to the schema that directly represents the data.
 - Update `from_core()` / `from_*()` factory methods to populate the field.
 - Update `to_core()` if the schema supports round-tripping back to a core type.
-- If the frontend expects `camelCase`, update `_serialize_game()` in `battle_hexes_api/src/battle_hexes_api/main.py` to rename fields or add top-level aliases.
+- If the frontend expects `camelCase` for a top-level game response field, update `_serialize_game()` in `battle_hexes_api/src/battle_hexes_api/main.py` to rename fields or add top-level aliases.
+- Nested schema fields often remain `snake_case` unless neighboring fields or compatibility requirements already use `camelCase`. Check the existing response shape at the same nesting level before choosing a name.
 - Decide whether the value appears in `/scenarios`, created game responses, fetched game responses, movement responses, combat responses, or all of them.
 
 Update tests such as:
@@ -272,6 +281,9 @@ Suppose a scenario terrain type adds `display_priority` and the frontend uses it
 9. Update `battle-hexes-web/src/model/game-creator.js` `#addTerrain()` to pass `value.display_priority` into `new Terrain(...)`.
 10. Update frontend tests in `game-creator.test.js` and `terrain.test.js`.
 11. Update drawers/overlay code to sort or render by `terrain.displayPriority`.
+
+    Because this example property only controls frontend rendering order, it can remain scenario/API/frontend metadata and does not need to be added to the core runtime `Terrain` class unless backend rules also consume it.
+
 12. Add the new property to mock responses.
 13. Run backend and frontend checks.
 
@@ -282,6 +294,6 @@ Suppose a scenario terrain type adds `display_priority` and the frontend uses it
 - **Forgetting API naming conventions.** Python fields are often `snake_case`, while selected frontend-facing fields are `camelCase` after `_serialize_game()`.
 - **Updating `/scenarios` but not `/games`.** Scenario list cards and active game payloads are different API shapes.
 - **Updating created games but not fetched games.** The same serializer should usually support both `/games` and `/games/{id}`.
-- **Forgetting movement/combat responses.** If a property changes during play or must persist after an action, make sure movement/combat schemas and frontend response handlers carry it forward.
+- **Forgetting movement/combat responses.** If a property changes during play or must persist after an action, make sure movement, combat, sparse-board schemas, and frontend response handlers carry it forward.
 - **Leaving mock-service responses stale.** Web tests or mock builds may still pass old data unless fixtures are updated.
 - **Testing implementation details instead of behavior.** Prefer tests that prove the value is visible in core objects, API JSON, and frontend models/behavior.

--- a/documentation/end-to-end-change-instructions.md
+++ b/documentation/end-to-end-change-instructions.md
@@ -150,7 +150,7 @@ Implementation notes:
 - Update `from_core()` / `from_*()` factory methods to populate the field.
 - Update `to_core()` if the schema supports round-tripping back to a core type.
 - If the frontend expects `camelCase` for a top-level game response field, update `_serialize_game()` in `battle_hexes_api/src/battle_hexes_api/main.py` to rename fields or add top-level aliases.
-- Nested schema fields often remain `snake_case` unless neighboring fields or compatibility requirements already use `camelCase`. Check the existing response shape at the same nesting level before choosing a name.
+- Treat existing nested `snake_case` API fields as current-state compatibility, not as the target convention for new fields. Before choosing any API response name, check `specs/naming-casing-cleanup.md`: HTTP API JSON and frontend mocks should move toward canonical `camelCase`, even for nested scenario-backed fields.
 - Decide whether the value appears in `/scenarios`, created game responses, fetched game responses, movement responses, combat responses, or all of them.
 
 Update tests such as:

--- a/specs/naming-casing-cleanup.md
+++ b/specs/naming-casing-cleanup.md
@@ -1,0 +1,223 @@
+# Naming Casing Cleanup Specification
+
+## Purpose
+
+Battle Hexes currently exposes a mix of `snake_case` and `camelCase` names across
+scenario JSON, Python internals, API payloads, and JavaScript internals. This
+spec describes how to clean up that naming split while preserving idiomatic code
+at each layer and minimizing compatibility risk.
+
+## Goals
+
+- Use idiomatic names within each language/runtime boundary:
+  - Python code and Pydantic model attributes use `snake_case`.
+  - JavaScript code, frontend model properties, and frontend method parameters
+    use `camelCase`.
+  - Scenario authoring JSON remains `snake_case` because it is loaded directly
+    by the Python core package and closely mirrors Python domain concepts.
+  - HTTP API request and response JSON uses `camelCase` because it is consumed
+    by the JavaScript frontend and is the client-facing contract.
+- Remove ad hoc casing conversions from scattered route and frontend mapping
+  code.
+- Keep backwards-compatible read support for existing `snake_case` API payloads
+  only during a documented migration window.
+- Make mock responses, sample payloads, and tests enforce the chosen casing.
+
+## Non-Goals
+
+- Do not rename Python attributes, core dataclasses, or scenario loader fields to
+  `camelCase`.
+- Do not rename JavaScript variables, methods, or model accessors to
+  `snake_case`.
+- Do not change the scenario JSON casing unless the project later decides that
+  scenario files are also a public web-facing format.
+- Do not redesign API resources beyond naming normalization.
+
+## Current State
+
+The current API contract is inconsistent:
+
+- Some top-level game response fields are manually converted to `camelCase`, such
+  as `scenarioId`, `scenarioName`, `stackingLimit`, `turnLimit`, `turnNumber`,
+  and `playerTypeIds`.
+- Some request models already use Pydantic aliases to accept `camelCase`, such as
+  `scenarioId` and `playerTypes` for game creation.
+- Several nested response fields remain `snake_case`, such as terrain
+  `move_cost`, terrain `combat_odds_shift`, board `road_types`, and board
+  `road_paths`.
+- Frontend mapping code accepts both styles for some top-level fields but expects
+  `snake_case` for several nested objects.
+- Mock responses contain the same mixture, which makes it hard to tell whether a
+  new field should be added as `snake_case`, `camelCase`, or both.
+
+This inconsistency is understandable historically, but it increases the chance
+that new end-to-end scenario properties are serialized with the wrong casing or
+that tests accidentally bless both names forever.
+
+## Target Casing Policy
+
+| Layer | Casing | Rationale |
+| --- | --- | --- |
+| Scenario JSON under `battle_hexes_core/src/battle_hexes_core/scenarios/` | `snake_case` | Authored for the Python core loader and aligned with Python schema names. |
+| Python core/domain code | `snake_case` | Idiomatic Python and already used by dataclasses, methods, and attributes. |
+| Python Pydantic model attributes | `snake_case` | Keeps Python code idiomatic and avoids leaking JSON naming into internals. |
+| HTTP API JSON requests | `camelCase` | Client-facing JSON consumed by the JavaScript frontend. |
+| HTTP API JSON responses | `camelCase` | Client-facing JSON consumed by the JavaScript frontend. |
+| JavaScript model/service/UI code | `camelCase` | Idiomatic JavaScript and already used by frontend classes. |
+| Frontend mock responses | `camelCase` | They should represent the HTTP API contract, not Python internals. |
+| API sample payloads | `camelCase` | They should represent the HTTP API contract. |
+
+## API Serialization Design
+
+### Pydantic Alias Strategy
+
+API schemas should use `snake_case` Python attributes with `camelCase` JSON
+aliases. Prefer a shared alias strategy instead of hand-written conversions in
+routes.
+
+Recommended approach:
+
+1. Add a shared API schema base class, for example `ApiBaseModel`, in the API
+   schemas package.
+2. Configure it with a snake-to-camel alias generator and `populate_by_name=True`.
+3. Use `model_dump(by_alias=True)` for route responses.
+4. Use explicit aliases only when a field does not follow mechanical
+   snake-to-camel conversion or when a compatibility exception is unavoidable.
+
+Example intent, not final code:
+
+```python
+class ApiBaseModel(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+```
+
+This lets Python code use `turn_number` while API JSON emits `turnNumber`.
+
+### Route Serialization
+
+Routes should not manually rename ordinary fields after dumping models. Manual
+route-level additions should be limited to values that are not actually part of
+that schema or temporary compatibility fields that have a removal plan.
+
+Target behavior:
+
+- Replace route-level `model["turnLimit"] = model.pop("turn_limit", None)` style
+  conversions with schema aliases.
+- Move top-level additions such as `scenarioId`, `scenarioName`,
+  `stackingLimit`, and `playerTypeIds` into explicit schema fields when they are
+  part of the game response contract.
+- Ensure created-game and fetched-game responses use the same response schema and
+  casing.
+- Ensure movement, combat, end-turn, and sparse-board responses use aliases when
+  returned to the frontend.
+
+### Request Parsing
+
+Client-facing request schemas should accept `camelCase` as the canonical input.
+During migration, request schemas may also accept `snake_case` via
+`populate_by_name=True`, but tests should emphasize `camelCase` as the supported
+contract.
+
+## Frontend Design
+
+Frontend code should treat API JSON as `camelCase` at the service boundary.
+
+Target behavior:
+
+- `GameCreator` and other response mappers should prefer `camelCase` field reads.
+- Temporary fallbacks for `snake_case` should be isolated in clearly named
+  compatibility helpers.
+- Frontend model constructors and getters should remain `camelCase`.
+- Once the backend emits only `camelCase` and mocks are updated, remove
+  compatibility reads for old nested `snake_case` response fields.
+
+Examples of frontend API field changes:
+
+| Current API field | Target API field |
+| --- | --- |
+| `board.terrain.types.*.move_cost` | `board.terrain.types.*.moveCost` |
+| `board.terrain.types.*.combat_odds_shift` | `board.terrain.types.*.combatOddsShift` |
+| `board.road_types` | `board.roadTypes` |
+| `board.road_paths` | `board.roadPaths` |
+| `turn_number` in nested action payloads | `turnNumber` |
+
+## Scenario JSON Design
+
+Scenario JSON should remain `snake_case` for now. It is not the same contract as
+HTTP API JSON:
+
+- Scenario files are part of the Python/core authoring path.
+- Existing scenario loader models already use `snake_case` field names.
+- Keeping scenario JSON in `snake_case` avoids needless churn in all scenario
+  files and core loader tests.
+
+If scenario JSON later becomes a public browser-authored format, create a
+separate spec to decide whether scenario authoring should also move to
+`camelCase` or support aliases.
+
+## Migration Plan
+
+### Phase 1: Inventory and Tests
+
+- Inventory every API request and response schema field.
+- Add API route tests that assert canonical `camelCase` response keys for game,
+  scenario list, movement, combat, end-turn, and sparse-board payloads.
+- Add frontend service/model tests that use canonical `camelCase` mock payloads.
+- Add regression tests proving scenario JSON remains accepted as `snake_case`.
+
+### Phase 2: Shared API Alias Infrastructure
+
+- Introduce the shared API base model with snake-to-camel aliases.
+- Convert schemas incrementally to inherit from the shared base.
+- Update route serialization to call `model_dump(by_alias=True)`.
+- Keep temporary read compatibility for old `snake_case` API payloads where the
+  frontend still needs it.
+
+### Phase 3: Payload and Mock Conversion
+
+- Convert frontend mock responses and API sample payloads to canonical
+  `camelCase` API JSON.
+- Update frontend mappers to read canonical `camelCase` fields first.
+- Keep fallback reads only for a short, documented compatibility period.
+
+### Phase 4: Compatibility Removal
+
+- Remove frontend fallback reads for obsolete `snake_case` API response fields.
+- Remove route-level manual casing conversions that are superseded by schema
+  aliases.
+- Remove tests that intentionally accept both casing styles for API responses,
+  except where backwards compatibility is explicitly required.
+
+## Validation Strategy
+
+- Run Python API schema and route tests after each schema conversion.
+- Run frontend model/service tests after mock payload updates.
+- Run full server-side checks and frontend tests before removing compatibility
+  shims.
+- Review generated or sample payloads manually to ensure no mixed casing remains
+  within the HTTP API JSON contract.
+
+## Risks and Mitigations
+
+- **Risk: breaking existing clients that consume `snake_case` API response
+  fields.** Mitigate by using a migration window with frontend compatibility
+  reads and a clear removal commit.
+- **Risk: accidental scenario JSON churn.** Mitigate by explicitly excluding
+  scenario files from the API JSON casing migration.
+- **Risk: overusing explicit aliases.** Mitigate by using a shared alias
+  generator and reserving explicit aliases for non-mechanical names.
+- **Risk: inconsistent mocks.** Mitigate by converting mock responses and sample
+  payloads in the same phase as frontend mapper updates.
+
+## Open Questions
+
+1. Are there any external clients beyond the bundled web frontend that currently
+   depend on `snake_case` API response fields?
+2. Should `/scenarios` responses also become fully `camelCase`, or should they
+   continue to mirror scenario JSON more closely because they describe authoring
+   metadata?
+3. What compatibility window is acceptable before removing frontend reads for old
+   `snake_case` API response fields?


### PR DESCRIPTION
### Motivation

- Clarify how new scenario/API/frontend properties should be named and propagated to avoid casing and serialization mistakes. 
- Provide a formal, low-risk migration strategy to normalize API JSON to `camelCase` while keeping Python and scenario authoring idiomatic.

### Description

- Add a new specification `specs/naming-casing-cleanup.md` that defines target casing per layer, a Pydantic alias strategy, a phased migration plan, validation strategy, and open questions. 
- Update `documentation/end-to-end-change-instructions.md` to better distinguish display-only, setup-time, and gameplay properties and to show typical runtime/API destinations in a decision table. 
- Expand guidance around API schema naming, nested field casing, and ensure movement/combat/sparse-board responses are considered when carrying properties through play. 
- Add examples and a note that purely display-only properties may not need core runtime additions.

### Testing

- No automated code tests were changed because this is documentation-only work. 
- Existing automated test suites are unaffected by these documentation changes and should continue to run in CI as before. 
- Documentation and spec additions do not introduce runtime changes requiring unit or integration test updates at this time.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d73c1fdf88327ad7b47931ee0b01f)