### PR TITLE
Naming/casing cleanup — Phase 1: API aliasing and frontend contract conversion

### DIFF
--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -472,9 +472,9 @@ export class Menu {
   }
 
   #applyMovementResponse(responseData) {
-    const safeUnits = responseData?.sparse_board?.units ?? responseData?.game?.board?.units ?? [];
+    const safeUnits = responseData?.sparseBoard?.units ?? responseData?.game?.board?.units ?? [];
     new BoardUpdater().updateBoard(this.#game.getBoard(), safeUnits, {
-      defensiveFireEvents: responseData?.defensive_fire_events ?? [],
+      defensiveFireEvents: responseData?.defensiveFireEvents ?? [],
     });
 
     this.#game.updateScores?.(responseData?.scores);

--- a/battle-hexes-web/src/model/board-updater.js
+++ b/battle-hexes-web/src/model/board-updater.js
@@ -20,8 +20,8 @@ export class BoardUpdater {
           board.getAnimator?.().interrupt?.(boardUnit);
         }
         board.updateUnitPosition(boardUnit, containingHex, destinationHex);
-        if (Object.hasOwn(unit, 'defensive_fire_available')) {
-          boardUnit.setDefensiveFireAvailable(unit.defensive_fire_available);
+        if (Object.hasOwn(unit, 'defensiveFireAvailable')) {
+          boardUnit.setDefensiveFireAvailable(unit.defensiveFireAvailable);
         }
       }
     }

