### PR TITLE
Implement API alias cleanup (Phase 2)

### DIFF
--- a/battle_hexes_api/src/battle_hexes_api/schemas/create_game.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/create_game.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List
 
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import Field, field_validator
 
 from .api_model import ApiBaseModel
 
@@ -12,13 +12,11 @@ from .api_model import ApiBaseModel
 class CreateGameRequest(ApiBaseModel):
     """Request body for the ``POST /games`` endpoint."""
 
-    scenario_id: str = Field(alias="scenarioId")
+    scenario_id: str
     player_types: List[str] = Field(
-        alias="playerTypes", min_length=2, max_length=2,
+        min_length=2, max_length=2,
         description="Identifiers for the desired player implementations.",
     )
-
-    model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("player_types")
     def _validate_player_types(cls, value: List[str]) -> List[str]:

--- a/battle_hexes_api/src/battle_hexes_api/schemas/movement.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/movement.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import ConfigDict, Field
+from pydantic import Field
 
 from .api_model import ApiBaseModel
 
@@ -60,8 +60,6 @@ class DefensiveFireEventModel(ApiBaseModel):
 class MovementResponseModel(ApiBaseModel):
     """Movement endpoint payload including board updates and reactions."""
 
-    model_config = ConfigDict(populate_by_name=True)
-
     game: GameModel
     plans: list[dict[str, Any]] = Field(default_factory=list)
     sparse_board: SparseBoard
@@ -69,14 +67,8 @@ class MovementResponseModel(ApiBaseModel):
         default_factory=list
     )
     scores: dict[str, int] = Field(default_factory=dict)
-    turn_limit: int | None = Field(
-        default=None,
-        serialization_alias="turnLimit",
-    )
-    turn_number: int = Field(
-        default=1,
-        serialization_alias="turnNumber",
-    )
+    turn_limit: int | None = None
+    turn_number: int = 1
 
     @classmethod
     def from_movement_result(

--- a/battle_hexes_api/tests/test_schemas.py
+++ b/battle_hexes_api/tests/test_schemas.py
@@ -1,6 +1,7 @@
 import unittest
 
 from battle_hexes_api.schemas import (
+    CreateGameRequest,
     DefensiveFireEventModel,
     GameModel,
     MovementResponseModel,
@@ -18,6 +19,72 @@ from battle_hexes_core.game.terrain import Terrain
 from battle_hexes_core.scenario.scenario import Scenario, ScenarioVictory
 from battle_hexes_core.unit.faction import Faction
 from battle_hexes_core.unit.unit import Unit
+
+
+class TestApiAliases(unittest.TestCase):
+    def test_create_game_request_accepts_camel_case_aliases(self):
+        request = CreateGameRequest.model_validate({
+            "scenarioId": "elim_1",
+            "playerTypes": ["human", "random"],
+        })
+
+        self.assertEqual(request.scenario_id, "elim_1")
+        self.assertEqual(request.player_types, ["human", "random"])
+
+    def test_game_model_dumps_nested_camel_case_aliases(self):
+        model = GameModel(
+            id="00000000-0000-0000-0000-000000000000",
+            players=[],
+            board={
+                "rows": 1,
+                "columns": 1,
+                "units": [
+                    {
+                        "id": "unit-1",
+                        "name": "Unit 1",
+                        "factionId": "allies",
+                        "type": "Infantry",
+                        "attack": 2,
+                        "defense": 3,
+                        "move": 4,
+                        "row": 0,
+                        "column": 0,
+                    }
+                ],
+                "terrain": {
+                    "default": "open",
+                    "types": {
+                        "open": {
+                            "name": "Open",
+                            "color": "#C6AA5C",
+                            "moveCost": 1,
+                            "combatOddsShift": 0,
+                        }
+                    },
+                    "hexes": [],
+                },
+                "roadTypes": {"secondary": 1.0},
+                "roadPaths": [],
+            },
+            objectives=[],
+            scores={},
+            turn_limit=10,
+            turn_number=2,
+        )
+
+        payload = model.model_dump(by_alias=True)
+
+        self.assertEqual(payload["turnLimit"], 10)
+        self.assertEqual(payload["turnNumber"], 2)
+        self.assertIn("roadTypes", payload["board"])
+        self.assertIn("roadPaths", payload["board"])
+        self.assertEqual(
+            payload["board"]["units"][0]["factionId"],
+            "allies",
+        )
+        terrain = payload["board"]["terrain"]["types"]["open"]
+        self.assertEqual(terrain["moveCost"], 1)
+        self.assertEqual(terrain["combatOddsShift"], 0)
 
 
 class TestScenarioModel(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- Continue the API casing cleanup by relying on the shared snake-to-camel alias generator so individual schemas no longer need per-field alias plumbing. 
- Reduce duplicated/hand-rolled serialization aliases and make response/request models consistently emit and accept `camelCase` JSON at the API boundary. 

### Description
- Removed explicit per-field aliases from `CreateGameRequest` so it uses the shared `ApiBaseModel` alias behavior for `scenario_id` and `player_types` (file: `schemas/create_game.py`).
- Removed explicit `serialization_alias` and `model_config` overrides from `MovementResponseModel` and reverted `turn_limit`/`turn_number` to plain attributes to rely on the shared alias infrastructure (file: `schemas/movement.py`).
- Added unit tests that exercise canonical camelCase input and output, including `CreateGameRequest` accepting `scenarioId`/`playerTypes` and `GameModel.model_dump(by_alias=True)` emitting nested keys like `factionId`, `roadTypes`, `moveCost`, and `combatOddsShift` (file: `tests/test_schemas.py`).

### Testing
- Ran `./server-side-checks.sh` which runs the Python test suites and linters across the repo, and all automated tests passed: `battle_hexes_core` (167 passed), `battle_agent_rl` (17 passed), and `battle_hexes_api` (44 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37037da5388327bf17ae05f7571db9)