### PR TITLE
Integrate backend gameStatus with web endgame flow

### DIFF
--- a/battle-hexes-web/src/battle-draw.js
+++ b/battle-hexes-web/src/battle-draw.js
@@ -52,6 +52,7 @@ new p5((p) => {
       );
 
       applyMovementResponse(game.getBoard(), movementResponse);
+      game.applyApiState?.(movementResponse);
     };
   };
   configureMovementHandling();

--- a/battle-hexes-web/src/gameoverdialog.js
+++ b/battle-hexes-web/src/gameoverdialog.js
@@ -5,6 +5,8 @@ export class GameOverDialog {
   #newGameBtn;
   #mainMenuBtn;
   #closeBtn;
+  #title;
+  #message;
   #onNewGameRequested;
   #locationRef;
   #shownGameIds = new Set();
@@ -18,22 +20,44 @@ export class GameOverDialog {
     this.#newGameBtn = document.getElementById('gameOverNewGameBtn');
     this.#mainMenuBtn = document.getElementById('gameOverMainMenuBtn');
     this.#closeBtn = document.getElementById('gameOverCloseBtn');
+    this.#title = document.getElementById('gameOverDialogTitle');
+    this.#message = document.getElementById('gameOverDialogMessage');
     this.#onNewGameRequested = onNewGameRequested;
     this.#locationRef = locationRef;
 
     this.#newGameBtn.addEventListener('click', () => this.#handleNewGameRequest());
     this.#mainMenuBtn.addEventListener('click', () => this.#returnToMainMenu());
     this.#closeBtn.addEventListener('click', () => this.#hide());
-    eventBus.on('gameOver', (event) => this.#showOnceForGame(event.gameId));
+    eventBus.on('gameOver', (event) => this.#showOnceForGame(event));
   }
 
-  #showOnceForGame(gameId) {
+  #showOnceForGame(event) {
+    const gameId = event?.gameId;
     if (this.#shownGameIds.has(gameId)) {
       return;
     }
 
     this.#shownGameIds.add(gameId);
+    this.#populate(event?.gameStatus);
     this.#show();
+  }
+
+  #populate(gameStatus) {
+    const suppliedMessage = gameStatus?.message;
+    const winner = gameStatus?.winner;
+    const winnerName = gameStatus?.winnerPlayerName ?? (typeof winner === 'string' ? winner : winner?.name);
+    const messageParts = [
+      typeof suppliedMessage === 'string' && suppliedMessage.trim().length > 0
+        ? suppliedMessage
+        : 'The game is over.',
+    ];
+
+    if (typeof winnerName === 'string' && winnerName.trim().length > 0) {
+      messageParts.push(`Winner: ${winnerName}`);
+    }
+
+    this.#title.textContent = 'Game Over';
+    this.#message.textContent = messageParts.join(' ');
   }
 
   #show() {

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -478,7 +478,7 @@ export class Menu {
   }
 
   #applyGameStateResponse(responseData) {
-    const safeUnits = responseData?.sparseBoard?.units ?? responseData?.game?.board?.units ?? [];
+    const safeUnits = responseData?.sparseBoard?.units ?? responseData?.game?.board?.units ?? responseData?.units ?? [];
     new BoardUpdater().updateBoard(this.#game.getBoard(), safeUnits, {
       defensiveFireEvents: responseData?.defensiveFireEvents ?? [],
     });

--- a/battle-hexes-web/src/menu.js
+++ b/battle-hexes-web/src/menu.js
@@ -220,11 +220,7 @@ export class Menu {
     this.#updatePhasesStyling();
     this.#disableOrEnableActionButton();
 
-    if (this.#game.isGameOver()) {
-      this.#showGameOver();
-    } else {
-      this.#hideGameOver();
-    }
+    this.#processGameStatus();
   }
 
   #toggleSelectedHexHeadings(isVisible) {
