### PR TITLE
Normalize faction sound keys to camelCase in API and update frontend

### DIFF
--- a/battle-hexes-web/src/sound-player.js
+++ b/battle-hexes-web/src/sound-player.js
@@ -33,8 +33,8 @@ export class SoundPlayer {
   }
 
   #resolveDefensiveFireSoundFilename(event) {
-    const soundKey = event?.outcome === 'no_effect' ? 'no_effect' : 'effect';
-    return this.#resolveFactionSoundForEvent(event, ['defensive_fire', soundKey]);
+    const soundKey = event?.outcome === 'no_effect' ? 'noEffect' : 'effect';
+    return this.#resolveFactionSoundForEvent(event, ['defensiveFire', soundKey]);
   }
 
   #resolveFactionSoundForEvent(event, soundPath) {

--- a/battle-hexes-web/tests/model/game-creator.test.js
+++ b/battle-hexes-web/tests/model/game-creator.test.js
@@ -10,7 +10,7 @@ beforeEach(() => {
     '"scenarioId":"elem_test",' +
     '"stackingLimit":2,' +
     '"playerTypeIds":["human","q-learning"],"turnLimit":9,"turnNumber":2,' +
-    '"players":[{"name":"Player 1","type":"Human","factions":[{"id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","name":"Red Faction","color":"#C81010","sounds":{"defensive_fire":{"effect":"red_effect.ogg","no_effect":"red_no_effect.ogg"}}}]},' +
+    '"players":[{"name":"Player 1","type":"Human","factions":[{"id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","name":"Red Faction","color":"#C81010","sounds":{"defensiveFire":{"effect":"red_effect.ogg","noEffect":"red_noEffect.ogg"}}}]},' +
     '{"name":"Player 2","type":"Computer","factions":[{"id":"38400000-8cf0-41bd-b23e-10b96e4ef00d","name":"Blue Faction","color":"#4682B4"}]}],' +
     '"board":{"rows":10,"columns":10,"units":[' +
     '{"id":"a22c90d0-db87-41d0-8c3a-00c04fd708be","name":"Red Unit","factionId":"f47ac10b-58cc-4372-a567-0e02b2c3d479","type":"Infantry","echelon":"platoon","attack":2,"defense":2,"move":6,"row":6,"column":4,"defensiveFireAvailable":false},' +
@@ -52,9 +52,9 @@ describe("createGame", () => {
     const redFaction = game.getPlayers().getAllPlayers()[0].getFactions()[0];
 
     expect(redFaction.getSounds()).toEqual({
-      defensive_fire: {
+      defensiveFire: {
         effect: 'red_effect.ogg',
-        no_effect: 'red_no_effect.ogg',
+        noEffect: 'red_noEffect.ogg',
       },
     });
   });

--- a/battle-hexes-web/tests/model/game.test.js
+++ b/battle-hexes-web/tests/model/game.test.js
@@ -192,7 +192,7 @@ describe('resolveCombat', () => {
 
   test('resolves firing faction from unit id in board state', () => {
     const faction = new Faction('f1', 'Faction 1', '#f00', {
-      defensive_fire: { effect: 'f1_effect.ogg' },
+      defensiveFire: { effect: 'f1_effect.ogg' },
     });
     faction.setOwningPlayer(player1);
     const unit = new Unit('u1', 'Unit1', faction, null, 1, 1, 2);

--- a/battle-hexes-web/tests/sound-player.test.js
+++ b/battle-hexes-web/tests/sound-player.test.js
@@ -11,7 +11,7 @@ const createAudioFactory = (playImpl = () => Promise.resolve()) => {
 describe('SoundPlayer defensive fire playback', () => {
   test('plays effect sound from the firing unit faction for non-no_effect outcomes', async () => {
     const faction = new Faction('red', 'Red', '#f00', {
-      defensive_fire: {
+      defensiveFire: {
         effect: 'm1_single_rifle_shot.ogg',
       },
     });
@@ -29,8 +29,8 @@ describe('SoundPlayer defensive fire playback', () => {
 
   test('plays no_effect sound for no_effect outcomes', async () => {
     const faction = new Faction('red', 'Red', '#f00', {
-      defensive_fire: {
-        no_effect: 'k98_distant.ogg',
+      defensiveFire: {
+        noEffect: 'k98_distant.ogg',
       },
     });
     const game = {
@@ -46,7 +46,7 @@ describe('SoundPlayer defensive fire playback', () => {
 
   test('stays silent for missing defensive fire config or empty filename', async () => {
     const faction = new Faction('red', 'Red', '#f00', {
-      defensive_fire: {
+      defensiveFire: {
         effect: '',
       },
     });
@@ -66,10 +66,10 @@ describe('SoundPlayer defensive fire playback', () => {
 
   test('uses each firing unit faction mapping independently', async () => {
     const redFaction = new Faction('red', 'Red', '#f00', {
-      defensive_fire: { effect: 'red_effect.ogg' },
+      defensiveFire: { effect: 'red_effect.ogg' },
     });
     const blueFaction = new Faction('blue', 'Blue', '#00f', {
-      defensive_fire: { effect: 'blue_effect.ogg' },
+      defensiveFire: { effect: 'blue_effect.ogg' },
     });
     const game = {
       getFactionForUnitId: jest.fn((unitId) => (unitId === 'red-unit' ? redFaction : blueFaction)),
@@ -88,7 +88,7 @@ describe('SoundPlayer defensive fire playback', () => {
 
   test('logs warning and continues when playback fails', async () => {
     const faction = new Faction('red', 'Red', '#f00', {
-      defensive_fire: {
+      defensiveFire: {
         effect: 'red_effect.ogg',
       },
     });

--- a/battle_hexes_api/sample-game-data.json
+++ b/battle_hexes_api/sample-game-data.json
@@ -31,35 +31,35 @@
       {
         "id": "red_unit_1",
         "name": "Red Unit",
-        "faction_id": "red faction",
         "type": "Infantry",
         "attack": 2,
         "defense": 2,
         "move": 6,
         "row": 2,
-        "column": 2
+        "column": 2,
+        "factionId": "red faction"
       },
       {
         "id": "blue_unit_1",
         "name": "Blue Unit",
-        "faction_id": "blue faction",
         "type": "Infantry",
         "attack": 4,
         "defense": 4,
         "move": 4,
         "row": 8,
-        "column": 9
+        "column": 9,
+        "factionId": "blue faction"
       },
       {
         "id": "blue_unit_2",
         "name": "Blue Two",
-        "faction_id": "blue faction",
         "type": "Scout",
         "attack": 2,
         "defense": 2,
         "move": 6,
         "row": 9,
-        "column": 5
+        "column": 5,
+        "factionId": "blue faction"
       }
     ],
     "terrain": {
@@ -81,7 +81,9 @@
           "terrain": "village"
         }
       ]
-    }
+    },
+    "roadTypes": {},
+    "roadPaths": []
   },
   "objectives": [
     {

--- a/battle_hexes_api/src/battle_hexes_api/schemas/api_model.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/api_model.py
@@ -10,6 +10,19 @@ def to_camel(value: str) -> str:
     return words[0] + "".join(word.capitalize() for word in words[1:])
 
 
+def to_snake(value: str) -> str:
+    """Convert a lower camelCase field name to snake_case."""
+
+    output = []
+    for character in value:
+        if character.isupper():
+            output.append("_")
+            output.append(character.lower())
+        else:
+            output.append(character)
+    return "".join(output)
+
+
 class ApiBaseModel(BaseModel):
     """Base model that exposes camelCase JSON aliases for API payloads."""
 

--- a/battle_hexes_api/src/battle_hexes_api/schemas/faction.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/faction.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import ConfigDict, Field
 
-from .api_model import ApiBaseModel
+from .api_model import ApiBaseModel, to_camel, to_snake
 
 from battle_hexes_core.unit.faction import Faction
 
@@ -23,7 +23,12 @@ class FactionModel(ApiBaseModel):
     def from_core(cls, faction: Faction) -> "FactionModel":
         """Create a ``FactionModel`` from a core :class:`Faction`."""
 
-        return cls.model_validate(faction)
+        return cls(
+            id=faction.id,
+            name=faction.name,
+            color=faction.color,
+            sounds=cls._camelize_sound_keys(faction.sounds),
+        )
 
     def to_core(self) -> Faction:
         """Convert the Pydantic model back into a core :class:`Faction`."""
@@ -32,5 +37,32 @@ class FactionModel(ApiBaseModel):
             id=self.id,
             name=self.name,
             color=self.color,
-            sounds=self.sounds,
+            sounds=self._snakeize_sound_keys(self.sounds),
         )
+
+    @classmethod
+    def _camelize_sound_keys(cls, value):
+        """Convert scenario-authored sound keys to the API casing contract."""
+
+        return cls._convert_sound_keys(value, to_camel)
+
+    @classmethod
+    def _snakeize_sound_keys(cls, value):
+        """Convert API sound keys back to the core scenario casing."""
+
+        return cls._convert_sound_keys(value, to_snake)
+
+    @classmethod
+    def _convert_sound_keys(cls, value, converter):
+        if isinstance(value, dict):
+            return {
+                converter(key) if isinstance(key, str) else key:
+                cls._convert_sound_keys(nested_value, converter)
+                for key, nested_value in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                cls._convert_sound_keys(nested_value, converter)
+                for nested_value in value
+            ]
+        return value

--- a/battle_hexes_api/tests/test_schemas.py
+++ b/battle_hexes_api/tests/test_schemas.py
@@ -3,6 +3,7 @@ import unittest
 from battle_hexes_api.schemas import (
     CreateGameRequest,
     DefensiveFireEventModel,
+    FactionModel,
     GameModel,
     MovementResponseModel,
     ScenarioModel,
@@ -85,6 +86,31 @@ class TestApiAliases(unittest.TestCase):
         terrain = payload["board"]["terrain"]["types"]["open"]
         self.assertEqual(terrain["moveCost"], 1)
         self.assertEqual(terrain["combatOddsShift"], 0)
+
+    def test_faction_model_exposes_nested_sound_keys_as_camel_case(self):
+        faction = Faction(
+            id="allies",
+            name="Allies",
+            color="#556B2F",
+            sounds={
+                "defensive_fire": {
+                    "effect": "m1_single_rifle_shot.ogg",
+                    "no_effect": "m1_no_effect.ogg",
+                },
+            },
+        )
+
+        payload = FactionModel.from_core(faction).model_dump(by_alias=True)
+
+        self.assertEqual(
+            payload["sounds"],
+            {
+                "defensiveFire": {
+                    "effect": "m1_single_rifle_shot.ogg",
+                    "noEffect": "m1_no_effect.ogg",
+                },
+            },
+        )
 
 
 class TestScenarioModel(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- The naming/casing cleanup spec requires the HTTP API to expose `camelCase` JSON while Python internals remain `snake_case`, and one remaining gap was faction `sounds` payloads which still used `snake_case` keys like `defensive_fire`/`no_effect`.
- Update frontend sound lookup and mock/sample payloads to the canonical API contract so casing is consistent end-to-end and tests/mocks reflect the client-facing JSON shape.

### Description
- Add a `to_snake` helper alongside `to_camel` in `schemas/api_model.py` to support reversible casing conversions for nested maps used by the API.
- Update `FactionModel` (`schemas/faction.py`) to convert core/scenario `sounds` (snake_case) into API `camelCase` on serialization and to convert back to `snake_case` when building core models, using a recursive `_convert_sound_keys` helper.
- Change the web frontend sound lookup in `battle-hexes-web/src/sound-player.js` to read the API camelCase keys (`defensiveFire` / `noEffect`) while keeping event `outcome` values unchanged.
- Update sample/mock payloads and tests to the canonical casing (examples: `battle_hexes_api/sample-game-data.json`, `battle-hexes-web` tests and `battle_hexes_api` schema tests) so mocks and assertions expect `camelCase` API JSON.

### Testing
- Ran the repository Python checks with `./server-side-checks.sh`, which executed unit tests across `battle_hexes_core`, `battle_agent_rl`, and `battle_hexes_api`; all Python tests passed (total suite passed).
- Ran frontend tests with `cd battle-hexes-web && npm test -- --runInBand`, which passed (all Jest suites green), and ran `npm run test-and-build`, which ran lint, tests and produced a successful webpack build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a371c57329883279badf9992b13607a)