### PR TITLE
Expose core-computed game status to API and add evaluator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,15 @@ tests and linter across **all** Python packages. The script adjusts
   PR to ensure tests and linting pass. If `flake8` is missing from the
   environment, install it before running the checks (e.g. `pip install flake8`).
 
+
+### API/Core/Schema Boundaries
+
+- Core owns game rules, scoring, victory detection, and the timing of game-status evaluation.
+- API routes orchestrate requests and core operations but do not execute or invoke game-rule evaluators.
+- Code under `battle_hexes_api/.../schemas` contains API data models, validation, serialization, and conversion from already-computed core results.
+- Schema modules must not execute game logic.
+- `main.py` should remain thin and must not contain schema assembly helpers or import core evaluators such as `GameStatusEvaluator`.
+
 ### Working with the Web Frontend
 
 - Install Node dependencies inside `battle-hexes-web` with `npm install`.

--- a/battle_hexes_api/src/battle_hexes_api/main.py
+++ b/battle_hexes_api/src/battle_hexes_api/main.py
@@ -27,7 +27,6 @@ from battle_hexes_core.scenario.scenarioregistry import (  # noqa: E402
 from battle_hexes_api.player_types import list_player_types  # noqa: E402
 from battle_hexes_api.gamecreator import GameCreator  # noqa: E402
 from battle_hexes_api.schemas import (  # noqa: E402
-    CombatResultSchema,
     CreateGameRequest,
     GameModel,
     MovementResponseModel,
@@ -171,15 +170,11 @@ def resolve_combat(
 
     game_repo.update_game(game)
     _call_end_game_callbacks(game)
-    sparse_board = SparseBoard.from_board(game.get_board())
-    sparse_board.scores = game.get_score_tracker().get_scores()
-    sparse_board.last_combat_results = [
-        CombatResultSchema.from_combat_result_data(battle)
-        for battle in results.get_battles()
-    ]
-    if not isinstance(sparse_board, SparseBoard):
-        return {}
-    return _dump_api_model(sparse_board)
+    return _dump_api_model(SparseBoard.from_game(
+        game,
+        include_scores=True,
+        combat_results=results,
+    ))
 
 
 @app.post('/games/{game_id}/movement')
@@ -246,14 +241,13 @@ def end_turn(game_id: str, sparse_board: SparseBoard = Body(...)):
 
     ObjectiveScorer().recalculate_scenario_victory(game)
 
-    old_player = game.get_current_player()
-    new_player = game.next_player()
+    end_turn_result = game.end_turn()
     logger.info(
         "The turn has ended for player: %s. Now it's %s's turn.",
-        old_player.name,
-        new_player.name,
+        end_turn_result.previous_player.name,
+        end_turn_result.current_player.name,
     )
 
     game_repo.update_game(game)
     _call_end_game_callbacks(game)
-    return _serialize_game(game)
+    return _dump_api_model(SparseBoard.from_game(game, include_scores=True))

--- a/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/__init__.py
@@ -6,6 +6,7 @@ from .create_game import CreateGameRequest
 from .faction import FactionModel
 from .movement import DefensiveFireEventModel, MovementResponseModel
 from .game_model import GameModel
+from .game_status import GameStatus
 from .objective import ObjectiveModel
 from .player import PlayerModel
 from .player_type import PlayerTypeModel
@@ -21,6 +22,7 @@ __all__ = [
     "FactionModel",
     "DefensiveFireEventModel",
     "GameModel",
+    "GameStatus",
     "MovementResponseModel",
     "ObjectiveModel",
     "PlayerModel",

--- a/battle_hexes_api/src/battle_hexes_api/schemas/game_status.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/game_status.py
@@ -1,0 +1,27 @@
+"""API schema for backend-computed game status."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from .api_model import ApiBaseModel
+
+
+class GameStatus(ApiBaseModel):
+    """Serialized game completion status."""
+
+    state: Literal["in_progress", "completed"]
+    winner_player_name: str | None = None
+    winner_faction_id: str | None = None
+    reason: str | None = None
+    message: str | None = None
+
+    @classmethod
+    def from_core(cls, status) -> "GameStatus":
+        return cls(
+            state=status.state,
+            winner_player_name=status.winner_player_name,
+            winner_faction_id=status.winner_faction_id,
+            reason=status.reason,
+            message=status.message,
+        )

--- a/battle_hexes_api/src/battle_hexes_api/schemas/movement.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/movement.py
@@ -104,10 +104,14 @@ class MovementResponseModel(ApiBaseModel):
             "defensive_fire_results",
             [],
         )
+        sparse_board = SparseBoard.from_game(
+            game,
+            game_status=getattr(movement_resolution, "game_status", None),
+        )
         return cls(
             game=GameModel.from_game(game),
             plans=[MovementPlanModel.from_plan(plan) for plan in plans],
-            sparse_board=SparseBoard.from_board(game.get_board()),
+            sparse_board=sparse_board,
             defensive_fire_events=[
                 DefensiveFireEventModel.from_result(result)
                 for result in defensive_fire_results

--- a/battle_hexes_api/src/battle_hexes_api/schemas/sparseboard.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/sparseboard.py
@@ -10,6 +10,7 @@ from pydantic import Field
 from .api_model import ApiBaseModel
 
 from .combat import CombatResultSchema
+from .game_status import GameStatus
 
 from .unit import SparseUnit
 
@@ -23,6 +24,7 @@ class SparseBoard(ApiBaseModel):
     units: List[SparseUnit] = Field(default_factory=list)
     last_combat_results: Optional[List[CombatResultSchema]] = None
     scores: Optional[dict[str, int]] = None
+    game_status: Optional[GameStatus] = None
 
     def add_unit(self, unit: SparseUnit) -> None:
         self.units.append(unit)
@@ -31,10 +33,40 @@ class SparseBoard(ApiBaseModel):
         return self.units
 
     @classmethod
+    def from_game(
+        cls,
+        game,
+        include_scores: bool = False,
+        combat_results=None,
+        game_status=None,
+    ) -> "SparseBoard":
+        """Create a sparse board from a game with computed status."""
+
+        sparse_board = cls.from_board(game.get_board())
+        if not isinstance(sparse_board, cls):
+            sparse_board = cls()
+        status = game_status
+        if status is None:
+            status = game.get_game_status()
+        sparse_board.game_status = GameStatus.from_core(status)
+        if include_scores:
+            scores = game.get_score_tracker().get_scores()
+            sparse_board.scores = scores if isinstance(scores, dict) else {}
+        if combat_results is not None:
+            sparse_board.last_combat_results = [
+                CombatResultSchema.from_combat_result_data(battle)
+                for battle in combat_results.get_battles()
+            ]
+        return sparse_board
+
+    @classmethod
     def from_board(cls, board: "Board") -> "SparseBoard":
         """Create a ``SparseBoard`` from the provided ``Board``."""
 
-        units = [SparseUnit.from_unit(unit) for unit in board.get_units()]
+        board_units = board.get_units()
+        if not isinstance(board_units, (list, tuple)):
+            board_units = []
+        units = [SparseUnit.from_unit(unit) for unit in board_units]
         return cls(units=units)
 
     def apply_to_board(self, board: "Board") -> None:

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 from uuid import uuid4
 
@@ -20,6 +21,17 @@ from battle_hexes_core.unit.faction import Faction
 class TestFastAPI(unittest.TestCase):
     def setUp(self):
         self.client = TestClient(app)
+
+    def _mock_game(self):
+        game = MagicMock()
+        game.get_game_status.return_value = SimpleNamespace(
+            state="in_progress",
+            winner_player_name=None,
+            winner_faction_id=None,
+            reason=None,
+            message=None,
+        )
+        return game
 
     def _game_model_payload(self):
         return GameModel(
@@ -191,7 +203,7 @@ class TestFastAPI(unittest.TestCase):
         }
 
         game_id = "game-123"
-        mock_game = MagicMock()
+        mock_game = self._mock_game()
         mock_game.id = game_id
         mock_game_repo.get_game.return_value = mock_game
         mock_game.get_board.return_value = mock_board
@@ -214,7 +226,7 @@ class TestFastAPI(unittest.TestCase):
     ):
         mock_board = MagicMock()
         mock_board.get_units.return_value = []
-        mock_game = MagicMock()
+        mock_game = self._mock_game()
         mock_game.get_board.return_value = mock_board
         score_tracker = MagicMock()
         score_tracker.get_scores.return_value = {"Alice": 5}
@@ -249,7 +261,7 @@ class TestFastAPI(unittest.TestCase):
     ):
         mock_board = MagicMock()
         game_id = "game-456"
-        mock_game = MagicMock()
+        mock_game = self._mock_game()
         mock_game.id = game_id
         mock_game.get_board.return_value = mock_board
         mock_game.get_score_tracker.return_value.get_scores.return_value = {}
@@ -286,7 +298,7 @@ class TestFastAPI(unittest.TestCase):
         self, mock_game_repo, mock_combat, mock_from_board
     ):
         mock_board = MagicMock()
-        mock_game = MagicMock()
+        mock_game = self._mock_game()
         mock_game.get_board.return_value = mock_board
         mock_game.is_game_over.return_value = True
         mock_player1 = MagicMock()
@@ -323,7 +335,7 @@ class TestFastAPI(unittest.TestCase):
         mock_player = MagicMock()
         mock_player.movement.return_value = [mock_plan]
         mock_plan.to_dict.return_value = {"unit_id": "u-1", "path": []}
-        mock_game = MagicMock()
+        mock_game = self._mock_game()
         mock_game.get_current_player.return_value = mock_player
         mock_game_repo.get_game.return_value = mock_game
         mock_from_game.return_value = self._game_model_payload()
@@ -356,6 +368,10 @@ class TestFastAPI(unittest.TestCase):
         )
         self.assertEqual(response.json()["defensiveFireEvents"], [])
         self.assertIn("sparseBoard", response.json())
+        self.assertEqual(
+            response.json()["sparseBoard"]["gameStatus"]["state"],
+            "in_progress",
+        )
         self.assertEqual(response.json()["scores"], {"Alice": 3})
         self.assertEqual(response.json()["turnLimit"], 7)
         self.assertEqual(response.json()["turnNumber"], 2)
@@ -374,7 +390,7 @@ class TestFastAPI(unittest.TestCase):
         mock_player = MagicMock()
         mock_player.name = "CPU 1"
         mock_player.movement.return_value = [mock_plan]
-        mock_game = MagicMock()
+        mock_game = self._mock_game()
         mock_game.get_current_player.return_value = mock_player
         mock_game.get_board.return_value = MagicMock()
         mock_game.apply_movement_plans.return_value = MovementResolutionResult(
@@ -419,7 +435,7 @@ class TestFastAPI(unittest.TestCase):
         mock_to_movement_plans,
         mock_from_board,
     ):
-        mock_game = MagicMock()
+        mock_game = self._mock_game()
         mock_board = MagicMock()
         mock_plan = MagicMock()
         mock_plan.to_dict.return_value = {"unit_id": "u-1", "path": []}
@@ -460,7 +476,7 @@ class TestFastAPI(unittest.TestCase):
         mock_to_movement_plans,
         mock_from_board,
     ):
-        mock_game = MagicMock()
+        mock_game = self._mock_game()
         mock_board = MagicMock()
         mock_plans = [MagicMock()]
         mock_plans[0].to_dict.return_value = {"unit_id": "u-1", "path": []}
@@ -515,7 +531,7 @@ class TestFastAPI(unittest.TestCase):
         mock_to_movement_plans,
         mock_from_board,
     ):
-        mock_game = MagicMock()
+        mock_game = self._mock_game()
         mock_game.get_board.return_value = MagicMock()
         mock_game_repo.get_game.return_value = mock_game
         mock_plan = MagicMock()
@@ -582,13 +598,16 @@ class TestFastAPI(unittest.TestCase):
         mock_scorer,
         mock_apply_to_board,
     ):
-        mock_game = MagicMock()
+        mock_game = self._mock_game()
         mock_old_player = MagicMock()
         mock_old_player.name = "Alice"
         mock_new_player = MagicMock()
         mock_new_player.name = "Bob"
-        mock_game.get_current_player.return_value = mock_old_player
-        mock_game.next_player.return_value = mock_new_player
+        mock_game.end_turn.return_value = SimpleNamespace(
+            previous_player=mock_old_player,
+            current_player=mock_new_player,
+            game_status=mock_game.get_game_status.return_value,
+        )
         mock_game_repo.get_game.return_value = mock_game
         mock_from_game.return_value = {
             "id": "game-789",
@@ -610,15 +629,12 @@ class TestFastAPI(unittest.TestCase):
         scorer_instance.recalculate_scenario_victory.assert_called_once_with(
             mock_game
         )
-        mock_game.get_current_player.assert_called_once_with()
-        mock_game.next_player.assert_called_once_with()
+        mock_game.end_turn.assert_called_once_with()
         mock_game_repo.update_game.assert_called_once_with(mock_game)
-        mock_from_game.assert_called_once_with(mock_game, None)
+        mock_from_game.assert_not_called()
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.json(),
-            {"id": "game-789", "current_player": "Bob"}
-        )
+        self.assertEqual(response.json()["gameStatus"]["state"], "in_progress")
+        self.assertIn("units", response.json())
 
     @patch('battle_hexes_api.main.ObjectiveScorer')
     @patch('battle_hexes_api.main.GameModel.from_game')
@@ -628,7 +644,7 @@ class TestFastAPI(unittest.TestCase):
     ):
         mock_player1 = MagicMock()
         mock_player2 = MagicMock()
-        mock_game = MagicMock()
+        mock_game = self._mock_game()
         mock_game.get_current_player.return_value = MagicMock()
         mock_game.next_player.return_value = MagicMock()
         mock_game.get_players.return_value = [mock_player1, mock_player2]
@@ -647,7 +663,7 @@ class TestFastAPI(unittest.TestCase):
         )
         mock_player1.end_game_cb.assert_called_once_with()
         mock_player2.end_game_cb.assert_called_once_with()
-        mock_from_game.assert_called_once_with(mock_game, None)
+        mock_from_game.assert_not_called()
 
     @patch('battle_hexes_api.main.list_player_types')
     def test_get_player_types(self, mock_list_player_types):

--- a/battle_hexes_api/tests/test_schemas.py
+++ b/battle_hexes_api/tests/test_schemas.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 
 from battle_hexes_api.schemas import (
     CreateGameRequest,
@@ -369,7 +370,14 @@ class TestMovementSchemas(unittest.TestCase):
                         outcome="no_effect",
                         retreat_destination=None,
                     )
-                ]
+                ],
+                "game_status": SimpleNamespace(
+                    state="completed",
+                    winner_player_name="Alice",
+                    winner_faction_id="f1",
+                    reason="unit_elimination",
+                    message="Alice wins.",
+                ),
             },
         )()
 
@@ -417,6 +425,11 @@ class TestMovementSchemas(unittest.TestCase):
         self.assertEqual(
             response.defensive_fire_events[0].outcome,
             "no_effect",
+        )
+        self.assertEqual(response.sparse_board.game_status.state, "completed")
+        self.assertEqual(
+            response.sparse_board.game_status.winner_player_name,
+            "Alice",
         )
         self.assertEqual(response.scores, {"Alice": 4})
         self.assertEqual(response.model_dump(by_alias=True)["turnLimit"], 6)

--- a/battle_hexes_api/tests/test_schemas_board.py
+++ b/battle_hexes_api/tests/test_schemas_board.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 from battle_hexes_api.schemas import (
     BoardModel,
@@ -244,3 +245,44 @@ class TestBoardModel(unittest.TestCase):
             ],
             [(1, 1), (1, 2), (2, 2)],
         )
+
+    def test_sparse_board_serializes_game_status_with_camel_case(self):
+        sparse_board = SparseBoard(
+            units=[],
+            gameStatus={
+                "state": "completed",
+                "winnerPlayerName": "Alice",
+                "winnerFactionId": "f1",
+                "reason": "unit_elimination",
+                "message": "Alice wins.",
+            },
+        )
+
+        payload = sparse_board.model_dump(by_alias=True)
+
+        self.assertEqual(payload["gameStatus"]["state"], "completed")
+        self.assertEqual(
+            payload["gameStatus"]["winnerPlayerName"], "Alice"
+        )
+        self.assertEqual(payload["gameStatus"]["winnerFactionId"], "f1")
+
+    def test_api_schemas_do_not_import_game_status_evaluator(self):
+        schema_dir = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "battle_hexes_api"
+            / "schemas"
+        )
+
+        for schema_file in schema_dir.glob("*.py"):
+            self.assertNotIn("GameStatusEvaluator", schema_file.read_text())
+
+    def test_api_main_does_not_import_game_status_evaluator(self):
+        api_main = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "battle_hexes_api"
+            / "main.py"
+        )
+
+        self.assertNotIn("GameStatusEvaluator", api_main.read_text())

--- a/battle_hexes_core/src/battle_hexes_core/defensivefire/defensive_fire.py
+++ b/battle_hexes_core/src/battle_hexes_core/defensivefire/defensive_fire.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -28,3 +29,4 @@ class MovementResolutionResult:
     defensive_fire_results: list[DefensiveFireResult] = field(
         default_factory=list
     )
+    game_status: Any | None = None

--- a/battle_hexes_core/src/battle_hexes_core/game/game.py
+++ b/battle_hexes_core/src/battle_hexes_core/game/game.py
@@ -1,5 +1,6 @@
 import uuid
-from typing import List
+from dataclasses import dataclass
+from typing import List, Any
 
 from battle_hexes_core.game.board import Board
 from battle_hexes_core.defensivefire.defensive_fire import (
@@ -13,6 +14,13 @@ from battle_hexes_core.game.player import Player
 from battle_hexes_core.game.scoretracker import ScoreTracker
 from battle_hexes_core.game.unitmovementplan import UnitMovementPlan
 from battle_hexes_core.unit.faction import Faction
+
+
+@dataclass
+class EndTurnResult:
+    previous_player: Player | None
+    current_player: Player | None
+    game_status: Any
 
 
 class Game:
@@ -36,6 +44,8 @@ class Game:
         self.turn_number = 1
         self.defensive_fire_resolver = DefensiveFireResolver(board)
         self._refresh_defensive_fire_availability()
+        self.game_status = None
+        self.update_game_status()
 
     def get_id(self):
         return self.id
@@ -68,6 +78,7 @@ class Game:
             self._apply_single_movement_plan(plan, movement, resolution)
         self._refresh_defensive_fire_availability()
         self.get_current_player().movement_cb()
+        resolution.game_status = self.update_game_status()
         return resolution
 
     def _apply_single_movement_plan(
@@ -137,7 +148,33 @@ class Game:
         self.current_player = self.players[next_idx]
         self._reset_defensive_fire_off_turn_usage(self.current_player)
         self._refresh_defensive_fire_availability()
+        self.update_game_status()
         return self.current_player
+
+    def end_turn(self) -> EndTurnResult:
+        """Advance the turn and return the resulting core state."""
+        previous_player = self.get_current_player() if self.players else None
+        current_player = self.next_player()
+        return EndTurnResult(
+            previous_player=previous_player,
+            current_player=current_player,
+            game_status=self.get_game_status(),
+        )
+
+    def update_game_status(self):
+        """Evaluate and store the current core game status."""
+        from battle_hexes_core.scoring.game_status_evaluator import (
+            GameStatusEvaluator,
+        )
+
+        self.game_status = GameStatusEvaluator().evaluate(self)
+        return self.game_status
+
+    def get_game_status(self):
+        """Return the latest core game status for this game."""
+        if self.game_status is None:
+            return self.update_game_status()
+        return self.game_status
 
     def _snapshot_defensive_fire_eligibility(
             self,

--- a/battle_hexes_core/src/battle_hexes_core/scoring/game_status_evaluator.py
+++ b/battle_hexes_core/src/battle_hexes_core/scoring/game_status_evaluator.py
@@ -1,0 +1,146 @@
+"""Evaluate whether a game has ended and who won."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+
+from battle_hexes_core.game.game import Game
+from battle_hexes_core.game.player import Player
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GameStatus:
+    """Machine-readable game completion status."""
+
+    state: str
+    winner_player_name: str | None = None
+    winner_faction_id: str | None = None
+    reason: str | None = None
+    message: str | None = None
+
+
+class GameStatusEvaluator:
+    """Determine game completion from core game state and scenario rules."""
+
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    TURN_LIMIT_REACHED = "turn_limit_reached"
+    OBJECTIVE_CONTROL = "objective_control"
+    UNIT_ELIMINATION = "unit_elimination"
+    DRAW = "draw"
+
+    def evaluate(self, game: Game) -> GameStatus:
+        """Return the current status for ``game``."""
+        elimination_winner = self._unit_elimination_winner(game)
+        if elimination_winner is not None:
+            return self._completed(
+                game,
+                elimination_winner,
+                self.UNIT_ELIMINATION,
+                (
+                    f"{elimination_winner.name} wins by eliminating "
+                    "all enemy units."
+                ),
+            )
+
+        if self._turn_limit_reached(game):
+            winner = self._score_winner(game)
+            reason = self._turn_limit_reason(game)
+            message = self._score_message(game, winner)
+            return self._completed(game, winner, reason, message)
+
+        return GameStatus(state=self.IN_PROGRESS)
+
+    def _turn_limit_reached(self, game: Game) -> bool:
+        turn_limit = getattr(game, "turn_limit", None)
+        if turn_limit is None:
+            turn_limit = game.get_turn_limit()
+        turn_number = getattr(game, "turn_number", None)
+        if turn_number is None:
+            turn_number = game.get_turn_number()
+        if not (
+            isinstance(turn_limit, int)
+            and isinstance(turn_number, int)
+        ):
+            return False
+        return turn_number > turn_limit
+
+    def _turn_limit_reason(self, game: Game) -> str:
+        victory = getattr(game, "victory", None)
+        if victory is not None and victory.method == self.OBJECTIVE_CONTROL:
+            return self.OBJECTIVE_CONTROL
+        return self.TURN_LIMIT_REACHED
+
+    def _unit_elimination_winner(self, game: Game) -> Player | None:
+        active_players = self._active_players(game)
+        if len(active_players) == 1:
+            return active_players[0]
+        return None
+
+    def _score_winner(self, game: Game) -> Player | None:
+        players = game.get_players() if hasattr(game, "get_players") else []
+        if not players:
+            return None
+        score_tracker = game.get_score_tracker()
+        scores = [
+            (player, score_tracker.get_score(player))
+            for player in players
+        ]
+        high_score = max(score for _, score in scores)
+        winners = [player for player, score in scores if score == high_score]
+        if len(winners) == 1:
+            return winners[0]
+        return None
+
+    def _score_message(self, game: Game, winner: Player | None) -> str:
+        scores = game.get_score_tracker().get_scores()
+        if winner is None:
+            return f"Game completed in a draw. Scores: {scores}."
+        return f"{winner.name} wins. Scores: {scores}."
+
+    def _completed(
+        self,
+        game: Game,
+        winner: Player | None,
+        reason: str,
+        message: str,
+    ) -> GameStatus:
+        status = GameStatus(
+            state=self.COMPLETED,
+            winner_player_name=getattr(winner, "name", None),
+            winner_faction_id=self._winner_faction_id(winner),
+            reason=reason if winner is not None else self.DRAW,
+            message=message,
+        )
+        logger.info(
+            "Game over detected: status=%s game_id=%s turn_number=%s "
+            "turn_limit=%s scores=%s active_players=%s",
+            status,
+            game.get_id(),
+            game.get_turn_number(),
+            game.get_turn_limit(),
+            game.get_score_tracker().get_scores(),
+            [player.name for player in self._active_players(game)],
+        )
+        return status
+
+    def _winner_faction_id(self, winner: Player | None) -> str | None:
+        if winner is None or not winner.factions:
+            return None
+        return winner.factions[0].id
+
+    def _active_players(self, game: Game) -> list[Player]:
+        active_players = []
+        players = game.get_players() if hasattr(game, "get_players") else []
+        if not isinstance(players, (list, tuple)):
+            return active_players
+        for player in players:
+            units = game.get_board().get_units_for_player(player)
+            if not isinstance(units, (list, tuple)):
+                continue
+            if any(unit.get_coords() is not None for unit in units):
+                active_players.append(player)
+        return active_players

--- a/battle_hexes_core/src/battle_hexes_core/scoring/objective_scorer.py
+++ b/battle_hexes_core/src/battle_hexes_core/scoring/objective_scorer.py
@@ -13,12 +13,15 @@ class ObjectiveScorer:
 
     def recalculate_scenario_victory(self, game: Game) -> int | None:
         """Recalculate scenario-driven victory scoring when configured."""
-        return self._award_scenario_objective_control(game)
+        points = self._award_scenario_objective_control(game)
+        game.update_game_status()
+        return points
 
     def award_hold_objectives(self, game: Game) -> int:
         """Award points for the active scenario scoring method."""
         scenario_points = self._award_scenario_objective_control(game)
         if scenario_points is not None:
+            game.update_game_status()
             return scenario_points
 
         current_player = game.get_current_player()
@@ -35,6 +38,7 @@ class ObjectiveScorer:
                 current_player.name, total_points, held_objectives
             )
 
+        game.update_game_status()
         return total_points
 
     def award_hold_objectives_after_combat(
@@ -43,6 +47,7 @@ class ObjectiveScorer:
         """Award points for surviving attackers on objectives."""
         scenario_points = self._award_scenario_objective_control(game)
         if scenario_points is not None:
+            game.update_game_status()
             return scenario_points
 
         current_player = game.get_current_player()
@@ -59,6 +64,7 @@ class ObjectiveScorer:
             self._log_awarded_points(
                 current_player.name, total_points, held_objectives
             )
+        game.update_game_status()
         return total_points
 
     def _award_scenario_objective_control(self, game: Game) -> int | None:

--- a/battle_hexes_core/tests/scoring/test_game_status_evaluator.py
+++ b/battle_hexes_core/tests/scoring/test_game_status_evaluator.py
@@ -1,0 +1,147 @@
+import unittest
+
+from battle_hexes_core.game.board import Board
+from battle_hexes_core.game.game import Game
+from battle_hexes_core.game.player import Player, PlayerType
+from battle_hexes_core.scenario.scenario import ScenarioVictory
+from battle_hexes_core.scoring.game_status_evaluator import GameStatusEvaluator
+from battle_hexes_core.unit.faction import Faction
+from battle_hexes_core.unit.unit import Unit
+
+
+class TestGameStatusEvaluator(unittest.TestCase):
+    def setUp(self):
+        self.board = Board(3, 3)
+        self.faction_one = Faction(id="f1", name="Alpha", color="#aaa")
+        self.faction_two = Faction(id="f2", name="Beta", color="#bbb")
+        self.player_one = Player(
+            name="Alice", type=PlayerType.HUMAN, factions=[self.faction_one]
+        )
+        self.player_two = Player(
+            name="Bob", type=PlayerType.CPU, factions=[self.faction_two]
+        )
+        self.unit_one = self._unit("u1", self.faction_one, self.player_one)
+        self.unit_two = self._unit("u2", self.faction_two, self.player_two)
+        self.board.add_unit(self.unit_one, 0, 0)
+        self.board.add_unit(self.unit_two, 2, 2)
+        self.game = Game([self.player_one, self.player_two], self.board)
+        self.evaluator = GameStatusEvaluator()
+
+    def _unit(self, unit_id, faction, player):
+        return Unit(
+            id=unit_id,
+            name=unit_id,
+            faction=faction,
+            player=player,
+            type="Infantry",
+            attack=1,
+            defense=1,
+            move=1,
+        )
+
+    def test_in_progress_when_no_ending_condition_is_met(self):
+        status = self.evaluator.evaluate(self.game)
+
+        self.assertEqual(status.state, "in_progress")
+        self.assertIsNone(status.reason)
+        self.assertIsNone(status.winner_player_name)
+
+    def test_completed_when_unit_elimination_leaves_one_player_active(self):
+        self.unit_two.set_coords(None, None)
+
+        status = self.evaluator.evaluate(self.game)
+
+        self.assertEqual(status.state, "completed")
+        self.assertEqual(status.reason, "unit_elimination")
+        self.assertEqual(status.winner_player_name, "Alice")
+        self.assertEqual(status.winner_faction_id, "f1")
+
+    def test_completed_at_turn_limit_with_score_winner(self):
+        self.game.turn_limit = 1
+        self.game.turn_number = 2
+        self.game.get_score_tracker().set_score(self.player_one, 3)
+        self.game.get_score_tracker().set_score(self.player_two, 1)
+
+        status = self.evaluator.evaluate(self.game)
+
+        self.assertEqual(status.state, "completed")
+        self.assertEqual(status.reason, "turn_limit_reached")
+        self.assertEqual(status.winner_player_name, "Alice")
+
+    def test_completed_objective_control_at_turn_limit(self):
+        self.game.turn_limit = 1
+        self.game.turn_number = 2
+        self.game.victory = ScenarioVictory(
+            method="objective_control",
+            scoring_side="Alpha",
+        )
+        self.game.get_score_tracker().set_score(self.player_one, 1)
+        self.game.get_score_tracker().set_score(self.player_two, 0)
+
+        status = self.evaluator.evaluate(self.game)
+
+        self.assertEqual(status.state, "completed")
+        self.assertEqual(status.reason, "objective_control")
+        self.assertEqual(status.winner_player_name, "Alice")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestGameStatusCoreWorkflow(unittest.TestCase):
+    def setUp(self):
+        self.board = Board(3, 3)
+        self.faction_one = Faction(id="f1", name="Alpha", color="#aaa")
+        self.faction_two = Faction(id="f2", name="Beta", color="#bbb")
+        self.player_one = Player(
+            name="Alice", type=PlayerType.HUMAN, factions=[self.faction_one]
+        )
+        self.player_two = Player(
+            name="Bob", type=PlayerType.CPU, factions=[self.faction_two]
+        )
+        self.unit_one = Unit(
+            id="u1",
+            name="u1",
+            faction=self.faction_one,
+            player=self.player_one,
+            type="Infantry",
+            attack=1,
+            defense=1,
+            move=1,
+        )
+        self.unit_two = Unit(
+            id="u2",
+            name="u2",
+            faction=self.faction_two,
+            player=self.player_two,
+            type="Infantry",
+            attack=1,
+            defense=1,
+            move=1,
+        )
+        self.board.add_unit(self.unit_one, 0, 0)
+        self.board.add_unit(self.unit_two, 2, 2)
+        self.game = Game([self.player_one, self.player_two], self.board)
+
+    def test_movement_result_contains_core_computed_game_status(self):
+        self.unit_two.set_coords(None, None)
+
+        result = self.game.apply_movement_plans([])
+
+        self.assertEqual(result.game_status.state, "completed")
+        self.assertEqual(result.game_status.reason, "unit_elimination")
+        self.assertEqual(result.game_status.winner_player_name, "Alice")
+
+    def test_end_turn_result_contains_core_computed_game_status(self):
+        self.game.turn_limit = 1
+        self.game.turn_number = 1
+        self.game.current_player = self.player_two
+        self.game.get_score_tracker().set_score(self.player_one, 2)
+        self.game.get_score_tracker().set_score(self.player_two, 1)
+
+        result = self.game.end_turn()
+
+        self.assertEqual(result.game_status.state, "completed")
+        self.assertEqual(result.game_status.reason, "turn_limit_reached")
+        self.assertEqual(result.game_status.winner_player_name, "Alice")


### PR DESCRIPTION
### Motivation
- Introduce a machine-readable game completion status computed by the core so API clients can see when a game ends and why.
- Ensure the API surface exposes core-computed status without moving game-rule evaluation into schema modules or `main.py`.
- Provide a consistent flow where core operations update game status and API schemas serialize the result.

### Description
- Add `GameStatusEvaluator` and `GameStatus` in core under `scoring` to determine end conditions like unit elimination and turn-limit scoring and to return structured status details.
- Extend `Game` with `update_game_status`, `get_game_status`, an `EndTurnResult` dataclass returned by `end_turn`, and attach `game_status` to movement resolution via `MovementResolutionResult.game_status` so core operations populate status objects.
- Add an API schema `GameStatus` and a `SparseBoard.from_game` helper to build sparse board payloads including `game_status`, scores, and optional combat results, and update `MovementResponseModel.from_movement_result` to use it.
- Update `main.py` to return API payloads built from `SparseBoard.from_game` (including `game_status`) and to use the new `end_turn` result rather than calling core evaluators from the API layer, and add guidance in `AGENTS.md` documenting API/core/schema boundaries.

### Testing
- Ran core unit tests including the new `battle_hexes_core.tests.scoring.test_game_status_evaluator` which verifies evaluator logic and core workflow and succeeded.  
- Ran API unit tests in `battle_hexes_api.tests.test_main`, `battle_hexes_api.tests.test_schemas`, and `battle_hexes_api.tests.test_schemas_board` which were updated to assert `gameStatus` is present and that schema files and `main.py` do not import core evaluators, and they succeeded.  
- Linting (`flake8`) and existing test suites across the API and core packages were executed via the repository checks and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381c40f820832793134869ada4949a)