@@ -387,6 +383,10 @@ export class Menu {
   }
 
   doEndPhase() {
+    if (this.#game.isGameOver()) {
+      return;
+    }
+
     if (this.#isCombatPhase()) {
       this.#handleCombatPhase();
     } else {
@@ -400,7 +400,13 @@ export class Menu {
 
   #handleCombatPhase() {
     console.log('Resolving combat.');
-    this.#game.resolveCombat(this.#postCombat).then(() => this.#finishPhase());
+    this.#game.resolveCombat(this.#postCombat).then(() => {
+      if (!this.#game.isGameOver()) {
+        this.#finishPhase();
+      } else {
+        this.updateMenu();
+      }
+    });
   }
 
   #finishPhase() {
@@ -415,7 +421,7 @@ export class Menu {
         this.#game.getId(),
         this.#game.getBoard().sparseBoard()
       ).then((responseData) => {
-        this.#applyMovementResponse(responseData);
+        this.#applyGameStateResponse(responseData);
         this.updateMenu();
       }).catch(err => console.error('Failed to update movement state', err));
     }
@@ -429,11 +435,7 @@ export class Menu {
         this.#game.getId(),
         endTurnPayload
       ).then((responseData) => {
-        this.#game.updateScores?.(responseData?.scores);
-        this.#game.updateTurnState?.({
-          turnLimit: responseData?.turnLimit,
-          turnNumber: responseData?.turnNumber,
-        });
+        this.#applyGameStateResponse(responseData);
         this.updateMenu();
       }).catch(err => console.error('Failed to update game state', err))
        .finally(() => {
@@ -475,17 +477,21 @@ export class Menu {
     // TODO: update the menu area of the UI to show the results of the combat
   }
 
-  #applyMovementResponse(responseData) {
+  #applyGameStateResponse(responseData) {
     const safeUnits = responseData?.sparseBoard?.units ?? responseData?.game?.board?.units ?? [];
     new BoardUpdater().updateBoard(this.#game.getBoard(), safeUnits, {
       defensiveFireEvents: responseData?.defensiveFireEvents ?? [],
     });
 
-    this.#game.updateScores?.(responseData?.scores);
-    this.#game.updateTurnState?.({
-      turnLimit: responseData?.turnLimit,
-      turnNumber: responseData?.turnNumber,
-    });
+    this.#game.applyApiState?.(responseData);
+  }
+
+  #processGameStatus() {
+    if (this.#game.isGameOver()) {
+      this.#showGameOver();
+    } else {
+      this.#hideGameOver();
+    }
   }
 
   #showDefensiveFireEvents(events = []) {