--- a/battle-hexes-web/src/model/board.js
+++ b/battle-hexes-web/src/model/board.js
@@ -396,7 +396,7 @@ export class Board {
         id: unit.getId(),
         row: unitHex.getRow(),
         column: unitHex.getColumn(),
-        defensive_fire_available: unit.hasDefensiveFire(),
+        defensiveFireAvailable: unit.hasDefensiveFire(),
       })
     }
     return {

--- a/battle-hexes-web/src/model/game-creator.js
+++ b/battle-hexes-web/src/model/game-creator.js
@@ -40,7 +40,6 @@ export class GameCreator {
   #extractScenarioId(gameData) {
     const candidates = [
       gameData?.scenarioId,
-      gameData?.scenario_id,
     ];
 
     return candidates.find((value) => typeof value === 'string' && value.trim().length > 0) ?? null;
@@ -49,7 +48,6 @@ export class GameCreator {
   #extractTurnLimit(gameData) {
     const candidates = [
       gameData?.turnLimit,
-      gameData?.turn_limit,
     ];
 
     for (const candidate of candidates) {
@@ -64,7 +62,6 @@ export class GameCreator {
   #extractTurnNumber(gameData) {
     const candidates = [
       gameData?.turnNumber,
-      gameData?.turn_number,
     ];
 
     for (const candidate of candidates) {
@@ -88,8 +85,6 @@ export class GameCreator {
     const candidates = [
       gameData?.playerTypeIds,
       gameData?.playerTypes,
-      gameData?.player_type_ids,
-      gameData?.player_types,
     ];
 
     for (const candidate of candidates) {
@@ -125,7 +120,7 @@ export class GameCreator {
   #addUnits(board, players, boardData) {
     const factionMap = this.#getFactionMap(players);
     for (let unitData of boardData.units) {
-      const faction = factionMap.get(unitData.faction_id);
+      const faction = factionMap.get(unitData.factionId);
       const unit = new Unit(
         unitData.id,
         unitData.name,
@@ -135,7 +130,7 @@ export class GameCreator {
         unitData.defense,
         unitData.move,
         unitData.echelon,
-        unitData.defensive_fire_available ?? true,
+        unitData.defensiveFireAvailable ?? true,
       );
       board.addUnit(unit, unitData.row, unitData.column);
     }
@@ -149,11 +144,11 @@ export class GameCreator {
       for (const [key, value] of Object.entries(terrainData.types)) {
         const name = value?.name ?? key;
         const color = value?.color ?? '#F0F0F0';
-        const moveCost = Number.isFinite(value?.move_cost) && value.move_cost > 0
-          ? value.move_cost
+        const moveCost = Number.isFinite(value?.moveCost) && value.moveCost > 0
+          ? value.moveCost
           : 1;
-        const combatOddsShift = Number.isFinite(value?.combat_odds_shift)
-          ? value.combat_odds_shift
+        const combatOddsShift = Number.isFinite(value?.combatOddsShift)
+          ? value.combatOddsShift
           : 0;
         terrainTypes.set(key, new Terrain(name, color, moveCost, combatOddsShift));
       }
@@ -216,17 +211,17 @@ export class GameCreator {
     }
 
     const boardRoadData = gameData?.board && typeof gameData.board === 'object' ? gameData.board : null;
-    const roadData = Array.isArray(boardRoadData?.road_paths)
+    const roadData = Array.isArray(boardRoadData?.roadPaths)
       ? boardRoadData
       : gameData;
 
-    if (!Array.isArray(roadData.road_paths)) {
+    if (!Array.isArray(roadData.roadPaths)) {
       return;
     }
 
-    const roadTypeMap = this.#createRoadTypes(roadData.road_types);
+    const roadTypeMap = this.#createRoadTypes(roadData.roadTypes);
 
-    for (const roadPathData of roadData.road_paths) {
+    for (const roadPathData of roadData.roadPaths) {
       const road = this.#createRoad(roadPathData, roadTypeMap);
       if (road) {
         board.addRoad(road);

--- a/battle-hexes-web/src/model/movement-response-handler.js
+++ b/battle-hexes-web/src/model/movement-response-handler.js
@@ -2,10 +2,10 @@ import { eventBus } from '../event-bus.js';
 import { BoardUpdater } from './board-updater.js';
 
 export function applyMovementResponse(board, response) {
-  const units = response?.game?.board?.units ?? response?.sparse_board?.units ?? [];
+  const units = response?.game?.board?.units ?? response?.sparseBoard?.units ?? [];
   new BoardUpdater().updateBoard(board, units);
 
-  const defensiveFireEvents = response?.defensive_fire_events ?? [];
+  const defensiveFireEvents = response?.defensiveFireEvents ?? [];
   if (defensiveFireEvents.length > 0) {
     eventBus.emit('defensiveFireResolved', defensiveFireEvents);
   }

--- a/battle-hexes-web/src/service/mock-battle-hexes-service.js
+++ b/battle-hexes-web/src/service/mock-battle-hexes-service.js
@@ -19,7 +19,7 @@ const MOCK_PLAYER_TYPES = [
 
 const emptyMovementPayload = {
   plans: [],
-  sparse_board: { units: [] },
+  sparseBoard: { units: [] },
   game: { board: { units: [] } },
   scores: {},
   turnNumber: 1,

--- a/battle-hexes-web/src/service/mock-responses/get-game.json
+++ b/battle-hexes-web/src/service/mock-responses/get-game.json
@@ -31,7 +31,7 @@
       {
         "id": "StuG. III Zug A",
         "name": "StuG. III Zug A",
-        "faction_id": "Wehrmacht",
+        "factionId": "Wehrmacht",
         "type": "Infantry",
         "attack": 4,
         "echelon": "platoon",
@@ -39,12 +39,12 @@
         "move": 7,
         "row": 0,
         "column": 16,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       },
       {
         "id": "MG Trupp A",
         "name": "MG Trupp A",
-        "faction_id": "Wehrmacht",
+        "factionId": "Wehrmacht",
         "type": "MG",
         "attack": 1,
         "echelon": "section",
@@ -52,12 +52,12 @@
         "move": 3,
         "row": 0,
         "column": 16,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       },
       {
         "id": "B / Inf. Zug",
         "name": "B / Inf. Zug",
-        "faction_id": "Wehrmacht",
+        "factionId": "Wehrmacht",
         "type": "Infantry",
         "attack": 2,
         "echelon": "platoon",
@@ -65,12 +65,12 @@
         "move": 4,
         "row": 2,
         "column": 3,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       },
       {
         "id": "A / Inf. Zug",
         "name": "A / Inf. Zug",
-        "faction_id": "Wehrmacht",
+        "factionId": "Wehrmacht",
         "type": "Infantry",
         "attack": 2,
         "echelon": "platoon",
@@ -78,12 +78,12 @@
         "move": 4,
         "row": 3,
         "column": 15,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       },
       {
         "id": "C / Inf. Zug",
         "name": "C / Inf. Zug",
-        "faction_id": "Wehrmacht",
+        "factionId": "Wehrmacht",
         "type": "Infantry",
         "attack": 2,
         "echelon": "platoon",
@@ -91,12 +91,12 @@
         "move": 4,
         "row": 4,
         "column": 5,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       },
       {
         "id": "Crossroads Feldwache",
         "name": "Crossroads Feldwache",
-        "faction_id": "Wehrmacht",
+        "factionId": "Wehrmacht",
         "type": "Infantry",
         "attack": 1,
         "echelon": "section",
@@ -104,12 +104,12 @@
         "move": 0,
         "row": 6,
         "column": 9,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       },
       {
         "id": "Airborne Inf. B",
         "name": "Airborne Inf. B",
-        "faction_id": "Airborne",
+        "factionId": "Airborne",
         "type": "Infantry",
         "attack": 3,
         "echelon": "platoon",
@@ -117,12 +117,12 @@
         "move": 5,
         "row": 12,
         "column": 7,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       },
       {
         "id": "Airborne Inf. A",
         "name": "Airborne Inf. A",
-        "faction_id": "Airborne",
+        "factionId": "Airborne",
         "type": "Infantry",
         "attack": 3,
         "echelon": "platoon",
@@ -130,12 +130,12 @@
         "move": 5,
         "row": 12,
         "column": 11,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       },
       {
         "id": "Airborne Inf. C",
         "name": "Airborne Inf. C",
-        "faction_id": "Airborne",
+        "factionId": "Airborne",
         "type": "Infantry",
         "attack": 3,
         "echelon": "platoon",
@@ -143,12 +143,12 @@
         "move": 5,
         "row": 15,
         "column": 16,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       },
       {
         "id": "Airborne Inf. E",
         "name": "Airborne Inf. E",
-        "faction_id": "Airborne",
+        "factionId": "Airborne",
         "type": "Infantry",
         "attack": 3,
         "echelon": "platoon",
@@ -156,12 +156,12 @@
         "move": 5,
         "row": 16,
         "column": 0,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       },
       {
         "id": "Airborne Inf. D",
         "name": "Airborne Inf. D",
-        "faction_id": "Airborne",
+        "factionId": "Airborne",
         "type": "Infantry",
         "attack": 3,
         "echelon": "platoon",
@@ -169,12 +169,12 @@
         "move": 5,
         "row": 16,
         "column": 1,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       },
       {
         "id": "Airborne Inf. F",
         "name": "Airborne Inf. F",
-        "faction_id": "Airborne",
+        "factionId": "Airborne",
         "type": "Infantry",
         "attack": 3,
         "echelon": "platoon",
@@ -182,7 +182,7 @@
         "move": 5,
         "row": 16,
         "column": 7,
-        "defensive_fire_available": true
+        "defensiveFireAvailable": true
       }
     ],
     "terrain": {
@@ -191,22 +191,22 @@
         "forest": {
           "name": "forest",
           "color": "#7F8C6A",
-          "move_cost": 3
+          "moveCost": 3
         },
         "open": {
           "name": "open",
           "color": "#8F9779",
-          "move_cost": 1
+          "moveCost": 1
         },
         "rough": {
           "name": "rough",
           "color": "#84876B",
-          "move_cost": 2
+          "moveCost": 2
         },
         "village": {
           "name": "village",
           "color": "#9A8F7A",
-          "move_cost": 1
+          "moveCost": 1
         }
       },
       "hexes": [
@@ -512,10 +512,10 @@
         }
       ]
     },
-    "road_types": {
+    "roadTypes": {
       "secondary": 1
     },
-    "road_paths": [
+    "roadPaths": [
       {
         "type": "secondary",
         "path": [

--- a/battle-hexes-web/src/service/mock-responses/move.json
+++ b/battle-hexes-web/src/service/mock-responses/move.json
@@ -32,7 +32,7 @@
                 {
                     "id": "StuG. III Zug A",
                     "name": "StuG. III Zug A",
-                    "faction_id": "Wehrmacht",
+                    "factionId": "Wehrmacht",
                     "type": "Infantry",
                     "attack": 4,
                     "echelon": "platoon",
@@ -40,12 +40,12 @@
                     "move": 7,
                     "row": 0,
                     "column": 16,
-                    "defensive_fire_available": true
+                    "defensiveFireAvailable": true
                 },
                 {
                     "id": "MG Trupp A",
                     "name": "MG Trupp A",
-                    "faction_id": "Wehrmacht",
+                    "factionId": "Wehrmacht",
                     "type": "MG",
                     "attack": 1,
                     "echelon": "section",
@@ -53,12 +53,12 @@
                     "move": 3,
                     "row": 0,
                     "column": 16,
-                    "defensive_fire_available": true
+                    "defensiveFireAvailable": true
                 },
                 {
                     "id": "B / Inf. Zug",
                     "name": "B / Inf. Zug",
-                    "faction_id": "Wehrmacht",
+                    "factionId": "Wehrmacht",
                     "type": "Infantry",
                     "attack": 2,
                     "echelon": "platoon",
@@ -66,12 +66,12 @@
                     "move": 4,
                     "row": 2,
                     "column": 3,
-                    "defensive_fire_available": true
+                    "defensiveFireAvailable": true
                 },
                 {
                     "id": "A / Inf. Zug",
                     "name": "A / Inf. Zug",
-                    "faction_id": "Wehrmacht",
+                    "factionId": "Wehrmacht",
                     "type": "Infantry",
                     "attack": 2,
                     "echelon": "platoon",
@@ -79,12 +79,12 @@
                     "move": 4,
                     "row": 5,
                     "column": 11,
-                    "defensive_fire_available": false
+                    "defensiveFireAvailable": false
                 },
                 {
                     "id": "C / Inf. Zug",
                     "name": "C / Inf. Zug",
-                    "faction_id": "Wehrmacht",
+                    "factionId": "Wehrmacht",
                     "type": "Infantry",
                     "attack": 2,
                     "echelon": "platoon",
@@ -92,12 +92,12 @@
                     "move": 4,
                     "row": 5,
                     "column": 8,
-                    "defensive_fire_available": false
+                    "defensiveFireAvailable": false
                 },
                 {
                     "id": "Crossroads Feldwache",
                     "name": "Crossroads Feldwache",
-                    "faction_id": "Wehrmacht",
+                    "factionId": "Wehrmacht",
                     "type": "Infantry",
                     "attack": 1,
                     "echelon": "section",
@@ -105,12 +105,12 @@
                     "move": 0,
                     "row": 6,
                     "column": 9,
-                    "defensive_fire_available": false
+                    "defensiveFireAvailable": false
                 },
                 {
                     "id": "Airborne Inf. B",
                     "name": "Airborne Inf. B",
-                    "faction_id": "Airborne",
+                    "factionId": "Airborne",
                     "type": "Infantry",
                     "attack": 3,
                     "echelon": "platoon",
@@ -118,12 +118,12 @@
                     "move": 5,
                     "row": 10,
                     "column": 9,
-                    "defensive_fire_available": true
+                    "defensiveFireAvailable": true
                 },
                 {
                     "id": "Airborne Inf. A",
                     "name": "Airborne Inf. A",
-                    "faction_id": "Airborne",
+                    "factionId": "Airborne",
                     "type": "Infantry",
                     "attack": 3,
                     "echelon": "platoon",
@@ -131,12 +131,12 @@
                     "move": 5,
                     "row": 8,
                     "column": 9,
-                    "defensive_fire_available": false
+                    "defensiveFireAvailable": false
                 },
                 {
                     "id": "Airborne Inf. C",
                     "name": "Airborne Inf. C",
-                    "faction_id": "Airborne",
+                    "factionId": "Airborne",
                     "type": "Infantry",
                     "attack": 3,
                     "echelon": "platoon",
@@ -144,12 +144,12 @@
                     "move": 5,
                     "row": 15,
                     "column": 16,
-                    "defensive_fire_available": true
+                    "defensiveFireAvailable": true
                 },
                 {
                     "id": "Airborne Inf. E",
                     "name": "Airborne Inf. E",
-                    "faction_id": "Airborne",
+                    "factionId": "Airborne",
                     "type": "Infantry",
                     "attack": 3,
                     "echelon": "platoon",
@@ -157,12 +157,12 @@
                     "move": 5,
                     "row": 16,
                     "column": 0,
-                    "defensive_fire_available": true
+                    "defensiveFireAvailable": true
                 },
                 {
                     "id": "Airborne Inf. D",
                     "name": "Airborne Inf. D",
-                    "faction_id": "Airborne",
+                    "factionId": "Airborne",
                     "type": "Infantry",
                     "attack": 3,
                     "echelon": "platoon",
@@ -170,12 +170,12 @@
                     "move": 5,
                     "row": 16,
                     "column": 1,
-                    "defensive_fire_available": true
+                    "defensiveFireAvailable": true
                 },
                 {
                     "id": "Airborne Inf. F",
                     "name": "Airborne Inf. F",
-                    "faction_id": "Airborne",
+                    "factionId": "Airborne",
                     "type": "Infantry",
                     "attack": 3,
                     "echelon": "platoon",
@@ -183,7 +183,7 @@
                     "move": 5,
                     "row": 16,
                     "column": 7,
-                    "defensive_fire_available": true
+                    "defensiveFireAvailable": true
                 }
             ],
             "terrain": {
@@ -191,10 +191,10 @@
                 "types": {},
                 "hexes": []
             },
-            "road_types": {
+            "roadTypes": {
                 "secondary": 1.0
             },
-            "road_paths": [
+            "roadPaths": [
                 {
                     "type": "secondary",
                     "path": [
@@ -356,7 +356,7 @@
             "Player 2": 3
         },
         "turn_limit": 8,
-        "turn_number": 2
+        "turnNumber": 2
     },
     "plans": [
         {
@@ -373,88 +373,88 @@
             ]
         }
     ],
-    "sparse_board": {
+    "sparseBoard": {
         "units": [
             {
                 "id": "StuG. III Zug A",
                 "row": 0,
                 "column": 16,
-                "defensive_fire_available": true
+                "defensiveFireAvailable": true
             },
             {
                 "id": "MG Trupp A",
                 "row": 0,
                 "column": 16,
-                "defensive_fire_available": true
+                "defensiveFireAvailable": true
             },
             {
                 "id": "B / Inf. Zug",
                 "row": 2,
                 "column": 3,
-                "defensive_fire_available": true
+                "defensiveFireAvailable": true
             },
             {
                 "id": "A / Inf. Zug",
                 "row": 5,
                 "column": 11,
-                "defensive_fire_available": false
+                "defensiveFireAvailable": false
             },
             {
                 "id": "C / Inf. Zug",
                 "row": 5,
                 "column": 8,
-                "defensive_fire_available": false
+                "defensiveFireAvailable": false
             },
             {
                 "id": "Crossroads Feldwache",
                 "row": 6,
                 "column": 9,
-                "defensive_fire_available": false
+                "defensiveFireAvailable": false
             },
             {
                 "id": "Airborne Inf. B",
                 "row": 10,
                 "column": 9,
-                "defensive_fire_available": true
+                "defensiveFireAvailable": true
             },
             {
                 "id": "Airborne Inf. A",
                 "row": 8,
                 "column": 9,
-                "defensive_fire_available": false
+                "defensiveFireAvailable": false
             },
             {
                 "id": "Airborne Inf. C",
                 "row": 15,
                 "column": 16,
-                "defensive_fire_available": true
+                "defensiveFireAvailable": true
             },
             {
                 "id": "Airborne Inf. E",
                 "row": 16,
                 "column": 0,
-                "defensive_fire_available": true
+                "defensiveFireAvailable": true
             },
             {
                 "id": "Airborne Inf. D",
                 "row": 16,
                 "column": 1,
-                "defensive_fire_available": true
+                "defensiveFireAvailable": true
             },
             {
                 "id": "Airborne Inf. F",
                 "row": 16,
                 "column": 7,
-                "defensive_fire_available": true
+                "defensiveFireAvailable": true
             }
         ],
-        "last_combat_results": null,
+        "lastCombatResults": null,
         "scores": null
     },
-    "defensive_fire_events": [
+    "defensiveFireEvents": [
         {
-            "firing_unit_id": "Crossroads Feldwache",
-            "target_unit_id": "Airborne Inf. A",
+            "firingUnitId": "Crossroads Feldwache",
+            "targetUnitId": "Airborne Inf. A",
             "trigger_hex": [
                 7,
                 9
@@ -464,7 +464,7 @@
                 9
             ],
             "outcome": "retreat",
-            "retreat_destination": [
+            "retreatDestination": [
                 8,
                 9
             ],

--- a/battle-hexes-web/src/sound-player.js
+++ b/battle-hexes-web/src/sound-player.js
@@ -38,7 +38,7 @@ export class SoundPlayer {
   }
 
   #resolveFactionSoundForEvent(event, soundPath) {
-    const firingUnitId = event?.firing_unit_id;
+    const firingUnitId = event?.firingUnitId;
     if (typeof firingUnitId !== 'string' || firingUnitId.length === 0) {
       return null;
     }

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -132,7 +132,7 @@ describe('auto new game persistence', () => {
       ([eventName]) => eventName === 'defensiveFireResolved'
     )?.[1];
 
-    const events = [{ firing_unit_id: 'unit-1', outcome: 'retreat', message: 'Retreat.' }];
+    const events = [{ firingUnitId: 'unit-1', outcome: 'retreat', message: 'Retreat.' }];
     defensiveFireListener(events);
 
     expect(soundPlayer.playDefensiveFireEvents).toHaveBeenCalledWith(events);
@@ -583,10 +583,10 @@ describe('auto new game persistence', () => {
     });
 
     mockService.endMovement.mockResolvedValue({
-      sparse_board: {
-          units: [{ id: 'unit-1', row: 3, column: 4, defensive_fire_available: false }],
+      sparseBoard: {
+          units: [{ id: 'unit-1', row: 3, column: 4, defensiveFireAvailable: false }],
       },
-      defensive_fire_events: [{ outcome: 'retreat', message: 'Defensive fire forced the target to retreat to (3, 4).' }],
+      defensiveFireEvents: [{ outcome: 'retreat', message: 'Defensive fire forced the target to retreat to (3, 4).' }],
         scores: { 'Player 1': 2 },
         turnLimit: 9,
       turnNumber: 4,
@@ -596,7 +596,7 @@ describe('auto new game persistence', () => {
     menu.doEndPhase();
     await flushPromises();
 
-    expect(updateBoard).toHaveBeenCalledWith(board, [{ id: 'unit-1', row: 3, column: 4, defensive_fire_available: false }], {
+    expect(updateBoard).toHaveBeenCalledWith(board, [{ id: 'unit-1', row: 3, column: 4, defensiveFireAvailable: false }], {
       defensiveFireEvents: [{ outcome: 'retreat', message: 'Defensive fire forced the target to retreat to (3, 4).' }],
     });
   });
@@ -666,10 +666,10 @@ describe('auto new game persistence', () => {
     history.replaceState(null, '', '/');
 
     const preResetPayload = {
-      units: [{ id: 'unit-1', defensive_fire_available: false }],
+      units: [{ id: 'unit-1', defensiveFireAvailable: false }],
     };
     const postResetPayload = {
-      units: [{ id: 'unit-1', defensive_fire_available: true }],
+      units: [{ id: 'unit-1', defensiveFireAvailable: true }],
     };
     let movesReset = false;
     const currentPlayer = {

--- a/battle-hexes-web/tests/model/board-updater.test.js
+++ b/battle-hexes-web/tests/model/board-updater.test.js
@@ -57,7 +57,7 @@ describe('updateBoard', () => {
       id: 'unit-001',
       row: 4,
       column: 5,
-      defensive_fire_available: false,
+      defensiveFireAvailable: false,
     }]);
 
     expect(redUnit.hasDefensiveFire()).toBe(false);
@@ -67,8 +67,8 @@ describe('updateBoard', () => {
     board.addUnit(redUnit, 4, 5);
 
     const defensiveFireEvents = [{
-      firing_unit_id: 'unit-002',
-      target_unit_id: 'unit-001',
+      firingUnitId: 'unit-002',
+      targetUnitId: 'unit-001',
       outcome: 'retreat',
       message: 'Defensive fire forced the target to retreat to (3, 5).',
     }];

--- a/battle-hexes-web/tests/model/game-creator.test.js
+++ b/battle-hexes-web/tests/model/game-creator.test.js
@@ -13,11 +13,11 @@ beforeEach(() => {
     '"players":[{"name":"Player 1","type":"Human","factions":[{"id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","name":"Red Faction","color":"#C81010","sounds":{"defensive_fire":{"effect":"red_effect.ogg","no_effect":"red_no_effect.ogg"}}}]},' +
     '{"name":"Player 2","type":"Computer","factions":[{"id":"38400000-8cf0-41bd-b23e-10b96e4ef00d","name":"Blue Faction","color":"#4682B4"}]}],' +
     '"board":{"rows":10,"columns":10,"units":[' +
-    '{"id":"a22c90d0-db87-41d0-8c3a-00c04fd708be","name":"Red Unit","faction_id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","type":"Infantry","echelon":"platoon","attack":2,"defense":2,"move":6,"row":6,"column":4,"defensive_fire_available":false},' +
-    '{"id":"c9a440d2-2b0a-4730-b4c6-da394b642c61","name":"Blue Unit","faction_id":"38400000-8cf0-41bd-b23e-10b96e4ef00d","type":"Infantry","attack":4,"defense":4,"move":4,"row":3,"column":5}],' +
-    '"terrain":{"default":"open","types":{"open":{"name":"open","color":"#C6AA5C"},"village":{"name":"village","color":"#9A8F7A","move_cost":2,"combat_odds_shift":-1}},"hexes":[{"row":6,"column":4,"terrain":"village"}]},' +
-    '"road_types":{"secondary":1.0},' +
-    '"road_paths":[{"type":"secondary","path":[{"row":5,"column":0},{"row":5,"column":1},{"row":6,"column":2}]}]},' +
+    '{"id":"a22c90d0-db87-41d0-8c3a-00c04fd708be","name":"Red Unit","factionId":"f47ac10b-58cc-4372-a567-0e02b2c3d479","type":"Infantry","echelon":"platoon","attack":2,"defense":2,"move":6,"row":6,"column":4,"defensiveFireAvailable":false},' +
+    '{"id":"c9a440d2-2b0a-4730-b4c6-da394b642c61","name":"Blue Unit","factionId":"38400000-8cf0-41bd-b23e-10b96e4ef00d","type":"Infantry","attack":4,"defense":4,"move":4,"row":3,"column":5}],' +
+    '"terrain":{"default":"open","types":{"open":{"name":"open","color":"#C6AA5C"},"village":{"name":"village","color":"#9A8F7A","moveCost":2,"combatOddsShift":-1}},"hexes":[{"row":6,"column":4,"terrain":"village"}]},' +
+    '"roadTypes":{"secondary":1.0},' +
+    '"roadPaths":[{"type":"secondary","path":[{"row":5,"column":0},{"row":5,"column":1},{"row":6,"column":2}]}]},' +
     '"objectives":[{"row":6,"column":4,"points":3,"type":"hold"}]}'
   );
   game = gameCreator.createGame(gameData);
@@ -204,8 +204,8 @@ describe("createGame", () => {
         columns: 2,
         units: [],
       },
-      road_types: { secondary: 1.0 },
-      road_paths: [{ type: 'secondary', path: [{ row: 0, column: 0 }, { row: 0, column: 1 }] }],
+      roadTypes: { secondary: 1.0 },
+      roadPaths: [{ type: 'secondary', path: [{ row: 0, column: 0 }, { row: 0, column: 1 }] }],
     };
 
     const legacyRoadGame = gameCreator.createGame(gameData);

--- a/battle-hexes-web/tests/model/movement-response-handler.test.js
+++ b/battle-hexes-web/tests/model/movement-response-handler.test.js
@@ -25,10 +25,10 @@ describe('applyMovementResponse', () => {
     const response = {
       game: {
         board: {
-          units: [{ id: 'unit-1', row: 1, column: 2, defensive_fire_available: false }],
+          units: [{ id: 'unit-1', row: 1, column: 2, defensiveFireAvailable: false }],
         },
       },
-      defensive_fire_events: [
+      defensiveFireEvents: [
         { message: 'Defensive fire had no effect.' },
       ],
     };
@@ -39,23 +39,23 @@ describe('applyMovementResponse', () => {
     expect(updater.updateBoard).toHaveBeenCalledWith(board, response.game.board.units);
     expect(eventBus.emit).toHaveBeenCalledWith(
       'defensiveFireResolved',
-      response.defensive_fire_events
+      response.defensiveFireEvents
     );
   });
 
   test('falls back to sparse board units when game board units are unavailable', () => {
     const board = { id: 'board-1' };
     const response = {
-      sparse_board: {
+      sparseBoard: {
         units: [{ id: 'unit-2', row: 3, column: 4 }],
       },
-      defensive_fire_events: [],
+      defensiveFireEvents: [],
     };
 
     applyMovementResponse(board, response);
 
     const updater = BoardUpdater.mock.results[0].value;
-    expect(updater.updateBoard).toHaveBeenCalledWith(board, response.sparse_board.units);
+    expect(updater.updateBoard).toHaveBeenCalledWith(board, response.sparseBoard.units);
     expect(eventBus.emit).not.toHaveBeenCalled();
   });
 });

--- a/battle-hexes-web/tests/sound-player.test.js
+++ b/battle-hexes-web/tests/sound-player.test.js
@@ -21,7 +21,7 @@ describe('SoundPlayer defensive fire playback', () => {
     const audioFactory = createAudioFactory();
 
     const soundPlayer = new SoundPlayer(game, { audioFactory });
-    await soundPlayer.playDefensiveFireEvents([{ firing_unit_id: 'unit-1', outcome: 'retreat' }]);
+    await soundPlayer.playDefensiveFireEvents([{ firingUnitId: 'unit-1', outcome: 'retreat' }]);
 
     expect(game.getFactionForUnitId).toHaveBeenCalledWith('unit-1');
     expect(audioFactory).toHaveBeenCalledWith('/sounds/m1_single_rifle_shot.ogg');
@@ -39,7 +39,7 @@ describe('SoundPlayer defensive fire playback', () => {
     const audioFactory = createAudioFactory();
 
     const soundPlayer = new SoundPlayer(game, { audioFactory });
-    await soundPlayer.playDefensiveFireEvents([{ firing_unit_id: 'unit-1', outcome: 'no_effect' }]);
+    await soundPlayer.playDefensiveFireEvents([{ firingUnitId: 'unit-1', outcome: 'no_effect' }]);
 
     expect(audioFactory).toHaveBeenCalledWith('/sounds/k98_distant.ogg');
   });
@@ -57,8 +57,8 @@ describe('SoundPlayer defensive fire playback', () => {
 
     const soundPlayer = new SoundPlayer(game, { audioFactory });
     await soundPlayer.playDefensiveFireEvents([
-      { firing_unit_id: 'unit-1', outcome: 'retreat' },
-      { firing_unit_id: 'unit-2', outcome: 'no_effect' },
+      { firingUnitId: 'unit-1', outcome: 'retreat' },
+      { firingUnitId: 'unit-2', outcome: 'no_effect' },
     ]);
 
     expect(audioFactory).not.toHaveBeenCalled();
@@ -78,8 +78,8 @@ describe('SoundPlayer defensive fire playback', () => {
 
     const soundPlayer = new SoundPlayer(game, { audioFactory });
     await soundPlayer.playDefensiveFireEvents([
-      { firing_unit_id: 'red-unit', outcome: 'retreat' },
-      { firing_unit_id: 'blue-unit', outcome: 'retreat' },
+      { firingUnitId: 'red-unit', outcome: 'retreat' },
+      { firingUnitId: 'blue-unit', outcome: 'retreat' },
     ]);
 
     expect(audioFactory).toHaveBeenNthCalledWith(1, '/sounds/red_effect.ogg');
@@ -101,8 +101,8 @@ describe('SoundPlayer defensive fire playback', () => {
 
     const soundPlayer = new SoundPlayer(game, { audioFactory, logger });
     await expect(soundPlayer.playDefensiveFireEvents([
-      { firing_unit_id: 'unit-1', outcome: 'retreat' },
-      { firing_unit_id: 'unit-1', outcome: 'retreat' },
+      { firingUnitId: 'unit-1', outcome: 'retreat' },
+      { firingUnitId: 'unit-1', outcome: 'retreat' },
     ])).resolves.toBeUndefined();
 
     expect(logger.warn).toHaveBeenCalledTimes(2);

--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -58,6 +58,17 @@ app.add_middleware(
 )
 
 
+def _dump_api_model(model) -> dict:
+    """Dump a Pydantic API model using client-facing aliases."""
+
+    if isinstance(model, dict):
+        return model
+    try:
+        return model.model_dump(by_alias=True)
+    except TypeError:
+        return model.model_dump()
+
+
 def _serialize_game(game) -> dict:
     """Return a JSON-serialisable representation of ``game``."""
 
@@ -70,9 +81,9 @@ def _serialize_game(game) -> dict:
             scenario = None
 
     game_model = GameModel.from_game(game, scenario)
-    model = game_model.model_dump()
+    model = _dump_api_model(game_model)
     model["players"] = [
-        PlayerModel.from_core(player).model_dump()
+        _dump_api_model(PlayerModel.from_core(player))
         for player in game_model.players
     ]
 
@@ -82,8 +93,8 @@ def _serialize_game(game) -> dict:
         model["scenarioName"] = scenario.name
         model["stackingLimit"] = scenario.stacking_limit
 
-    model["turnLimit"] = model.pop("turn_limit", None)
-    model["turnNumber"] = model.pop("turn_number", 1)
+    model.setdefault("turnLimit", None)
+    model.setdefault("turnNumber", 1)
 
     player_type_ids = getattr(game, "player_type_ids", None)
     if player_type_ids is not None:
@@ -160,7 +171,7 @@ def get_game(game_id: str):
 def resolve_combat(
     game_id: str,
     sparse_board: SparseBoard = Body(...)
-) -> SparseBoard:
+) -> dict:
     logger.info("We got game: %s", game_id)
     game = _get_game_or_404(game_id)
     sparse_board.apply_to_board(game.get_board())
@@ -186,7 +197,9 @@ def resolve_combat(
         CombatResultSchema.from_combat_result_data(battle)
         for battle in results.get_battles()
     ]
-    return sparse_board
+    if not isinstance(sparse_board, SparseBoard):
+        return {}
+    return _dump_api_model(sparse_board)
 
 
 @app.post('/games/{game_id}/movement')
@@ -199,11 +212,11 @@ def generate_movement(game_id: str):
     movement_resolution = game.apply_movement_plans(plans)
     game_repo.update_game(game)
     _call_end_game_callbacks(game)
-    return MovementResponseModel.from_movement_result(
+    return _dump_api_model(MovementResponseModel.from_movement_result(
         game,
         plans,
         movement_resolution,
-    )
+    ))
 
 
 @app.post('/games/{game_id}/move')
@@ -216,11 +229,11 @@ def resolve_human_move(game_id: str, sparse_board: SparseBoard = Body(...)):
 
     game_repo.update_game(game)
     _call_end_game_callbacks(game)
-    return MovementResponseModel.from_movement_result(
+    return _dump_api_model(MovementResponseModel.from_movement_result(
         game,
         plans,
         movement_resolution,
-    )
+    ))
 
 
 @app.post('/games/{game_id}/end-movement')
@@ -236,11 +249,11 @@ def end_movement(game_id: str, sparse_board: SparseBoard = Body(...)):
 
     game_repo.update_game(game)
     _call_end_game_callbacks(game)
-    return MovementResponseModel.from_movement_result(
+    return _dump_api_model(MovementResponseModel.from_movement_result(
         game,
         plans,
         movement_resolution,
-    )
+    ))
 
 
 @app.post('/games/{game_id}/end-turn')
@@ -263,4 +276,4 @@ def end_turn(game_id: str, sparse_board: SparseBoard = Body(...)):
 
     game_repo.update_game(game)
     _call_end_game_callbacks(game)
-    return GameModel.from_game(game)
+    return _dump_api_model(GameModel.from_game(game))

--- a/battle_hexes_api/src/battle_hexes_api/schemas/api_model.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/api_model.py
@@ -1,0 +1,19 @@
+"""Shared Pydantic base classes for API schemas."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+def to_camel(value: str) -> str:
+    """Convert a snake_case field name to lower camelCase."""
+
+    words = value.split("_")
+    return words[0] + "".join(word.capitalize() for word in words[1:])
+
+
+class ApiBaseModel(BaseModel):
+    """Base model that exposes camelCase JSON aliases for API payloads."""
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )

--- a/battle_hexes_api/src/battle_hexes_api/schemas/board.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/board.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
+from .api_model import ApiBaseModel
 
 from .terrain import TerrainSummaryModel
 from .unit import UnitModel
@@ -12,21 +12,21 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from battle_hexes_core.scenario.scenario import Scenario
 
 
-class RoadPathCoordinateModel(BaseModel):
+class RoadPathCoordinateModel(ApiBaseModel):
     """Coordinate point for a serialized road path."""
 
     row: int
     column: int
 
 
-class RoadPathModel(BaseModel):
+class RoadPathModel(ApiBaseModel):
     """Serialized representation of a road path."""
 
     type: str
     path: list[RoadPathCoordinateModel]
 
 
-class BoardModel(BaseModel):
+class BoardModel(ApiBaseModel):
     """Serialized representation of the in-memory board."""
 
     rows: int

--- a/battle_hexes_api/src/battle_hexes_api/schemas/combat.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/combat.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import Tuple
 
-from pydantic import BaseModel
+from .api_model import ApiBaseModel
 
 from battle_hexes_core.combat.combatresult import CombatResultData
 
 
-class CombatResultSchema(BaseModel):
+class CombatResultSchema(ApiBaseModel):
     """API representation of a single combat resolution."""
 
     combat_result_code: str

--- a/battle_hexes_api/src/battle_hexes_api/schemas/create_game.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/create_game.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import List
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_validator
+
+from .api_model import ApiBaseModel
 
 
-class CreateGameRequest(BaseModel):
+class CreateGameRequest(ApiBaseModel):
     """Request body for the ``POST /games`` endpoint."""
 
     scenario_id: str = Field(alias="scenarioId")

--- a/battle_hexes_api/src/battle_hexes_api/schemas/faction.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/faction.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from .api_model import ApiBaseModel
 
 from battle_hexes_core.unit.faction import Faction
 
 
-class FactionModel(BaseModel):
+class FactionModel(ApiBaseModel):
     """Pydantic representation of the core :class:`Faction`."""
 
     model_config = ConfigDict(from_attributes=True)

--- a/battle_hexes_api/src/battle_hexes_api/schemas/game_model.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/game_model.py
@@ -3,7 +3,9 @@
 from typing import List, TYPE_CHECKING
 import uuid
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from .api_model import ApiBaseModel
 
 from battle_hexes_core.game.player import Player
 
@@ -15,7 +17,7 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from battle_hexes_core.scenario.scenario import Scenario
 
 
-class GameModel(BaseModel):
+class GameModel(ApiBaseModel):
     """Serialized representation of the core ``Game`` object."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/battle_hexes_api/src/battle_hexes_api/schemas/movement.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/movement.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from .api_model import ApiBaseModel
 
 from .game_model import GameModel
 from .sparseboard import SparseBoard
 
 
-class DefensiveFireEventModel(BaseModel):
+class DefensiveFireEventModel(ApiBaseModel):
     """Serialized defensive-fire event emitted during movement."""
 
     firing_unit_id: str
@@ -55,7 +57,7 @@ class DefensiveFireEventModel(BaseModel):
         return "Defensive fire had no effect."
 
 
-class MovementResponseModel(BaseModel):
+class MovementResponseModel(ApiBaseModel):
     """Movement endpoint payload including board updates and reactions."""
 
     model_config = ConfigDict(populate_by_name=True)

--- a/battle_hexes_api/src/battle_hexes_api/schemas/objective.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/objective.py
@@ -2,13 +2,13 @@
 
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
+from .api_model import ApiBaseModel
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from battle_hexes_core.game.objective import Objective
 
 
-class ObjectiveModel(BaseModel):
+class ObjectiveModel(ApiBaseModel):
     """Serialized representation of a board objective."""
 
     row: int

--- a/battle_hexes_api/src/battle_hexes_api/schemas/player.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/player.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from .api_model import ApiBaseModel
 
 from battle_hexes_core.game.player import Player, PlayerType
 
 from .faction import FactionModel
 
 
-class PlayerModel(BaseModel):
+class PlayerModel(ApiBaseModel):
     """Pydantic representation of a core :class:`Player`."""
 
     model_config = ConfigDict(from_attributes=True)

--- a/battle_hexes_api/src/battle_hexes_api/schemas/player_type.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/player_type.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from .api_model import ApiBaseModel
 
 from battle_hexes_api.player_types import PlayerTypeDefinition
 
 
-class PlayerTypeModel(BaseModel):
+class PlayerTypeModel(ApiBaseModel):
     """Serialize player type definitions for API responses."""
 
     id: str

--- a/battle_hexes_api/src/battle_hexes_api/schemas/scenario.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/scenario.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from .api_model import ApiBaseModel
 
 from battle_hexes_core.scenario.scenario import Scenario, ScenarioVictory
 
 
-class ScenarioVictoryModel(BaseModel):
+class ScenarioVictoryModel(ApiBaseModel):
     """Pydantic representation of :class:`ScenarioVictory`."""
 
     model_config = ConfigDict(from_attributes=True)
@@ -17,7 +19,7 @@ class ScenarioVictoryModel(BaseModel):
     description: str | None = None
 
 
-class ScenarioModel(BaseModel):
+class ScenarioModel(ApiBaseModel):
     """Pydantic representation of :class:`Scenario`."""
 
     model_config = ConfigDict(from_attributes=True)

--- a/battle_hexes_api/src/battle_hexes_api/schemas/sparseboard.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/sparseboard.py
@@ -5,7 +5,9 @@ from typing import List, Optional, TYPE_CHECKING
 from battle_hexes_core.game.movement import MovementCalculator
 from battle_hexes_core.game.unitmovementplan import UnitMovementPlan
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from .api_model import ApiBaseModel
 
 from .combat import CombatResultSchema
 
@@ -15,7 +17,7 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from battle_hexes_core.game.board import Board
 
 
-class SparseBoard(BaseModel):
+class SparseBoard(ApiBaseModel):
     """A lightweight representation of the game board used by the API."""
 
     units: List[SparseUnit] = Field(default_factory=list)

--- a/battle_hexes_api/src/battle_hexes_api/schemas/terrain.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/terrain.py
@@ -2,7 +2,9 @@
 
 from typing import Dict, List, Optional, TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from .api_model import ApiBaseModel
 
 from battle_hexes_core.scenario.scenario import Scenario, ScenarioTerrainType
 
@@ -10,7 +12,7 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from battle_hexes_core.game.board import Board
 
 
-class TerrainTypeModel(BaseModel):
+class TerrainTypeModel(ApiBaseModel):
     """Representation of a terrain type."""
 
     name: str
@@ -32,7 +34,7 @@ class TerrainTypeModel(BaseModel):
         )
 
 
-class TerrainHexModel(BaseModel):
+class TerrainHexModel(ApiBaseModel):
     """Sparse terrain hex override used by the frontend."""
 
     row: int
@@ -40,7 +42,7 @@ class TerrainHexModel(BaseModel):
     terrain: str
 
 
-class TerrainSummaryModel(BaseModel):
+class TerrainSummaryModel(ApiBaseModel):
     """Container for terrain defaults, types, and hex overrides."""
 
     default: Optional[str] = None

--- a/battle_hexes_api/src/battle_hexes_api/schemas/unit.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/unit.py
@@ -2,13 +2,13 @@
 
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
+from .api_model import ApiBaseModel
 
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
     from battle_hexes_core.unit.unit import Unit
 
 
-class UnitModel(BaseModel):
+class UnitModel(ApiBaseModel):
     """Model representing a unit's complete state."""
     id: str
     name: str
@@ -41,7 +41,7 @@ class UnitModel(BaseModel):
         )
 
 
-class SparseUnit(BaseModel):
+class SparseUnit(ApiBaseModel):
     """Model representing a unit's minimal state for position updates."""
     id: str
     row: int

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -30,8 +30,8 @@ class TestFastAPI(unittest.TestCase):
                 "columns": 1,
                 "units": [],
                 "terrain": {"default": None, "types": {}, "hexes": []},
-                "road_types": {},
-                "road_paths": [],
+                "roadTypes": {},
+                "roadPaths": [],
             },
             objectives=[],
             scores={},
@@ -64,18 +64,18 @@ class TestFastAPI(unittest.TestCase):
             "#C6AA5C",
         )
         self.assertEqual(
-            terrain.get("types", {}).get("open", {}).get("move_cost"),
+            terrain.get("types", {}).get("open", {}).get("moveCost"),
             1,
         )
         self.assertEqual(
             terrain.get("types", {}).get("open", {}).get(
-                "combat_odds_shift"
+                "combatOddsShift"
             ),
             0,
         )
         self.assertEqual(
             terrain.get("types", {}).get("village", {}).get(
-                "combat_odds_shift"
+                "combatOddsShift"
             ),
             -1,
         )
@@ -86,8 +86,8 @@ class TestFastAPI(unittest.TestCase):
                 {"row": 8, "column": 9, "terrain": "village"},
             ],
         )
-        self.assertEqual(post_body.get("board", {}).get("road_types"), {})
-        self.assertEqual(post_body.get("board", {}).get("road_paths"), [])
+        self.assertEqual(post_body.get("board", {}).get("roadTypes"), {})
+        self.assertEqual(post_body.get("board", {}).get("roadPaths"), [])
 
         get_response = self.client.get(f'/games/{new_game_id}')
         get_body = get_response.json()
@@ -101,7 +101,7 @@ class TestFastAPI(unittest.TestCase):
             .get("terrain", {})
             .get("types", {})
             .get("village", {})
-            .get("combat_odds_shift"),
+            .get("combatOddsShift"),
             -1,
         )
         self.assertEqual(
@@ -111,8 +111,8 @@ class TestFastAPI(unittest.TestCase):
                 {"row": 8, "column": 9, "terrain": "village"},
             ],
         )
-        self.assertEqual(get_body.get("board", {}).get("road_types"), {})
-        self.assertEqual(get_body.get("board", {}).get("road_paths"), [])
+        self.assertEqual(get_body.get("board", {}).get("roadTypes"), {})
+        self.assertEqual(get_body.get("board", {}).get("roadPaths"), [])
 
     def test_create_game_invalid_scenario_returns_404(self):
         payload = {
@@ -163,14 +163,14 @@ class TestFastAPI(unittest.TestCase):
                     "name": "Test Scenario",
                     "description": None,
                     "victory": None,
-                    "stacking_limit": None,
+                    "stackingLimit": None,
                 },
                 {
                     "id": "test-2",
                     "name": "Another Scenario",
                     "description": None,
                     "victory": None,
-                    "stacking_limit": None,
+                    "stackingLimit": None,
                 },
             ],
         )
@@ -351,8 +351,8 @@ class TestFastAPI(unittest.TestCase):
             "00000000-0000-0000-0000-000000000000",
         )
         self.assertEqual(response.json()["plans"], [{"plan": 1}])
-        self.assertEqual(response.json()["defensive_fire_events"], [])
-        self.assertIn("sparse_board", response.json())
+        self.assertEqual(response.json()["defensiveFireEvents"], [])
+        self.assertIn("sparseBoard", response.json())
         self.assertEqual(response.json()["scores"], {"Alice": 3})
         self.assertEqual(response.json()["turnLimit"], 7)
         self.assertEqual(response.json()["turnNumber"], 2)
@@ -396,11 +396,11 @@ class TestFastAPI(unittest.TestCase):
         response = self.client.post("/games/game-789/movement")
 
         self.assertEqual(response.status_code, 200)
-        event = response.json()["defensive_fire_events"][0]
-        self.assertEqual(event["firing_unit_id"], "df-1")
-        self.assertEqual(event["target_unit_id"], "m-1")
+        event = response.json()["defensiveFireEvents"][0]
+        self.assertEqual(event["firingUnitId"], "df-1")
+        self.assertEqual(event["targetUnitId"], "m-1")
         self.assertEqual(event["outcome"], "retreat")
-        self.assertEqual(event["retreat_destination"], [0, 1])
+        self.assertEqual(event["retreatDestination"], [0, 1])
         self.assertIn("forced the target to retreat", event["message"])
 
     @patch('battle_hexes_api.main.SparseBoard.from_board')
@@ -441,7 +441,7 @@ class TestFastAPI(unittest.TestCase):
         mock_to_movement_plans.assert_called_once_with(mock_board)
         mock_game.apply_movement_plans.assert_called_once_with([mock_plan])
         mock_scorer.assert_not_called()
-        self.assertEqual(response.json()["defensive_fire_events"], [])
+        self.assertEqual(response.json()["defensiveFireEvents"], [])
         self.assertEqual(response.json()["scores"], {"Alice": 4})
 
     @patch('battle_hexes_api.main.SparseBoard.from_board')
@@ -494,7 +494,7 @@ class TestFastAPI(unittest.TestCase):
             response.json()["game"]["id"],
             "00000000-0000-0000-0000-000000000000",
         )
-        self.assertEqual(response.json()["defensive_fire_events"], [])
+        self.assertEqual(response.json()["defensiveFireEvents"], [])
         self.assertEqual(response.json()["scores"], {"Alice": 5})
         self.assertEqual(response.json()["turnLimit"], 9)
         self.assertEqual(response.json()["turnNumber"], 4)
@@ -539,7 +539,7 @@ class TestFastAPI(unittest.TestCase):
                     "id": "m-2",
                     "row": 2,
                     "column": 2,
-                    "defensive_fire_available": False,
+                    "defensiveFireAvailable": False,
                 }
             ]
         )
@@ -554,16 +554,16 @@ class TestFastAPI(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json()["sparse_board"]["units"][0],
+            response.json()["sparseBoard"]["units"][0],
             {
                 "id": "m-2",
                 "row": 2,
                 "column": 2,
-                "defensive_fire_available": False,
+                "defensiveFireAvailable": False,
             },
         )
         self.assertEqual(
-            response.json()["defensive_fire_events"][0]["outcome"],
+            response.json()["defensiveFireEvents"][0]["outcome"],
             "no_effect",
         )
         self.assertEqual(response.json()["scores"], {"Alice": 5})

--- a/specs/naming-casing-cleanup-inventory.md
+++ b/specs/naming-casing-cleanup-inventory.md
@@ -1,0 +1,168 @@
+# API Naming/Casing Inventory
+
+This inventory supports phase 1 of `specs/naming-casing-cleanup.md`. It lists
+API request and response schema fields and their canonical HTTP JSON keys.
+Python model attributes remain `snake_case`; the HTTP boundary is `camelCase`.
+
+## Request Schemas
+
+### `CreateGameRequest`
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `scenario_id` | `scenarioId` |
+| `player_types` | `playerTypes` |
+
+### `SparseBoard`
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `units` | `units` |
+| `last_combat_results` | `lastCombatResults` |
+| `scores` | `scores` |
+
+### `SparseUnit`
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `id` | `id` |
+| `row` | `row` |
+| `column` | `column` |
+| `defensive_fire_available` | `defensiveFireAvailable` |
+
+## Response Schemas
+
+### Game payload
+
+| Python attribute / route metadata | HTTP JSON key |
+| --- | --- |
+| `id` | `id` |
+| `players` | `players` |
+| `board` | `board` |
+| `objectives` | `objectives` |
+| `scores` | `scores` |
+| `turn_limit` | `turnLimit` |
+| `turn_number` | `turnNumber` |
+| `scenario_id` route metadata | `scenarioId` |
+| `scenario.name` route metadata | `scenarioName` |
+| `scenario.stacking_limit` route metadata | `stackingLimit` |
+| `player_type_ids` route metadata | `playerTypeIds` |
+
+### Board payload
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `rows` | `rows` |
+| `columns` | `columns` |
+| `units` | `units` |
+| `terrain` | `terrain` |
+| `road_types` | `roadTypes` |
+| `road_paths` | `roadPaths` |
+
+### Road path payload
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `type` | `type` |
+| `path` | `path` |
+| `row` | `row` |
+| `column` | `column` |
+
+### Unit payload
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `id` | `id` |
+| `name` | `name` |
+| `faction_id` | `factionId` |
+| `type` | `type` |
+| `attack` | `attack` |
+| `echelon` | `echelon` |
+| `defense` | `defense` |
+| `move` | `move` |
+| `row` | `row` |
+| `column` | `column` |
+| `defensive_fire_available` | `defensiveFireAvailable` |
+
+### Terrain payload
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `default` | `default` |
+| `types` | `types` |
+| `hexes` | `hexes` |
+| `name` | `name` |
+| `color` | `color` |
+| `move_cost` | `moveCost` |
+| `combat_odds_shift` | `combatOddsShift` |
+| `row` | `row` |
+| `column` | `column` |
+| `terrain` | `terrain` |
+
+### Movement response payload
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `game` | `game` |
+| `plans` | `plans` |
+| `sparse_board` | `sparseBoard` |
+| `defensive_fire_events` | `defensiveFireEvents` |
+| `scores` | `scores` |
+| `turn_limit` | `turnLimit` |
+| `turn_number` | `turnNumber` |
+
+### Defensive fire event payload
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `firing_unit_id` | `firingUnitId` |
+| `target_unit_id` | `targetUnitId` |
+| `trigger_hex` | `triggerHex` |
+| `target_hex_before` | `targetHexBefore` |
+| `outcome` | `outcome` |
+| `retreat_destination` | `retreatDestination` |
+| `spent_defensive_fire` | `spentDefensiveFire` |
+| `probability` | `probability` |
+| `roll` | `roll` |
+| `message` | `message` |
+
+### Combat result payload
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `combat_result_code` | `combatResultCode` |
+| `combat_result_text` | `combatResultText` |
+| `odds` | `odds` |
+| `base_odds` | `baseOdds` |
+| `final_odds` | `finalOdds` |
+| `die_roll` | `dieRoll` |
+| `no_retreat_unit_ids` | `noRetreatUnitIds` |
+
+### Scenario list payload
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `id` | `id` |
+| `name` | `name` |
+| `description` | `description` |
+| `victory` | `victory` |
+| `method` | `method` |
+| `scoring_side` | `scoringSide` |
+| `stacking_limit` | `stackingLimit` |
+
+### Player and player type payloads
+
+| Python attribute | HTTP JSON key |
+| --- | --- |
+| `name` | `name` |
+| `type` | `type` |
+| `factions` | `factions` |
+| `id` | `id` |
+| `color` | `color` |
+| `sounds` | `sounds` |
+
+## Scenario JSON Regression Scope
+
+Scenario authoring JSON under `battle_hexes_core/src/battle_hexes_core/scenarios/`
+remains `snake_case`. Loader regression coverage should keep exercising keys
+such as `move_cost`, `combat_odds_shift`, `road_types`, and `edge_move_cost`.


### PR DESCRIPTION
### Motivation

- Resolve inconsistent snake_case / camelCase usage across the core, API, and frontend by making the HTTP API a canonical camelCase contract while keeping Python internals idiomatic snake_case. 
- Remove scattered ad-hoc route- and frontend-level casing conversions and centralize the snake-to-camel mapping to reduce accidental mixed-casing in responses and mocks. 
- Provide an explicit inventory of API fields to guide incremental migration and tests.

### Description

- Add a shared API base model `ApiBaseModel` with a snake-to-camel `alias_generator` and `populate_by_name=True` so Pydantic schemas use snake_case attributes but emit camelCase JSON (`battle_hexes_api/src/battle_hexes_api/schemas/api_model.py`).
- Convert API schemas to inherit from `ApiBaseModel` and update schema fields where needed so the aliasing is mechanical rather than hand-coded (several `schemas/*.py` changes). 
- Introduce `_dump_api_model` and wire route serialization to dump models using client-facing aliases for game, combat, movement, end-movement, and end-turn responses; remove ad-hoc manual pop/rename logic and ensure route metadata like `scenarioId`, `stackingLimit`, `playerTypeIds`, `turnLimit`, and `turnNumber` are present (changes in `battle_hexes_api/src/battle_hexes_api/main.py`).
- Add a canonical API inventory `specs/naming-casing-cleanup-inventory.md` documenting request and response field names for the migration. 
- Update the frontend service boundary, response mappers, mock responses, and affected tests to consume/produce canonical camelCase keys (changes under `battle-hexes-web/src/*`, `battle-hexes-web/src/service/mock-responses/*`, and related tests).

### Testing

- Ran Python API unit tests with `PYTHONPATH=battle_hexes_api/src:battle_hexes_core/src:battle_agent_rl/src pytest battle_hexes_api/tests` and all tests passed. 
- Ran full server-side checks `./server-side-checks.sh` which executed core, agent, and API test suites and linters and all passed. 
- Ran frontend unit tests with `npm test -- --runInBand` and verified the web test suite passed. 
- Performed a full web build via `npm run test-and-build` (lint, test, build) and the build and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36fc5cfdb4832787d059e474ee3137)