### PR TITLE
Implement phase 3 casing cleanup (frontend mocks & consumers)

### DIFF
--- a/battle-hexes-web/src/model/combat-resolver.js
+++ b/battle-hexes-web/src/model/combat-resolver.js
@@ -16,7 +16,7 @@ export class CombatResolver {
     console.log(`${this.#gameId} - ${sparseBoard}`);
 
     const combatResult = await this.service.resolveCombat(this.#gameId, sparseBoard);
-    console.log('combat result: ', combatResult.last_combat_results);
+    console.log('combat result: ', combatResult.lastCombatResults);
     console.log('new board state: ', combatResult.units);
 
     const boardUpdater = new BoardUpdater();

--- a/battle-hexes-web/src/player/cpu-player.js
+++ b/battle-hexes-web/src/player/cpu-player.js
@@ -4,6 +4,8 @@ import { eventBus } from '../event-bus.js';
 import { MovementAnimator } from '../animation/movement-animator.js';
 import { applyMovementResponse } from '../model/movement-response-handler.js';
 
+const getMovementPlanUnitId = (plan) => plan.unitId ?? plan.unit_id;
+
 export class CpuPlayer extends Player {
   static PHASE_DELAY_MS = 333;
 
@@ -27,7 +29,7 @@ export class CpuPlayer extends Player {
         const animator = new MovementAnimator(game.getBoard());
         for (const plan of responseData.plans) {
           const unit = [...game.getBoard().units].find(
-            u => u.getId() === plan.unitId
+            u => u.getId() === getMovementPlanUnitId(plan)
           );
           if (unit) {
             const path = plan.path.map(h =>

--- a/battle-hexes-web/src/player/cpu-player.js
+++ b/battle-hexes-web/src/player/cpu-player.js
@@ -27,7 +27,7 @@ export class CpuPlayer extends Player {
         const animator = new MovementAnimator(game.getBoard());
         for (const plan of responseData.plans) {
           const unit = [...game.getBoard().units].find(
-            u => u.getId() === plan.unit_id
+            u => u.getId() === plan.unitId
           );
           if (unit) {
             const path = plan.path.map(h =>

--- a/battle-hexes-web/src/service/mock-battle-hexes-service.js
+++ b/battle-hexes-web/src/service/mock-battle-hexes-service.js
@@ -67,7 +67,7 @@ export class MockBattleHexesService extends BattleHexesService {
     console.log('Returning mock response for resolveCombat.');
     return Promise.resolve({
       units: [],
-      last_combat_results: [],
+      lastCombatResults: [],
       scores: {},
       turnNumber: 1,
       turnLimit: null,

--- a/battle-hexes-web/src/service/mock-responses/move.json
+++ b/battle-hexes-web/src/service/mock-responses/move.json
@@ -355,12 +355,12 @@
             "Player 1": 0,
             "Player 2": 3
         },
-        "turn_limit": 8,
+        "turnLimit": 8,
         "turnNumber": 2
     },
     "plans": [
         {
-            "unit_id": "Airborne Inf. A",
+            "unitId": "Airborne Inf. A",
             "path": [
                 {
                     "row": 8,
@@ -455,11 +455,11 @@
         {
             "firingUnitId": "Crossroads Feldwache",
             "targetUnitId": "Airborne Inf. A",
-            "trigger_hex": [
+            "triggerHex": [
                 7,
                 9
             ],
-            "target_hex_before": [
+            "targetHexBefore": [
                 7,
                 9
             ],
@@ -468,7 +468,7 @@
                 8,
                 9
             ],
-            "spent_defensive_fire": true,
+            "spentDefensiveFire": true,
             "probability": 0.125,
             "roll": 0.07586604005985398,
             "message": "Defensive fire forced the target to retreat to (8, 9)."

--- a/battle-hexes-web/tests/player/cpu-player.test.js
+++ b/battle-hexes-web/tests/player/cpu-player.test.js
@@ -184,7 +184,7 @@ describe('CpuPlayer', () => {
       game: { board: { units: [] } },
       plans: [
         {
-          unit_id: 'unit-001',
+          unitId: 'unit-001',
           path: [ { row: 0, column: 0 }, { row: 0, column: 1 } ],
         },
       ],

--- a/battle-hexes-web/tests/player/cpu-player.test.js
+++ b/battle-hexes-web/tests/player/cpu-player.test.js
@@ -172,7 +172,7 @@ describe('CpuPlayer', () => {
     expect(updateTurnStateSpy).not.toHaveBeenCalled();
   });
 
-  test('animates movement plans returned from server', async () => {
+  test('animates movement plans returned from server using canonical camelCase keys', async () => {
     jest.useFakeTimers();
     const board = new Board(1, 2);
     const players = new Players([cpuPlayer, new Player('Dummy')]);
@@ -185,6 +185,38 @@ describe('CpuPlayer', () => {
       plans: [
         {
           unitId: 'unit-001',
+          path: [ { row: 0, column: 0 }, { row: 0, column: 1 } ],
+        },
+      ],
+    });
+
+    const playPromise = cpuPlayer.play(game);
+    await Promise.resolve();
+
+    await jest.runOnlyPendingTimersAsync();
+    await Promise.resolve();
+
+    expect(MovementAnimator).toHaveBeenCalledWith(game.getBoard());
+    expect(MovementAnimator.mock.calls.length).toBeGreaterThan(1);
+    expect(mockUpdateBoard).toHaveBeenCalled();
+
+    await jest.runOnlyPendingTimersAsync();
+    await playPromise;
+  });
+
+  test('animates movement plans returned from current HTTP API snake_case keys', async () => {
+    jest.useFakeTimers();
+    const board = new Board(1, 2);
+    const players = new Players([cpuPlayer, new Player('Dummy')]);
+    game = new Game('g2', ['Movement', 'End Turn'], players, board);
+    jest.spyOn(game, 'isGameOver').mockReturnValue(false);
+    const unit = new Unit('unit-001');
+    board.addUnit(unit, 0, 0);
+    mockService.generateCpuMovement.mockResolvedValueOnce({
+      game: { board: { units: [] } },
+      plans: [
+        {
+          unit_id: 'unit-001',
           path: [ { row: 0, column: 0 }, { row: 0, column: 1 } ],
         },
       ],

--- a/battle-hexes-web/tests/service/mock-battle-hexes-service.test.js
+++ b/battle-hexes-web/tests/service/mock-battle-hexes-service.test.js
@@ -28,3 +28,39 @@ describe('MockBattleHexesService', () => {
     expect(secondResponse.board.units[0].name).not.toBe('changed');
   });
 });
+
+describe('mock API payload casing', () => {
+  const mockResponseDirectory = path.resolve('src/service/mock-responses');
+  const snakeCaseKeyPattern = /^[a-z][a-z0-9]*(_[a-z0-9]+)+$/;
+
+  function collectSnakeCaseKeys(value, pathSegments = []) {
+    if (Array.isArray(value)) {
+      return value.flatMap((item, index) => collectSnakeCaseKeys(item, [...pathSegments, `[${index}]`]));
+    }
+
+    if (!value || typeof value !== 'object') {
+      return [];
+    }
+
+    return Object.entries(value).flatMap(([key, nestedValue]) => {
+      const currentPath = [...pathSegments, key];
+      const matches = snakeCaseKeyPattern.test(key) ? [currentPath.join('.')] : [];
+      return [...matches, ...collectSnakeCaseKeys(nestedValue, currentPath)];
+    });
+  }
+
+  test('uses camelCase keys in frontend mock API responses', () => {
+    const mockResponseFiles = fs
+      .readdirSync(mockResponseDirectory)
+      .filter((fileName) => fileName.endsWith('.json'));
+
+    const snakeCaseKeys = mockResponseFiles.flatMap((fileName) => {
+      const payload = JSON.parse(
+        fs.readFileSync(path.join(mockResponseDirectory, fileName), 'utf8'),
+      );
+      return collectSnakeCaseKeys(payload).map((keyPath) => `${fileName}:${keyPath}`);
+    });
+
+    expect(snakeCaseKeys).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Finish Phase 3 of the naming/casing cleanup by converting frontend mock payloads and frontend consumers to the canonical `camelCase` API JSON contract.
- Prevent regressions by adding an automated check that ensures frontend mock responses do not contain `snake_case` keys.

### Description
- Converted keys in frontend mock movement payloads to `camelCase` (example: `turn_limit` → `turnLimit`, `unit_id` → `unitId`, `trigger_hex` → `triggerHex`, `target_hex_before` → `targetHexBefore`, `spent_defensive_fire` → `spentDefensiveFire`, `lastCombatResults` used instead of `last_combat_results`).
- Updated frontend consumers to read the canonical fields (example: `plan.unitId` in `CpuPlayer`, `combatResult.lastCombatResults` in `CombatResolver`).
- Updated the mock service to emit camelCase keys for combat results and movement payloads (`MockBattleHexesService`).
- Added a regression test that scans all frontend mock JSON files and fails if any `snake_case` keys are present (`tests/service/mock-battle-hexes-service.test.js`).

### Testing
- Ran the focused tests with `npm test -- --runTestsByPath tests/service/mock-battle-hexes-service.test.js tests/player/cpu-player.test.js`, and they passed.
- Ran the full web package check and build with `npm run test-and-build`, and the suite completed successfully (32 test suites, 195 tests passed) and the webpack build succeeded.
- All modified tests and added regression test passed after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3705c680b0832790bf85d9f12fdd33)