@@ -529,7 +535,10 @@ export class Menu {
       this.#newGameBtn.style.display = 'none';
       this.#scheduleAutoNewGame();
     } else {
-      eventBus.emit('gameOver', { gameId: this.#game.getId() });
+      eventBus.emit('gameOver', {
+        gameId: this.#game.getId(),
+        gameStatus: this.#game.getGameStatus?.() ?? null,
+      });
       this.#newGameBtn.style.display = 'block';
     }
   }

--- a/battle-hexes-web/src/model/board.js
+++ b/battle-hexes-web/src/model/board.js
@@ -15,6 +15,7 @@ export class Board {
   #stackingLimit = null;
   #movementHandler;
   #movementInProgress = false;
+  #gameplayBlockedProvider = () => false;
 
   constructor(rows, columns) {
     this.#hexMap = new Map();
@@ -89,6 +90,10 @@ export class Board {
     this.movementHandler = handler;
   }
 
+  setGameplayBlockedProvider(provider) {
+    this.#gameplayBlockedProvider = provider;
+  }
+
   get columns() {
     return this.#columns;
   }
@@ -121,7 +126,7 @@ export class Board {
 
   selectHex(hexToSelect) {
     if (hexToSelect === this.#selectedHex) return;
-    if (this.#movementInProgress) return;
+    if (this.#movementInProgress || this.#gameplayBlockedProvider()) return;
     
     const oldSelection = this.#selectedHex;
 
@@ -243,7 +248,7 @@ export class Board {
       return oldHover;
     }
 
-    if (this.#hoverHex && this.hasSelection() && !this.#selectedHex.isEmpty()
+    if (!this.#gameplayBlockedProvider() && this.#hoverHex && this.hasSelection() && !this.#selectedHex.isEmpty()
         && !this.#selectedHex.hasUnitMoves() 
         && this.#hoverHex.isAdjacent(this.#selectedHex)
         && this.isOwnHexSelected()

--- a/battle-hexes-web/src/model/game-creator.js
+++ b/battle-hexes-web/src/model/game-creator.js
@@ -28,6 +28,7 @@ export class GameCreator {
         scores: this.#getScores(gameData),
         turnLimit,
         turnNumber,
+        gameStatus: gameData?.gameStatus ?? null,
       },
     );
     this.#addTerrain(board, gameData.board);

--- a/battle-hexes-web/src/model/game.js
+++ b/battle-hexes-web/src/model/game.js
@@ -13,6 +13,7 @@ export class Game {
   #scores;
   #turnLimit;
   #turnNumber;
+  #gameStatus;
 
   constructor(id, phases, players, board, {
     scenarioId = null,
@@ -20,6 +21,7 @@ export class Game {
     scores = {},
     turnLimit = null,
     turnNumber = 1,
+    gameStatus = null,
   } = {}) {
     this.#id = id;
     this.#phases = phases;
@@ -39,6 +41,8 @@ export class Game {
     this.#scores = { ...scores };
     this.#turnLimit = Number.isInteger(turnLimit) && turnLimit > 0 ? turnLimit : null;
     this.#turnNumber = Number.isInteger(turnNumber) && turnNumber > 0 ? turnNumber : 1;
+    this.#gameStatus = this.#normalizeGameStatus(gameStatus);
+    this.#board.setGameplayBlockedProvider?.(() => this.isGameOver());
   }
 
   endPhase() {
@@ -145,23 +149,55 @@ export class Game {
     this.#turnNumber = Number.isInteger(turnNumber) && turnNumber > 0 ? turnNumber : 1;
   }
 
-  isGameOver() {
-    if (Number.isInteger(this.#turnLimit) && this.#turnNumber > this.#turnLimit) {
-      return true;
-    }
+  getGameStatus() {
+    return this.#gameStatus ? { ...this.#gameStatus } : null;
+  }
 
-    const owners = new Set();
-    for (const unit of this.#board.getUnits()) {
-      if (unit.getContainingHex()) {
-        owners.add(unit.getOwningPlayer());
-      }
+  updateGameStatus(gameStatus) {
+    this.#gameStatus = this.#normalizeGameStatus(gameStatus);
+  }
+
+  applyApiState(responseData = {}) {
+    if (Object.prototype.hasOwnProperty.call(responseData ?? {}, 'scores')) {
+      this.updateScores(responseData.scores);
     }
-    return owners.size <= 1;
+    if (Object.prototype.hasOwnProperty.call(responseData ?? {}, 'turnLimit')
+        || Object.prototype.hasOwnProperty.call(responseData ?? {}, 'turnNumber')) {
+      this.updateTurnState({
+        turnLimit: responseData?.turnLimit,
+        turnNumber: responseData?.turnNumber,
+      });
+    }
+    const gameStatus = this.#extractGameStatus(responseData);
+    if (gameStatus !== undefined) {
+      this.updateGameStatus(gameStatus);
+    }
+  }
+
+  isGameOver() {
+    return this.#gameStatus?.state === 'completed';
+  }
+
+  #extractGameStatus(responseData) {
+    if (Object.prototype.hasOwnProperty.call(responseData ?? {}, 'gameStatus')) {
+      return responseData.gameStatus;
+    }
+    if (Object.prototype.hasOwnProperty.call(responseData?.sparseBoard ?? {}, 'gameStatus')) {
+      return responseData.sparseBoard.gameStatus;
+    }
+    return undefined;
+  }
+
+  #normalizeGameStatus(gameStatus) {
+    if (!gameStatus || typeof gameStatus !== 'object') {
+      return null;
+    }
+    return { ...gameStatus };
   }
 
   resolveCombat(finishedCb) {
     return this.#combatResolver.resolveCombat().then((combatResult) => {
-      this.updateScores(combatResult?.scores);
+      this.applyApiState(combatResult);
       if (finishedCb) {
         finishedCb(combatResult);
       }

--- a/battle-hexes-web/src/player/cpu-player.js
+++ b/battle-hexes-web/src/player/cpu-player.js
@@ -42,11 +42,13 @@ export class CpuPlayer extends Player {
         }
 
         applyMovementResponse(game.getBoard(), responseData);
+        game.applyApiState?.(responseData);
 
-        await this.service.endMovement(
+        const endMovementResponse = await this.service.endMovement(
           game.getId(),
           game.getBoard().sparseBoard(),
         );
+        game.applyApiState?.(endMovementResponse);
 
         game.endPhase();
         eventBus.emit("redraw");
@@ -81,11 +83,7 @@ export class CpuPlayer extends Player {
           return null;
         });
       if (endTurnResponse) {
-        game.updateScores?.(endTurnResponse.scores);
-        game.updateTurnState?.({
-          turnLimit: endTurnResponse.turnLimit,
-          turnNumber: endTurnResponse.turnNumber,
-        });
+        game.applyApiState?.(endTurnResponse);
       }
       game.endPhase();
       eventBus.emit("redraw");

--- a/battle-hexes-web/src/service/mock-responses/get-game-completed.json
+++ b/battle-hexes-web/src/service/mock-responses/get-game-completed.json
@@ -684,10 +684,10 @@
     "q-learning"
   ],
   "gameStatus": {
-    "state": "in_progress",
-    "winnerPlayerName": null,
-    "winnerFactionId": null,
-    "reason": null,
-    "message": "Game in progress."
+    "state": "completed",
+    "winnerPlayerName": "Player 1",
+    "winnerFactionId": "allies",
+    "reason": "elimination",
+    "message": "Player 1 wins by eliminating all opposing units."
   }
 }

--- a/battle-hexes-web/src/service/mock-responses/move.json
+++ b/battle-hexes-web/src/service/mock-responses/move.json
@@ -449,7 +449,14 @@
             }
         ],
         "lastCombatResults": null,
-        "scores": null
+        "scores": null,
+        "gameStatus": {
+            "state": "in_progress",
+            "winnerPlayerName": null,
+            "winnerFactionId": null,
+            "reason": null,
+            "message": "Game in progress."
+        }
     },
     "defensiveFireEvents": [
         {
@@ -479,5 +486,12 @@
         "Player 2": 3
     },
     "turnLimit": 8,
-    "turnNumber": 2
+    "turnNumber": 2,
+    "gameStatus": {
+        "state": "in_progress",
+        "winnerPlayerName": null,
+        "winnerFactionId": null,
+        "reason": null,
+        "message": "Game in progress."
+    }
 }

--- a/battle-hexes-web/tests/menu/gameoverdialog.test.js
+++ b/battle-hexes-web/tests/menu/gameoverdialog.test.js
@@ -32,11 +32,31 @@ describe('game over dialog', () => {
     const eventBus = fakeEventBus();
 
     new GameOverDialog({ eventBus });
-    gameOverListener(eventBus)({ gameId: 'game-id' });
+    gameOverListener(eventBus)({
+      gameId: 'game-id',
+      gameStatus: {
+        state: 'completed',
+        winnerPlayerName: 'Player 1',
+        message: 'Player 1 wins by objective control.',
+      },
+    });
 
     expect(document.getElementById('gameOverDialog').style.display).toBe('flex');
     expect(document.getElementById('gameOverDialogTitle').textContent).toBe('Game Over');
-    expect(document.getElementById('gameOverDialogMessage').textContent).toBe('The game is over.');
+    expect(document.getElementById('gameOverDialogMessage').textContent).toBe('Player 1 wins by objective control. Winner: Player 1');
+  });
+
+  test('handles completed games without a winner', () => {
+    buildDom();
+    const eventBus = fakeEventBus();
+
+    new GameOverDialog({ eventBus });
+    gameOverListener(eventBus)({
+      gameId: 'draw-game-id',
+      gameStatus: { state: 'completed', message: 'The game ends in a draw.' },
+    });
+
+    expect(document.getElementById('gameOverDialogMessage').textContent).toBe('The game ends in a draw.');
   });
 
   test('does not reopen after it is closed for the same game ending', () => {

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -825,6 +825,38 @@ describe('auto new game persistence', () => {
     );
   });
 
+
+  test('preserves top-level units from authoritative end-turn responses', async () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+
+    const updateBoard = jest.fn();
+    BoardUpdater.mockImplementation(() => ({ updateBoard }));
+
+    const board = {
+      sparseBoard: () => ({ units: [{ id: 'unit-1', row: 1, column: 1 }] }),
+      getSelectedHex: () => null,
+      isOwnHexSelected: () => false,
+      hasCombat: () => false,
+    };
+    const game = fakeGame({
+      getCurrentPhase: () => 'End Turn',
+      endPhase: () => true,
+      getBoard: () => board,
+    });
+    const authoritativeUnits = [{ id: 'unit-1', row: 2, column: 3 }];
+
+    mockService.endTurn.mockResolvedValue({ units: authoritativeUnits });
+
+    const menu = new Menu(game, { service: mockService });
+    menu.doEndPhase();
+    await flushPromises();
+
+    expect(updateBoard).toHaveBeenCalledWith(board, authoritativeUnits, {
+      defensiveFireEvents: [],
+    });
+  });
+
   test('redraws immediately after a turn switch so refreshed defensive fire icons are visible', () => {
     buildDom();
     history.replaceState(null, '', '/');

--- a/battle-hexes-web/tests/menu/menu.test.js
+++ b/battle-hexes-web/tests/menu/menu.test.js
@@ -83,6 +83,8 @@ describe('auto new game persistence', () => {
       }),
       getScores: () => ({}),
       isGameOver: () => false,
+      getGameStatus: () => null,
+      applyApiState: jest.fn(),
       getId: () => 'game-id',
       getScenarioId: () => 'elim_1',
     };
@@ -306,7 +308,7 @@ describe('auto new game persistence', () => {
 
       new Menu(fakeGame({ isGameOver: () => true }), { service: mockService });
 
-      expect(eventBus.emit).toHaveBeenCalledWith('gameOver', { gameId: 'game-id' });
+      expect(eventBus.emit).toHaveBeenCalledWith('gameOver', { gameId: 'game-id', gameStatus: null });
     });
 
     test('does not emit a game over event when auto new game is enabled', () => {
@@ -667,6 +669,9 @@ describe('auto new game persistence', () => {
       updateScores: (scores) => {
         currentScores = { ...scores };
       },
+      applyApiState: (responseData) => {
+        currentScores = { ...responseData.scores };
+      },
       getCurrentPhase: () => 'Movement',
       endPhase: () => false,
       getBoard: () => ({
@@ -690,6 +695,86 @@ describe('auto new game persistence', () => {
     await flushPromises();
 
     expect(document.querySelector('.victory-score').textContent).toBe('4');
+  });
+
+
+  test('in-progress API status does not open the game over dialog event', async () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+
+    let status = { state: 'in_progress', message: 'Keep playing.' };
+    const game = fakeGame({
+      getCurrentPhase: () => 'Movement',
+      endPhase: () => false,
+      isGameOver: () => status.state === 'completed',
+      getGameStatus: () => status,
+      applyApiState: (responseData) => { status = responseData.gameStatus; },
+      getBoard: () => ({
+        sparseBoard: () => ({}),
+        getSelectedHex: () => null,
+        isOwnHexSelected: () => false,
+        hasCombat: () => false,
+      }),
+    });
+
+    mockService.endMovement.mockResolvedValue({ gameStatus: status });
+
+    const menu = new Menu(game, { service: mockService });
+    eventBus.emit.mockClear();
+    menu.doEndPhase();
+    await flushPromises();
+
+    expect(eventBus.emit).not.toHaveBeenCalledWith('gameOver', expect.anything());
+  });
+
+  test('completed API status opens the game over dialog event with backend data', async () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+
+    let status = { state: 'in_progress' };
+    const completedStatus = {
+      state: 'completed',
+      winnerPlayerName: 'Player 1',
+      message: 'Player 1 wins.',
+    };
+    const game = fakeGame({
+      getCurrentPhase: () => 'Movement',
+      endPhase: () => false,
+      isGameOver: () => status.state === 'completed',
+      getGameStatus: () => status,
+      applyApiState: (responseData) => { status = responseData.gameStatus; },
+      getBoard: () => ({
+        sparseBoard: () => ({}),
+        getSelectedHex: () => null,
+        isOwnHexSelected: () => false,
+        hasCombat: () => false,
+      }),
+    });
+
+    mockService.endMovement.mockResolvedValue({ gameStatus: completedStatus });
+
+    const menu = new Menu(game, { service: mockService });
+    eventBus.emit.mockClear();
+    menu.doEndPhase();
+    await flushPromises();
+
+    expect(eventBus.emit).toHaveBeenCalledWith('gameOver', {
+      gameId: 'game-id',
+      gameStatus: completedStatus,
+    });
+  });
+
+  test('blocks end phase gameplay after completion', () => {
+    buildDom();
+    history.replaceState(null, '', '/');
+
+    const game = fakeGame({ isGameOver: () => true });
+    const menu = new Menu(game, { service: mockService });
+    eventBus.emit.mockClear();
+    menu.doEndPhase();
+
+    expect(mockService.endMovement).not.toHaveBeenCalled();
+    expect(mockService.endTurn).not.toHaveBeenCalled();
   });
 
   test('posts end-turn board state captured before endPhase resets moves', async () => {

--- a/battle-hexes-web/tests/model/board.test.js
+++ b/battle-hexes-web/tests/model/board.test.js
@@ -116,6 +116,27 @@ describe('animator integration', () => {
     expect(animatorInstance.animate).toHaveBeenCalledWith(unit, [start, end], true);
   });
 
+
+  test('selectHex blocks gameplay movement when completed', () => {
+    const player = { isHuman: () => true };
+    const factions = [new Faction('f1', 'f1', '#f00')];
+    factions[0].setOwningPlayer(player);
+    const board = new Board(1, 2);
+    board.players = { getCurrentPlayer: () => player };
+    board.setGameplayBlockedProvider(() => true);
+    const unit = new Unit('u1', 'Unit', factions[0], null, 1, 1, 1);
+    board.addUnit(unit, 0, 0);
+
+    const start = board.getHex(0, 0);
+    const end = board.getHex(0, 1);
+
+    const animatorInstance = board.animator;
+    board.selectHex(start);
+    board.selectHex(end);
+
+    expect(animatorInstance.animate).not.toHaveBeenCalled();
+  });
+
   test('selectHex resolves movement during the movement phase', async () => {
     const player = { isHuman: () => true };
     const factions = [new Faction('f1', 'f1', '#f00')];

--- a/battle-hexes-web/tests/model/game.test.js
+++ b/battle-hexes-web/tests/model/game.test.js
@@ -203,50 +203,31 @@ describe('resolveCombat', () => {
     expect(game.getFactionForUnitId('missing')).toBeNull();
   });
 
-describe('isGameOver', () => {
-  test('returns false when multiple players have units', () => {
-    const f1 = new Faction('f1', 'f1', '#f00');
-    const f2 = new Faction('f2', 'f2', '#0f0');
-    f1.setOwningPlayer(player1);
-    f2.setOwningPlayer(player2);
-
-    const u1 = new Unit('u1', 'Unit1', f1, null, 1, 1, 1);
-    const u2 = new Unit('u2', 'Unit2', f2, null, 1, 1, 1);
-    game.getBoard().addUnit(u1, 0, 0);
-    game.getBoard().addUnit(u2, 0, 1);
+describe('game status', () => {
+  test('is not over when backend status is in progress regardless of local board state', () => {
+    game.updateGameStatus({ state: 'in_progress' });
 
     expect(game.isGameOver()).toBe(false);
   });
 
-  test('returns true when only one player has units', () => {
-    const f1 = new Faction('f1', 'f1', '#f00');
-    f1.setOwningPlayer(player1);
-    const u1 = new Unit('u1', 'Unit1', f1, null, 1, 1, 1);
-    game.getBoard().addUnit(u1, 0, 0);
+  test('is over only when backend status is completed', () => {
+    game.updateGameStatus({ state: 'completed', message: 'Done.' });
 
     expect(game.isGameOver()).toBe(true);
+    expect(game.getGameStatus()).toEqual({ state: 'completed', message: 'Done.' });
   });
 
+  test('does not infer game over from turn limits or remaining unit owners', () => {
+    const limitedGame = new Game('game-id', phases, players, new Board(10, 10), {
+      turnLimit: 1,
+      turnNumber: 2,
+      gameStatus: { state: 'in_progress' },
+    });
 
-  test('returns true when turn limit is exceeded', () => {
-    const limitedGame = new Game('game-id', phases, players, new Board(10, 10), { turnLimit: 1, turnNumber: 2 });
-
-    expect(limitedGame.isGameOver()).toBe(true);
-  });
-
-  test('returns true after a unit is eliminated leaving one player', () => {
     const f1 = new Faction('f1', 'f1', '#f00');
-    const f2 = new Faction('f2', 'f2', '#0f0');
     f1.setOwningPlayer(player1);
-    f2.setOwningPlayer(player2);
+    limitedGame.getBoard().addUnit(new Unit('u1', 'Unit1', f1, null, 1, 1, 1), 0, 0);
 
-    const u1 = new Unit('u1', 'Unit1', f1, null, 1, 1, 1);
-    const u2 = new Unit('u2', 'Unit2', f2, null, 1, 1, 1);
-    game.getBoard().addUnit(u1, 0, 0);
-    game.getBoard().addUnit(u2, 0, 1);
-
-    game.getBoard().removeUnit(u2);
-
-    expect(game.isGameOver()).toBe(true);
+    expect(limitedGame.isGameOver()).toBe(false);
   });
 });

--- a/battle_hexes_api/src/battle_hexes_api/schemas/game_model.py
+++ b/battle_hexes_api/src/battle_hexes_api/schemas/game_model.py
@@ -8,6 +8,7 @@ from pydantic import ConfigDict
 from .api_model import ApiBaseModel
 
 from .board import BoardModel
+from .game_status import GameStatus
 from .objective import ObjectiveModel
 from .player import PlayerModel
 
@@ -32,6 +33,7 @@ class GameModel(ApiBaseModel):
     scenario_name: str | None = None
     stacking_limit: int | None = None
     player_type_ids: list[str] | None = None
+    game_status: GameStatus | None = None
 
     @classmethod
     def from_game(
@@ -57,4 +59,5 @@ class GameModel(ApiBaseModel):
             scenario_name=getattr(scenario, "name", None),
             stacking_limit=getattr(scenario, "stacking_limit", None),
             player_type_ids=getattr(game, "player_type_ids", None),
+            game_status=GameStatus.from_core(game.get_game_status()),
         )

--- a/battle_hexes_api/tests/test_main.py
+++ b/battle_hexes_api/tests/test_main.py
@@ -67,6 +67,10 @@ class TestFastAPI(unittest.TestCase):
         self.assertEqual(post_body.get('playerTypeIds'), ['human', 'random'])
         self.assertEqual(post_body.get('scenarioId'), 'elim_1')
         self.assertEqual(post_body.get('stackingLimit'), 2)
+        self.assertEqual(
+            post_body.get('gameStatus', {}).get('state'),
+            'in_progress',
+        )
         terrain = post_body.get("board", {}).get("terrain", {})
         self.assertEqual(terrain.get("default"), "open")
         self.assertIn("open", terrain.get("types", {}))
@@ -108,6 +112,10 @@ class TestFastAPI(unittest.TestCase):
         self.assertEqual(get_body.get('playerTypeIds'), ['human', 'random'])
         self.assertEqual(get_body.get('scenarioId'), 'elim_1')
         self.assertEqual(get_body.get('stackingLimit'), 2)
+        self.assertEqual(
+            get_body.get('gameStatus', {}).get('state'),
+            'in_progress',
+        )
         self.assertEqual(
             get_body.get("board", {})
             .get("terrain", {})

--- a/battle_hexes_api/tests/test_schemas.py
+++ b/battle_hexes_api/tests/test_schemas.py
@@ -78,6 +78,7 @@ class TestApiAliases(unittest.TestCase):
 
         self.assertEqual(payload["turnLimit"], 10)
         self.assertEqual(payload["turnNumber"], 2)
+        self.assertIsNone(payload["gameStatus"])
         self.assertIn("roadTypes", payload["board"])
         self.assertIn("roadPaths", payload["board"])
         self.assertEqual(
@@ -204,6 +205,7 @@ class TestGameModel(unittest.TestCase):
         self.assertEqual(model.players[0].name, "Alice")
         self.assertEqual(model.players[0].type, "Human")
         self.assertEqual(model.board.rows, 2)
+        self.assertEqual(model.game_status.state, "completed")
         self.assertEqual(model.board.columns, 2)
         self.assertEqual(len(model.board.units), 1)
         self.assertEqual(model.board.terrain.default, "open")


### PR DESCRIPTION
### Motivation
- The backend `gameStatus` must be the single authoritative source for whether a game has completed instead of duplicated frontend inference from turn limits, unit counts, objectives, or scores. 
- Centralize processing of API state responses so the UI reacts consistently after movement, combat, and end-turn responses. 
- Preserve the existing end-of-game dialog UI and actions while populating it with backend-supplied message/winner data.

### Description
- Add persistent `gameStatus` to the frontend `Game` model and central API-state handling via `getGameStatus`, `updateGameStatus`, `applyApiState`, `#extractGameStatus`, and `#normalizeGameStatus`, and change `isGameOver()` to return `this.#gameStatus?.state === 'completed'`. 
- Wire API responses through the centralized path: updated `Menu.#applyGameStateResponse` (used for movement/end-turn), `battle-draw` and `CpuPlayer` now call `game.applyApiState` after applying authoritative board updates, and `GameCreator` initializes `gameStatus` from server payloads. 
- Block gameplay interactions centrally by adding `Board.setGameplayBlockedProvider` and consulting that provider in `selectHex` and `updateHoverHex`, with `Game` registering a provider tied to `isGameOver()`. 
- Populate the existing `GameOverDialog` with backend data (display message, show winner when present, handle completed draws), keep the existing New Game/Main Menu/Close actions, and ensure the dialog does not reopen for the same game after closing; `Menu` emits `gameOver` with `{ gameId, gameStatus }` when appropriate. 
- Update mock API fixtures to include both `in_progress` and `completed` `gameStatus` variants and add/adjust unit tests to cover removal of old inferred logic, in-progress vs completed behavior, dialog population, close-not-reopen semantics, gameplay blocking after completion, and that New Game / Main Menu continue to work. 

### Testing
- Ran the full frontend build and test pipeline with `cd battle-hexes-web && npm run test-and-build`, which runs lint, the Jest test suite, and `webpack` build. 
- All frontend unit tests passed and the build completed successfully (test suite run: all tests passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38393579b483278277e97564b127c8)